### PR TITLE
Stack exchange provider

### DIFF
--- a/AspNet.Security.OAuth.Providers.sln
+++ b/AspNet.Security.OAuth.Providers.sln
@@ -69,6 +69,8 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "AspNet.Security.OAuth.Autom
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "AspNet.Security.OAuth.EVEOnline", "src\AspNet.Security.OAuth.EVEOnline\AspNet.Security.OAuth.EVEOnline.xproj", "{B953D0C1-4C31-489D-A6C6-56A7C60AA3C6}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "AspNet.Security.OAuth.StackExchange", "src\AspNet.Security.OAuth.StackExchange\AspNet.Security.OAuth.StackExchange.xproj", "{AA05963A-91BA-4B9D-A532-B280E5A9AB88}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -199,6 +201,10 @@ Global
 		{B953D0C1-4C31-489D-A6C6-56A7C60AA3C6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B953D0C1-4C31-489D-A6C6-56A7C60AA3C6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B953D0C1-4C31-489D-A6C6-56A7C60AA3C6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AA05963A-91BA-4B9D-A532-B280E5A9AB88}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AA05963A-91BA-4B9D-A532-B280E5A9AB88}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AA05963A-91BA-4B9D-A532-B280E5A9AB88}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AA05963A-91BA-4B9D-A532-B280E5A9AB88}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -235,5 +241,6 @@ Global
 		{B332222F-43B4-4B3E-8EB3-9BCE29901043} = {C1352FD3-AE8B-43EE-B45B-F6E0B3FBAC6D}
 		{DD97337C-37C6-4F0E-A392-2DAD59246616} = {C1352FD3-AE8B-43EE-B45B-F6E0B3FBAC6D}
 		{B953D0C1-4C31-489D-A6C6-56A7C60AA3C6} = {C1352FD3-AE8B-43EE-B45B-F6E0B3FBAC6D}
+		{AA05963A-91BA-4B9D-A532-B280E5A9AB88} = {C1352FD3-AE8B-43EE-B45B-F6E0B3FBAC6D}
 	EndGlobalSection
 EndGlobal

--- a/samples/Mvc.Client/project.json
+++ b/samples/Mvc.Client/project.json
@@ -39,6 +39,7 @@
     "AspNet.Security.OAuth.Slack": { "target": "project" },
     "AspNet.Security.OAuth.SoundCloud": { "target": "project" },
     "AspNet.Security.OAuth.Spotify": { "target": "project" },
+    "AspNet.Security.OAuth.StackExchange": { "target": "project" },
     "AspNet.Security.OAuth.Twitch": { "target": "project" },
     "AspNet.Security.OAuth.Vimeo": { "target": "project" },
     "AspNet.Security.OAuth.Vkontakte": { "target": "project" },

--- a/src/AspNet.Security.OAuth.StackExchange/AspNet.Security.OAuth.StackExchange.xproj
+++ b/src/AspNet.Security.OAuth.StackExchange/AspNet.Security.OAuth.StackExchange.xproj
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>9dfee19e-c170-4f20-93f3-ec952b1532f2</ProjectGuid>
+    <RootNamespace>AspNet.Security.OAuth.StackExchange</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/AspNet.Security.OAuth.StackExchange/AspNet.Security.OAuth.StackExchange.xproj
+++ b/src/AspNet.Security.OAuth.StackExchange/AspNet.Security.OAuth.StackExchange.xproj
@@ -1,18 +1,16 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
-    <ProjectGuid>9dfee19e-c170-4f20-93f3-ec952b1532f2</ProjectGuid>
+    <ProjectGuid>aa05963a-91ba-4b9d-a532-b280e5a9ab88</ProjectGuid>
     <RootNamespace>AspNet.Security.OAuth.StackExchange</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
-
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>

