### PR TITLE
Take all tokens from the payload into the ClaimsPrincipal.

### DIFF
--- a/src/AspNet.Security.OAuth.GitHub/GitHubAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.GitHub/GitHubAuthenticationHandler.cs
@@ -43,9 +43,11 @@ namespace AspNet.Security.OAuth.GitHub {
             
             identity.AddOptionalClaim(ClaimTypes.NameIdentifier, GitHubAuthenticationHelper.GetIdentifier(payload), Options.ClaimsIssuer)
                     .AddOptionalClaim(ClaimTypes.Name, GitHubAuthenticationHelper.GetLogin(payload), Options.ClaimsIssuer)
-                    .AddOptionalClaim(ClaimTypes.Email, GitHubAuthenticationHelper.GetEmail(payload), Options.ClaimsIssuer)
-                    .AddOptionalClaim("urn:github:name", GitHubAuthenticationHelper.GetName(payload), Options.ClaimsIssuer)
-                    .AddOptionalClaim("urn:github:url", GitHubAuthenticationHelper.GetLink(payload), Options.ClaimsIssuer);
+                    .AddOptionalClaim(ClaimTypes.Email, GitHubAuthenticationHelper.GetEmail(payload), Options.ClaimsIssuer);
+            
+            foreach (var token in payload) {
+                identity.AddOptionalClaim($"urn:github:{token.Key}", token.Value.ToString(), Options.ClaimsIssuer);
+            }
 
             // When the email address is not public, retrieve it from
             // the emails endpoint if the user:email scope is specified.


### PR DESCRIPTION
This change allows access to all the tokens from the payload, instead of just name and url.