### PR TITLE
added bot and webhook claims to teh slack authentication helper

### DIFF
--- a/src/AspNet.Security.OAuth.Slack/SlackAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Slack/SlackAuthenticationHandler.cs
@@ -49,6 +49,21 @@ namespace AspNet.Security.OAuth.Slack {
                     .AddOptionalClaim("urn:slack:team_name", SlackAuthenticationHelper.GetTeamName(payload), Options.ClaimsIssuer)
                     .AddOptionalClaim("urn:slack:team_url", SlackAuthenticationHelper.GetTeamLink(payload), Options.ClaimsIssuer);
 
+            JObject bot = tokens.Response.Value<JObject>("bot");
+            if (bot != null)
+            {
+                identity.AddOptionalClaim("urn:slack:bot:userid", SlackAuthenticationHelper.GetBotUserId(bot), Options.ClaimsIssuer);
+                identity.AddOptionalClaim("urn:slack:bot:accesstoken", SlackAuthenticationHelper.GetBotAccessToken(bot), Options.ClaimsIssuer);
+            }
+
+            JObject webhook = tokens.Response.Value<JObject>("incoming_webhook");
+            if (webhook != null)
+            {
+                identity.AddOptionalClaim("urn:slack:webhook:channel", SlackAuthenticationHelper.GetWebhookChannel(webhook), Options.ClaimsIssuer);
+                identity.AddOptionalClaim("urn:slack:webhook:url", SlackAuthenticationHelper.GetWebhookURL(webhook), Options.ClaimsIssuer);
+                identity.AddOptionalClaim("urn:slack:webhook:configurationurl", SlackAuthenticationHelper.GetWebhookConfigurationURL(webhook), Options.ClaimsIssuer);
+            }
+
             var principal = new ClaimsPrincipal(identity);
             var ticket = new AuthenticationTicket(principal, properties, Options.AuthenticationScheme);
 

--- a/src/AspNet.Security.OAuth.Slack/SlackAuthenticationHelper.cs
+++ b/src/AspNet.Security.OAuth.Slack/SlackAuthenticationHelper.cs
@@ -37,5 +37,31 @@ namespace AspNet.Security.OAuth.Slack {
         /// Gets the URL corresponding to the authenticated user.
         /// </summary>
         public static string GetTeamLink([NotNull] JObject user) => user.Value<string>("url");
+
+        /// <summary>
+        /// Gets the User Id of the bot
+        /// </summary>
+        public static string GetBotUserId([NotNull] JObject bot) => bot.Value<string>("bot_user_id");
+
+        /// <summary>
+        /// Gets the Access Token of the bot
+        /// </summary>
+        public static string GetBotAccessToken([NotNull] JObject bot) => bot.Value<string>("bot_access_token");
+
+        /// <summary>
+        /// Gets the Channel name of the selected webhook
+        /// </summary>
+        public static string GetWebhookChannel([NotNull] JObject webhook) => webhook.Value<string>("channel");
+
+        /// <summary>
+        /// Gets the URL of the selected webhook
+        /// </summary>
+        public static string GetWebhookURL([NotNull] JObject webhook) => webhook.Value<string>("url");
+
+        /// <summary>
+        /// Gets the channel configuration URL of the selected webhook
+        /// </summary>
+        public static string GetWebhookConfigurationURL([NotNull] JObject webhook) => webhook.Value<string>("configuration_url");
+
     }
 }


### PR DESCRIPTION
### Purpose
Add bot and webhook claims data when either bot or incoming-webhook scopes are requested.

### Background
According to the slack documentation located https://api.slack.com/docs/oauth
when you ask for a _bot_ or _incoming-webhook_  scopes the access token response will also contains auth and configuration data for the bot and webhook.

for example:

> {
    "access_token": "xoxp-XXXXXXXX-XXXXXXXX-XXXXX",
    "scope": "incoming-webhook,commands,bot",
    "team_name": "Team Installing Your Hook",
    "team_id": "XXXXXXXXXX",
    "incoming_webhook": {
        "url": "https://hooks.slack.com/TXXXXX/BXXXXX/XXXXXXXXXX",
        "channel": "#channel-it-will-post-to",
        "configuration_url": "https://teamname.slack.com/services/BXXXXX"
    },
    "bot":{
        "bot_user_id":"UTTTTTTTTTTR",
        "bot_access_token":"xoxb-XXXXXXXXXXXX-TTTTTTTTTTTTTT"
    }
}