--- a/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationDefaults.cs
+++ b/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationDefaults.cs
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using Microsoft.AspNetCore.Builder;
+
+namespace AspNet.Security.OAuth.StackExchange {
+    /// <summary>
+    /// Default values used by the StackExchange authentication middleware.
+    /// </summary>
+    public static class StackExchangeAuthenticationDefaults {
+        /// <summary>
+        /// Default value for <see cref="AuthenticationOptions.AuthenticationScheme"/>.
+        /// </summary>
+        public const string AuthenticationScheme = "StackExchange";
+
+        /// <summary>
+        /// Default value for <see cref="RemoteAuthenticationOptions.DisplayName"/>.
+        /// </summary>
+        public const string DisplayName = "StackExchange";
+
+        /// <summary>
+        /// Default value for <see cref="AuthenticationOptions.ClaimsIssuer"/>.
+        /// </summary>
+        public const string Issuer = "StackExchange";
+
+        /// <summary>
+        /// Default value for <see cref="RemoteAuthenticationOptions.CallbackPath"/>.
+        /// </summary>
+        public const string CallbackPath = "/signin-stackexchange";
+
+        /// <summary>
+        /// Default value for <see cref="OAuthOptions.AuthorizationEndpoint"/>.
+        /// </summary>
+        public const string AuthorizationEndpoint = "https://stackexchange.com/oauth";
+
+        /// <summary>
+        /// Default value for <see cref="OAuthOptions.TokenEndpoint"/>.
+        /// </summary>
+        public const string TokenEndpoint = "https://stackexchange.com/oauth/access_token";
+
+        /// <summary>
+        /// Default value for <see cref="OAuthOptions.UserInformationEndpoint"/>.
+        /// </summary>
+        public const string UserInformationEndpoint = "https://api.stackexchange.com/2.2/me";
+    }
+}

