### PR TITLE
Make GitHubAuthenticationOptions.UserEmailsEndpoint overrideable

### DIFF
--- a/src/AspNet.Security.OAuth.GitHub/GitHubAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.GitHub/GitHubAuthenticationOptions.cs
@@ -28,6 +28,6 @@ namespace AspNet.Security.OAuth.GitHub {
         /// Gets or sets the address of the endpoint exposing
         /// the email addresses associated with the logged in user.
         /// </summary>
-        public string UserEmailsEndpoint { get; } = GitHubAuthenticationDefaults.UserEmailsEndpoint;
+        public string UserEmailsEndpoint { get; set; } = GitHubAuthenticationDefaults.UserEmailsEndpoint;
     }
 }


### PR DESCRIPTION
Change [`GitHubAuthenticationOptions`](https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/blob/dev/src/AspNet.Security.OAuth.GitHub/GitHubAuthenticationOptions.cs)'s `UserEmailsEndpoint` to be overrideable, currently it's initialized with defaults to github.com and readonly.

Fix for #130 