--- a/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationExtensions.cs
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System;
+using AspNet.Security.OAuth.StackExchange;
+using JetBrains.Annotations;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.AspNetCore.Builder {
+    /// <summary>
+    /// Extension methods to add StackExchange authentication capabilities to an HTTP application pipeline.
+    /// </summary>
+    public static class StackExchangeAuthenticationExtensions {
+        /// <summary>
+        /// Adds the <see cref="StackExchangeAuthenticationMiddleware"/> middleware to the specified
+        /// <see cref="IApplicationBuilder"/>, which enables StackExchange authentication capabilities.
+        /// </summary>
+        /// <param name="app">The <see cref="IApplicationBuilder"/> to add the middleware to.</param>
+        /// <param name="options">A <see cref="StackExchangeAuthenticationOptions"/> that specifies options for the middleware.</param>        
+        /// <returns>A reference to this instance after the operation has completed.</returns>
+        public static IApplicationBuilder UseStackExchangeAuthentication(
+            [NotNull] this IApplicationBuilder app,
+            [NotNull] StackExchangeAuthenticationOptions options) {
+            if (app == null) {
+                throw new ArgumentNullException(nameof(app));
+            }
+
+            if (options == null) {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            return app.UseMiddleware<StackExchangeAuthenticationMiddleware>(Options.Create(options));
+        }
+
+        /// <summary>
+        /// Adds the <see cref="StackExchangeAuthenticationMiddleware"/> middleware to the specified
+        /// <see cref="IApplicationBuilder"/>, which enables StackExchange authentication capabilities.
+        /// </summary>
+        /// <param name="app">The <see cref="IApplicationBuilder"/> to add the middleware to.</param>
+        /// <param name="configuration">An action delegate to configure the provided <see cref="StackExchangeAuthenticationOptions"/>.</param>
+        /// <returns>A reference to this instance after the operation has completed.</returns>
+        public static IApplicationBuilder UseStackExchangeAuthentication(
+            [NotNull] this IApplicationBuilder app,
+            [NotNull] Action<StackExchangeAuthenticationOptions> configuration) {
+            if (app == null) {
+                throw new ArgumentNullException(nameof(app));
+            }
+
+            if (configuration == null) {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
+            var options = new StackExchangeAuthenticationOptions();
+            configuration(options);
+
+            return app.UseMiddleware<StackExchangeAuthenticationMiddleware>(Options.Create(options));
+        }
+    }
+}

--- a/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationHandler.cs
@@ -4,15 +4,21 @@
  * for more information concerning the license and the contributors participating to this project.
  */
 
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Security.Claims;
+using System.Text;
 using System.Threading.Tasks;
 using AspNet.Security.OAuth.Extensions;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
 using Microsoft.AspNetCore.Http.Authentication;
+using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
 
@@ -24,14 +30,23 @@ namespace AspNet.Security.OAuth.StackExchange {
 
         protected override async Task<AuthenticationTicket> CreateTicketAsync([NotNull] ClaimsIdentity identity,
             [NotNull] AuthenticationProperties properties, [NotNull] OAuthTokenResponse tokens) {
-            var request = new HttpRequestMessage(HttpMethod.Get, Options.UserInformationEndpoint);
+            
+            //access tokens and request keys are passed in the querystring for StackExchange
+            var queryParameters = new Dictionary<string, string>() {
+                                      {"access_token", tokens.AccessToken},
+                                      {"key", Options.RequestKey},
+                                      {"site", Options.Site}
+                                  };
+            var requestUrl = QueryHelpers.AddQueryString(Options.UserInformationEndpoint, queryParameters);
+
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUrl);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", tokens.AccessToken);
 
             var response = await Backchannel.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, Context.RequestAborted);
             response.EnsureSuccessStatusCode();
 
-            var payload = JObject.Parse(await response.Content.ReadAsStringAsync());
+            //content will be UTF-8 encoded and gzipped
+            var payload = JObject.Parse(await ReadGzipUTF8ContentAsStringAsync(response.Content));
 
             identity.AddOptionalClaim(ClaimTypes.NameIdentifier, StackExchangeAuthenticationHelper.GetIdentifier(payload), Options.ClaimsIssuer);
 
@@ -45,6 +60,55 @@ namespace AspNet.Security.OAuth.StackExchange {
             await Options.Events.CreatingTicket(context);
 
             return context.Ticket;
+        }
+
+        protected override async Task<OAuthTokenResponse> ExchangeCodeAsync(string code, string redirectUri) {
+            var tokenRequestParameters = new Dictionary<string, string> {
+                { "client_id", Options.ClientId },
+                { "redirect_uri", redirectUri },
+                { "client_secret", Options.ClientSecret },
+                { "code", code },
+                { "grant_type", "authorization_code" },
+            };
+
+            var requestContent = new FormUrlEncodedContent(tokenRequestParameters);
+
+            var requestMessage = new HttpRequestMessage(HttpMethod.Post, Options.TokenEndpoint);
+            // Stack exchange always responsds with a payload of the form access_token=...&expires=1234
+            //requestMessage.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            requestMessage.Content = requestContent;
+            var response = await Backchannel.SendAsync(requestMessage, Context.RequestAborted);
+            if (response.IsSuccessStatusCode) {
+                var content = await response.Content.ReadAsStringAsync();
+                //convert the data to a json string instead
+                var queryDictionary = QueryHelpers.ParseQuery(content);
+                var payload = new JObject();
+                foreach (var keyValuePair in queryDictionary) {
+                    //assume we only have one of each parameter
+                    payload[keyValuePair.Key] = keyValuePair.Value[0];
+                }
+                return OAuthTokenResponse.Success(payload);
+            } else {
+                Logger.LogError("An error occurred when retrieving an access token: the remote server " +
+                               "returned a {Status} response with the following payload: {Headers} {Body}.",
+                               /* Status: */ response.StatusCode,
+                               /* Headers: */ response.Headers.ToString(),
+                               /* Body: */ await response.Content.ReadAsStringAsync());
+                return OAuthTokenResponse.Failed(new Exception("An error occurred when retrieving an access token"));
+            }
+        }
+
+
+        private static async Task<string> ReadGzipUTF8ContentAsStringAsync(HttpContent responseContent) {
+            using (var outputStream = new MemoryStream()) {
+                var inputStream = await responseContent.ReadAsStreamAsync();
+                using (var gzipStream = new GZipStream(inputStream, CompressionMode.Decompress, false)) {
+                    gzipStream.CopyTo(outputStream);
+                }
+
+                return Encoding.UTF8.GetString(outputStream.ToArray());
+            }
+
         }
     }
 }

--- a/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationHandler.cs
@@ -48,8 +48,11 @@ namespace AspNet.Security.OAuth.StackExchange {
             //content will be UTF-8 encoded and gzipped
             var payload = JObject.Parse(await ReadGzipUTF8ContentAsStringAsync(response.Content));
 
-            identity.AddOptionalClaim(ClaimTypes.NameIdentifier, StackExchangeAuthenticationHelper.GetIdentifier(payload), Options.ClaimsIssuer);
-
+            //we cannot get the email claim from the stack exchange endpoint
+            identity.AddOptionalClaim(ClaimTypes.NameIdentifier, StackExchangeAuthenticationHelper.GetIdentifier(payload), Options.ClaimsIssuer)
+                    .AddOptionalClaim(ClaimTypes.Name, StackExchangeAuthenticationHelper.GetDisplayName(payload), Options.ClaimsIssuer)
+                    .AddOptionalClaim(ClaimTypes.Webpage, StackExchangeAuthenticationHelper.GetWebsiteUrl(payload), Options.ClaimsIssuer)
+                    .AddOptionalClaim("urn:stackexchange:link", StackExchangeAuthenticationHelper.GetLink(payload), Options.ClaimsIssuer);
             // TODO: Add any optional claims, eg
             //  .AddOptionalClaim("urn:stackexchange:name", StackExchangeAuthenticationHelper.GetName(payload), Options.ClaimsIssuer)
 

--- a/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationHandler.cs
@@ -6,8 +6,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
-using System.IO.Compression;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Security.Claims;
@@ -46,7 +44,7 @@ namespace AspNet.Security.OAuth.StackExchange {
             response.EnsureSuccessStatusCode();
 
             //content will be UTF-8 encoded and gzipped
-            var payload = JObject.Parse(await ReadGzipUTF8ContentAsStringAsync(response.Content));
+            var payload = JObject.Parse(await response.Content.ReadAsStringAsync());
 
             //we cannot get the email claim from the stack exchange endpoint
             identity.AddOptionalClaim(ClaimTypes.NameIdentifier, StackExchangeAuthenticationHelper.GetIdentifier(payload), Options.ClaimsIssuer)
@@ -99,19 +97,6 @@ namespace AspNet.Security.OAuth.StackExchange {
                                /* Body: */ await response.Content.ReadAsStringAsync());
                 return OAuthTokenResponse.Failed(new Exception("An error occurred when retrieving an access token"));
             }
-        }
-
-
-        private static async Task<string> ReadGzipUTF8ContentAsStringAsync(HttpContent responseContent) {
-            using (var outputStream = new MemoryStream()) {
-                var inputStream = await responseContent.ReadAsStreamAsync();
-                using (var gzipStream = new GZipStream(inputStream, CompressionMode.Decompress, false)) {
-                    gzipStream.CopyTo(outputStream);
-                }
-
-                return Encoding.UTF8.GetString(outputStream.ToArray());
-            }
-
         }
     }
 }

--- a/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationHandler.cs
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using AspNet.Security.OAuth.Extensions;
+using JetBrains.Annotations;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.OAuth;
+using Microsoft.AspNetCore.Http.Authentication;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
+
+namespace AspNet.Security.OAuth.StackExchange {
+    public class StackExchangeAuthenticationHandler : OAuthHandler<StackExchangeAuthenticationOptions> {
+        public StackExchangeAuthenticationHandler([NotNull] HttpClient client)
+            : base(client) {
+        }
+
+        protected override async Task<AuthenticationTicket> CreateTicketAsync([NotNull] ClaimsIdentity identity,
+            [NotNull] AuthenticationProperties properties, [NotNull] OAuthTokenResponse tokens) {
+            var request = new HttpRequestMessage(HttpMethod.Get, Options.UserInformationEndpoint);
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", tokens.AccessToken);
+
+            var response = await Backchannel.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, Context.RequestAborted);
+            response.EnsureSuccessStatusCode();
+
+            var payload = JObject.Parse(await response.Content.ReadAsStringAsync());
+
+            identity.AddOptionalClaim(ClaimTypes.NameIdentifier, StackExchangeAuthenticationHelper.GetIdentifier(payload), Options.ClaimsIssuer);
+
+            // TODO: Add any optional claims, eg
+            //  .AddOptionalClaim("urn:stackexchange:name", StackExchangeAuthenticationHelper.GetName(payload), Options.ClaimsIssuer)
+
+            var principal = new ClaimsPrincipal(identity);
+            var ticket = new AuthenticationTicket(principal, properties, Options.AuthenticationScheme);
+
+            var context = new OAuthCreatingTicketContext(ticket, Context, Options, Backchannel, tokens, payload);
+            await Options.Events.CreatingTicket(context);
+
+            return context.Ticket;
+        }
+    }
+}

--- a/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationHelper.cs
+++ b/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationHelper.cs
@@ -16,6 +16,21 @@ namespace AspNet.Security.OAuth.StackExchange {
         /// <summary>
         /// Gets the identifier corresponding to the authenticated user.
         /// </summary>
-        public static string GetIdentifier([NotNull] JObject user) => user.Value<string>("id");
+        public static string GetIdentifier([NotNull] JObject user) => user["items"][0].Value<string>("account_id");
+
+        /// <summary>
+        /// Gets the display name corresponding to the authenticated user.
+        /// </summary>
+        public static string GetDisplayName([NotNull] JObject user) => user["items"][0].Value<string>("display_name");
+
+        /// <summary>
+        /// Gets the URL corresponding to the authenticated user.
+        /// </summary>
+        public static string GetLink([NotNull] JObject user) => user["items"][0].Value<string>("link");
+
+        /// <summary>
+        /// Gets the URL corresponding to the authenticated user.
+        /// </summary>
+        public static string GetWebsiteUrl([NotNull] JObject user) => user["items"][0].Value<string>("website_url");
     }
 }

--- a/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationHelper.cs
+++ b/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationHelper.cs
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using JetBrains.Annotations;
+using Newtonsoft.Json.Linq;
+
+namespace AspNet.Security.OAuth.StackExchange {
+    /// <summary>
+    /// Contains static methods that allow to extract user's information from a <see cref="JObject"/>
+    /// instance retrieved from StackExchange after a successful authentication process.
+    /// </summary>
+    public static class StackExchangeAuthenticationHelper {
+        /// <summary>
+        /// Gets the identifier corresponding to the authenticated user.
+        /// </summary>
+        public static string GetIdentifier([NotNull] JObject user) => user.Value<string>("id");
+    }
+}

--- a/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationMiddleware.cs
+++ b/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationMiddleware.cs
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.OAuth;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using JetBrains.Annotations;
+
+namespace AspNet.Security.OAuth.StackExchange {
+    public class StackExchangeAuthenticationMiddleware : OAuthMiddleware<StackExchangeAuthenticationOptions> {
+        public StackExchangeAuthenticationMiddleware(
+            [NotNull] RequestDelegate next,
+            [NotNull] IDataProtectionProvider dataProtectionProvider,
+            [NotNull] ILoggerFactory loggerFactory,
+            [NotNull] UrlEncoder encoder,
+            [NotNull] IOptions<SharedAuthenticationOptions> sharedOptions,
+            [NotNull] IOptions<StackExchangeAuthenticationOptions> options)
+            : base(next, dataProtectionProvider, loggerFactory, encoder, sharedOptions, options) {
+        }
+
+        protected override AuthenticationHandler<StackExchangeAuthenticationOptions> CreateHandler() {
+            return new StackExchangeAuthenticationHandler(Backchannel);
+        }
+    }
+}

--- a/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationOptions.cs
@@ -23,5 +23,15 @@ namespace AspNet.Security.OAuth.StackExchange {
             TokenEndpoint = StackExchangeAuthenticationDefaults.TokenEndpoint;
             UserInformationEndpoint = StackExchangeAuthenticationDefaults.UserInformationEndpoint;
         }
+
+        /// <summary>
+        /// The application request key, obtained when registering your application with StackApps
+        /// </summary>
+        public string RequestKey { get; set; }
+
+        /// <summary>
+        /// The site on which the user is registered
+        /// </summary>
+        public string Site { get; set; } = "StackOverflow";
     }
 }

--- a/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationOptions.cs
@@ -4,6 +4,8 @@
  * for more information concerning the license and the contributors participating to this project.
  */
 
+using System.Net;
+using System.Net.Http;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 
@@ -22,6 +24,7 @@ namespace AspNet.Security.OAuth.StackExchange {
             AuthorizationEndpoint = StackExchangeAuthenticationDefaults.AuthorizationEndpoint;
             TokenEndpoint = StackExchangeAuthenticationDefaults.TokenEndpoint;
             UserInformationEndpoint = StackExchangeAuthenticationDefaults.UserInformationEndpoint;
+            BackchannelHttpHandler = new HttpClientHandler {AutomaticDecompression = DecompressionMethods.GZip};
         }
 
         /// <summary>

--- a/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationOptions.cs
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+namespace AspNet.Security.OAuth.StackExchange {
+    /// <summary>
+    /// Defines a set of options used by <see cref="StackExchangeAuthenticationHandler"/>.
+    /// </summary>
+    public class StackExchangeAuthenticationOptions : OAuthOptions {
+        public StackExchangeAuthenticationOptions() {
+            AuthenticationScheme = StackExchangeAuthenticationDefaults.AuthenticationScheme;
+            DisplayName = StackExchangeAuthenticationDefaults.DisplayName;
+            ClaimsIssuer = StackExchangeAuthenticationDefaults.Issuer;
+
+            CallbackPath = new PathString(StackExchangeAuthenticationDefaults.CallbackPath);
+
+            AuthorizationEndpoint = StackExchangeAuthenticationDefaults.AuthorizationEndpoint;
+            TokenEndpoint = StackExchangeAuthenticationDefaults.TokenEndpoint;
+            UserInformationEndpoint = StackExchangeAuthenticationDefaults.UserInformationEndpoint;
+        }
+    }
+}

--- a/src/AspNet.Security.OAuth.StackExchange/project.json
+++ b/src/AspNet.Security.OAuth.StackExchange/project.json
@@ -1,0 +1,49 @@
+{
+    "version": "1.0.0-beta2-*",
+    "description": "ASP.NET Core security middleware enabling StackExchange authentication.",
+    "authors": [ "Andrew Lock" ],
+
+  "packOptions": {
+    "owners": [ "Kévin Chalet", "Jerrie Pelser" ],
+
+    "projectUrl": "https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers",
+    "iconUrl": "https://avatars3.githubusercontent.com/u/7998081?s=64",
+    "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0.html",
+
+    "repository": {
+      "type": "git",
+      "url": "git://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers"
+    },
+
+    "tags": [
+      "aspnetcore",
+      "authentication",
+      "stackexchange",
+      "oauth",
+      "security"
+    ]
+  },
+
+  "buildOptions": {
+    "warningsAsErrors": true,
+    "nowarn": [ "CS1591" ],
+    "xmlDoc": true
+  },
+
+  "dependencies": {
+    "AspNet.Security.OAuth.Extensions": { "target": "project", "type": "build" },
+    "JetBrains.Annotations": { "type": "build", "version": "10.1.4" },
+    "Microsoft.AspNetCore.Authentication.OAuth": "1.0.0"
+  },
+
+  "frameworks": {
+    "net451": { },
+
+    "netstandard1.3": {
+      "imports": [
+        "dotnet5.4",
+        "portable-net451+win8"
+      ]
+    }
+  }
+}

--- a/src/AspNet.Security.OAuth.StackExchange/project.json
+++ b/src/AspNet.Security.OAuth.StackExchange/project.json
@@ -33,7 +33,9 @@
   "dependencies": {
     "AspNet.Security.OAuth.Extensions": { "target": "project", "type": "build" },
     "JetBrains.Annotations": { "type": "build", "version": "10.1.4" },
-    "Microsoft.AspNetCore.Authentication.OAuth": "1.0.0"
+    "Microsoft.AspNetCore.Authentication.OAuth": "1.0.0",
+    "Microsoft.AspNetCore.WebUtilities": "1.0.0",
+    "System.IO.Compression":  "4.1.0" 
   },
 
   "frameworks": {

--- a/src/AspNet.Security.OAuth.StackExchange/project.json
+++ b/src/AspNet.Security.OAuth.StackExchange/project.json
@@ -34,8 +34,7 @@
     "AspNet.Security.OAuth.Extensions": { "target": "project", "type": "build" },
     "JetBrains.Annotations": { "type": "build", "version": "10.1.4" },
     "Microsoft.AspNetCore.Authentication.OAuth": "1.0.0",
-    "Microsoft.AspNetCore.WebUtilities": "1.0.0",
-    "System.IO.Compression":  "4.1.0" 
+    "Microsoft.AspNetCore.WebUtilities": "1.0.0"
   },
 
   "frameworks": {


### PR DESCRIPTION
Fixes #16 

Some bits of this are a little scrappy and may require some additional tidying up, but it works and is tested 😄 

There were basically 2 pain points - the StackExchange TokenEndpoint ignores the `accept` header, and always sends back a string of the form `access_token=...&expires=1234`, so that needs to be handled in `ExchangeCodeAsync`.

Also, the response from the UserInformationEndpoint is both gzipped and utf-8 encoded, which is a bit of a pain, and requires a reference to System.IO.Compression. The handler at the moment assumes that the response will always be utf-8 and gzipped, but we may want to improve it to handle future changes if the api stops doing that?

Finally, there's not actually that many useful claims you can get back - you get an id and a display name, but you can't get FirstName, LastName or Email. 

Still, it works at least!