### PR TITLE
Add Autodesk provider to resolve #120

### DIFF
--- a/AspNet.Security.OAuth.Providers.sln
+++ b/AspNet.Security.OAuth.Providers.sln
@@ -85,6 +85,8 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "AspNet.Security.OAuth.Untap
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "AspNet.Security.OAuth.MailChimp", "src\AspNet.Security.OAuth.MailChimp\AspNet.Security.OAuth.MailChimp.xproj", "{337B29EB-54B4-43BF-8ADC-A5B3D11538AF}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "AspNet.Security.OAuth.Autodesk", "src\AspNet.Security.OAuth.Autodesk\AspNet.Security.OAuth.Autodesk.xproj", "{92406BD8-0270-4BF9-B860-D1AE6508DF8C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -247,6 +249,10 @@ Global
 		{337B29EB-54B4-43BF-8ADC-A5B3D11538AF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{337B29EB-54B4-43BF-8ADC-A5B3D11538AF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{337B29EB-54B4-43BF-8ADC-A5B3D11538AF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{92406BD8-0270-4BF9-B860-D1AE6508DF8C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{92406BD8-0270-4BF9-B860-D1AE6508DF8C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{92406BD8-0270-4BF9-B860-D1AE6508DF8C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{92406BD8-0270-4BF9-B860-D1AE6508DF8C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -291,5 +297,6 @@ Global
 		{F276EB53-7758-4CEE-8013-61BA537B94C6} = {C1352FD3-AE8B-43EE-B45B-F6E0B3FBAC6D}
 		{C17F7C35-4CAD-408F-9031-44EF1A3CC379} = {C1352FD3-AE8B-43EE-B45B-F6E0B3FBAC6D}
 		{337B29EB-54B4-43BF-8ADC-A5B3D11538AF} = {C1352FD3-AE8B-43EE-B45B-F6E0B3FBAC6D}
+		{92406BD8-0270-4BF9-B860-D1AE6508DF8C} = {C1352FD3-AE8B-43EE-B45B-F6E0B3FBAC6D}
 	EndGlobalSection
 EndGlobal

--- a/samples/Mvc.Client/project.json
+++ b/samples/Mvc.Client/project.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "AspNet.Security.OAuth.ArcGIS": { "target": "project" },
     "AspNet.Security.OAuth.Asana": { "target": "project" },
+    "AspNet.Security.OAuth.Autodesk": { "target": "project" },
     "AspNet.Security.OAuth.Automatic": { "target": "project" },
     "AspNet.Security.OAuth.Beam": { "target": "project" },
     "AspNet.Security.OAuth.BattleNet": { "target": "project" },

--- a/src/AspNet.Security.OAuth.Autodesk/AspNet.Security.OAuth.Autodesk.xproj
+++ b/src/AspNet.Security.OAuth.Autodesk/AspNet.Security.OAuth.Autodesk.xproj
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>92406bd8-0270-4bf9-b860-d1ae6508df8c</ProjectGuid>
+    <RootNamespace>AspNet.Security.OAuth.Autodesk</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/AspNet.Security.OAuth.Autodesk/AutodeskAuthenticationConstants.cs
+++ b/src/AspNet.Security.OAuth.Autodesk/AutodeskAuthenticationConstants.cs
@@ -1,0 +1,35 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+namespace AspNet.Security.OAuth.Autodesk
+{
+    /// <summary>
+    /// Constants used with authentication in Autodesk provider
+    /// </summary>
+    public static class AutodeskAuthenticationConstants
+    {
+        public static class Claims
+        {
+            /// <summary>
+            /// Key for claim containing a boolean value indicating whether the user's email has been verified
+            /// </summary>
+            public const string EmailVerified = "urn:autodesk:emailverified";
+
+            /// <summary>
+            /// Key for claim containing a boolean value indicating whether the user has enabled two factor authentication
+            /// </summary>
+            public const string TwoFactorEnabled = "urn:autodesk:twofactorenabled";
+        }
+
+        public static class Scopes
+        {
+            /// <summary>
+            /// OAuth scope for reading Autodesk user profile
+            /// </summary>
+            public const string UserProfileRead = "user-profile:read";
+        }
+    }
+}

--- a/src/AspNet.Security.OAuth.Autodesk/AutodeskAuthenticationDefaults.cs
+++ b/src/AspNet.Security.OAuth.Autodesk/AutodeskAuthenticationDefaults.cs
@@ -7,11 +7,13 @@
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Builder;
 
-namespace AspNet.Security.OAuth.Autodesk {
+namespace AspNet.Security.OAuth.Autodesk
+{
     /// <summary>
     /// Default values used by the Autodesk authentication middleware.
     /// </summary>
-    public static class AutodeskAuthenticationDefaults {
+    public static class AutodeskAuthenticationDefaults
+    {
         /// <summary>
         /// Default value for <see cref="AuthenticationOptions.AuthenticationScheme"/>.
         /// </summary>

--- a/src/AspNet.Security.OAuth.Autodesk/AutodeskAuthenticationDefaults.cs
+++ b/src/AspNet.Security.OAuth.Autodesk/AutodeskAuthenticationDefaults.cs
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Builder;
+
+namespace AspNet.Security.OAuth.Autodesk {
+    /// <summary>
+    /// Default values used by the Autodesk authentication middleware.
+    /// </summary>
+    public static class AutodeskAuthenticationDefaults {
+        /// <summary>
+        /// Default value for <see cref="AuthenticationOptions.AuthenticationScheme"/>.
+        /// </summary>
+        public const string AuthenticationScheme = "Autodesk";
+
+        /// <summary>
+        /// Default value for <see cref="RemoteAuthenticationOptions.DisplayName"/>.
+        /// </summary>
+        public const string DisplayName = "Autodesk";
+
+        /// <summary>
+        /// Default value for <see cref="AuthenticationOptions.ClaimsIssuer"/>.
+        /// </summary>
+        public const string Issuer = "Autodesk";
+
+        /// <summary>
+        /// Default value for <see cref="RemoteAuthenticationOptions.CallbackPath"/>.
+        /// </summary>
+        public const string CallbackPath = "/signin-autodesk";
+
+        /// <summary>
+        /// Default value for <see cref="OAuthOptions.AuthorizationEndpoint"/>.
+        /// </summary>
+        public const string AuthorizationEndpoint = "https://developer.api.autodesk.com/authentication/v1/authorize";
+
+        /// <summary>
+        /// Default value for <see cref="OAuthOptions.TokenEndpoint"/>.
+        /// </summary>
+        public const string TokenEndpoint = "https://developer.api.autodesk.com/authentication/v1/gettoken";
+
+        /// <summary>
+        /// Default value for <see cref="OAuthOptions.UserInformationEndpoint"/>.
+        /// </summary>
+        public const string UserInformationEndpoint = "https://developer.api.autodesk.com/userprofile/v1/users/@me";
+
+        /// <summary>
+        /// Default value for <see cref="OAuthOptions.Scope"/>.
+        /// </summary>
+        public static readonly IEnumerable<string> Scope = new[] { "user-profile:read" };
+    }
+}

--- a/src/AspNet.Security.OAuth.Autodesk/AutodeskAuthenticationDefaults.cs
+++ b/src/AspNet.Security.OAuth.Autodesk/AutodeskAuthenticationDefaults.cs
@@ -52,6 +52,6 @@ namespace AspNet.Security.OAuth.Autodesk
         /// <summary>
         /// Default value for <see cref="OAuthOptions.Scope"/>.
         /// </summary>
-        public static readonly IEnumerable<string> Scope = new[] { "user-profile:read" };
+        public static readonly IEnumerable<string> Scope = new[] { AutodeskAuthenticationConstants.Scopes.UserProfileRead };
     }
 }

--- a/src/AspNet.Security.OAuth.Autodesk/AutodeskAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.Autodesk/AutodeskAuthenticationExtensions.cs
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System;
+using AspNet.Security.OAuth.Autodesk;
+using JetBrains.Annotations;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.AspNetCore.Builder {
+    /// <summary>
+    /// Extension methods to add Autodesk authentication capabilities to an HTTP application pipeline.
+    /// </summary>
+    public static class AutodeskAuthenticationExtensions {
+        /// <summary>
+        /// Adds the <see cref="AutodeskAuthenticationMiddleware"/> middleware to the specified
+        /// <see cref="IApplicationBuilder"/>, which enables Autodesk authentication capabilities.
+        /// </summary>
+        /// <param name="app">The <see cref="IApplicationBuilder"/> to add the middleware to.</param>
+        /// <param name="options">A <see cref="AutodeskAuthenticationOptions"/> that specifies options for the middleware.</param>        
+        /// <returns>A reference to this instance after the operation has completed.</returns>
+        public static IApplicationBuilder UseAutodeskAuthentication(
+            [NotNull] this IApplicationBuilder app,
+            [NotNull] AutodeskAuthenticationOptions options) {
+            if (app == null) {
+                throw new ArgumentNullException(nameof(app));
+            }
+
+            if (options == null) {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            return app.UseMiddleware<AutodeskAuthenticationMiddleware>(Options.Create(options));
+        }
+
+        /// <summary>
+        /// Adds the <see cref="AutodeskAuthenticationMiddleware"/> middleware to the specified
+        /// <see cref="IApplicationBuilder"/>, which enables Autodesk authentication capabilities.
+        /// </summary>
+        /// <param name="app">The <see cref="IApplicationBuilder"/> to add the middleware to.</param>
+        /// <param name="configuration">An action delegate to configure the provided <see cref="AutodeskAuthenticationOptions"/>.</param>
+        /// <returns>A reference to this instance after the operation has completed.</returns>
+        public static IApplicationBuilder UseAutodeskAuthentication(
+            [NotNull] this IApplicationBuilder app,
+            [NotNull] Action<AutodeskAuthenticationOptions> configuration) {
+            if (app == null) {
+                throw new ArgumentNullException(nameof(app));
+            }
+
+            if (configuration == null) {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
+            var options = new AutodeskAuthenticationOptions();
+            configuration(options);
+
+            return app.UseMiddleware<AutodeskAuthenticationMiddleware>(Options.Create(options));
+        }
+    }
+}

--- a/src/AspNet.Security.OAuth.Autodesk/AutodeskAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.Autodesk/AutodeskAuthenticationExtensions.cs
@@ -9,11 +9,13 @@ using AspNet.Security.OAuth.Autodesk;
 using JetBrains.Annotations;
 using Microsoft.Extensions.Options;
 
-namespace Microsoft.AspNetCore.Builder {
+namespace Microsoft.AspNetCore.Builder
+{
     /// <summary>
     /// Extension methods to add Autodesk authentication capabilities to an HTTP application pipeline.
     /// </summary>
-    public static class AutodeskAuthenticationExtensions {
+    public static class AutodeskAuthenticationExtensions
+    {
         /// <summary>
         /// Adds the <see cref="AutodeskAuthenticationMiddleware"/> middleware to the specified
         /// <see cref="IApplicationBuilder"/>, which enables Autodesk authentication capabilities.
@@ -23,7 +25,8 @@ namespace Microsoft.AspNetCore.Builder {
         /// <returns>A reference to this instance after the operation has completed.</returns>
         public static IApplicationBuilder UseAutodeskAuthentication(
             [NotNull] this IApplicationBuilder app,
-            [NotNull] AutodeskAuthenticationOptions options) {
+            [NotNull] AutodeskAuthenticationOptions options)
+        {
             if (app == null) {
                 throw new ArgumentNullException(nameof(app));
             }
@@ -44,7 +47,8 @@ namespace Microsoft.AspNetCore.Builder {
         /// <returns>A reference to this instance after the operation has completed.</returns>
         public static IApplicationBuilder UseAutodeskAuthentication(
             [NotNull] this IApplicationBuilder app,
-            [NotNull] Action<AutodeskAuthenticationOptions> configuration) {
+            [NotNull] Action<AutodeskAuthenticationOptions> configuration)
+        {
             if (app == null) {
                 throw new ArgumentNullException(nameof(app));
             }

--- a/src/AspNet.Security.OAuth.Autodesk/AutodeskAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.Autodesk/AutodeskAuthenticationExtensions.cs
@@ -27,11 +27,13 @@ namespace Microsoft.AspNetCore.Builder
             [NotNull] this IApplicationBuilder app,
             [NotNull] AutodeskAuthenticationOptions options)
         {
-            if (app == null) {
+            if (app == null)
+            {
                 throw new ArgumentNullException(nameof(app));
             }
 
-            if (options == null) {
+            if (options == null)
+            {
                 throw new ArgumentNullException(nameof(options));
             }
 
@@ -49,11 +51,13 @@ namespace Microsoft.AspNetCore.Builder
             [NotNull] this IApplicationBuilder app,
             [NotNull] Action<AutodeskAuthenticationOptions> configuration)
         {
-            if (app == null) {
+            if (app == null)
+            {
                 throw new ArgumentNullException(nameof(app));
             }
 
-            if (configuration == null) {
+            if (configuration == null)
+            {
                 throw new ArgumentNullException(nameof(configuration));
             }
 

--- a/src/AspNet.Security.OAuth.Autodesk/AutodeskAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Autodesk/AutodeskAuthenticationHandler.cs
@@ -41,8 +41,8 @@ namespace AspNet.Security.OAuth.Autodesk
             identity.AddOptionalClaim(ClaimTypes.GivenName, AutodeskAuthenticationHelper.GetFirstName(payload), Options.ClaimsIssuer);
             identity.AddOptionalClaim(ClaimTypes.Surname, AutodeskAuthenticationHelper.GetLastName(payload), Options.ClaimsIssuer);
             identity.AddOptionalClaim(ClaimTypes.Email, AutodeskAuthenticationHelper.GetEmailAddress(payload), ClaimValueTypes.Email, Options.ClaimsIssuer);
-            identity.AddOptionalClaim(AutodeskAuthenticationHelper.EmailVerifiedClaim, AutodeskAuthenticationHelper.GetEmailVerified(payload), ClaimValueTypes.Boolean, Options.ClaimsIssuer);
-            identity.AddOptionalClaim(AutodeskAuthenticationHelper.TwoFactorEnabledClaim, AutodeskAuthenticationHelper.GetTwoFactorEnabled(payload), ClaimValueTypes.Boolean, Options.ClaimsIssuer);
+            identity.AddOptionalClaim(AutodeskAuthenticationConstants.Claims.EmailVerified, AutodeskAuthenticationHelper.GetEmailVerified(payload), ClaimValueTypes.Boolean, Options.ClaimsIssuer);
+            identity.AddOptionalClaim(AutodeskAuthenticationConstants.Claims.TwoFactorEnabled, AutodeskAuthenticationHelper.GetTwoFactorEnabled(payload), ClaimValueTypes.Boolean, Options.ClaimsIssuer);
             
             var principal = new ClaimsPrincipal(identity);
             var ticket = new AuthenticationTicket(principal, properties, Options.AuthenticationScheme);

--- a/src/AspNet.Security.OAuth.Autodesk/AutodeskAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Autodesk/AutodeskAuthenticationHandler.cs
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using AspNet.Security.OAuth.Extensions;
+using JetBrains.Annotations;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.OAuth;
+using Microsoft.AspNetCore.Http.Authentication;
+using Newtonsoft.Json.Linq;
+
+namespace AspNet.Security.OAuth.Autodesk {
+    public class AutodeskAuthenticationHandler : OAuthHandler<AutodeskAuthenticationOptions> {
+        public AutodeskAuthenticationHandler([NotNull] HttpClient client)
+            : base(client) {
+        }
+
+        protected override async Task<AuthenticationTicket> CreateTicketAsync([NotNull] ClaimsIdentity identity,
+            [NotNull] AuthenticationProperties properties, [NotNull] OAuthTokenResponse tokens) {
+            var request = new HttpRequestMessage(HttpMethod.Get, Options.UserInformationEndpoint);
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", tokens.AccessToken);
+
+            var response = await Backchannel.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, Context.RequestAborted);
+            response.EnsureSuccessStatusCode();
+
+            var payload = JObject.Parse(await response.Content.ReadAsStringAsync());
+
+            identity.AddOptionalClaim(ClaimTypes.NameIdentifier, AutodeskAuthenticationHelper.GetUserId(payload), Options.ClaimsIssuer);
+            identity.AddOptionalClaim(ClaimTypes.Name, AutodeskAuthenticationHelper.GetUserName(payload), Options.ClaimsIssuer);
+            identity.AddOptionalClaim(ClaimTypes.GivenName, AutodeskAuthenticationHelper.GetFirstName(payload), Options.ClaimsIssuer);
+            identity.AddOptionalClaim(ClaimTypes.Surname, AutodeskAuthenticationHelper.GetLastName(payload), Options.ClaimsIssuer);
+            identity.AddOptionalClaim(ClaimTypes.Email, AutodeskAuthenticationHelper.GetEmailAddress(payload), ClaimValueTypes.Email, Options.ClaimsIssuer);
+            identity.AddOptionalClaim(AutodeskAuthenticationHelper.EmailVerifiedClaim, AutodeskAuthenticationHelper.GetEmailVerified(payload), ClaimValueTypes.Boolean, Options.ClaimsIssuer);
+            identity.AddOptionalClaim(AutodeskAuthenticationHelper.TwoFactorEnabledClaim, AutodeskAuthenticationHelper.GetTwoFactorEnabled(payload), ClaimValueTypes.Boolean, Options.ClaimsIssuer);
+            
+            var principal = new ClaimsPrincipal(identity);
+            var ticket = new AuthenticationTicket(principal, properties, Options.AuthenticationScheme);
+
+            var context = new OAuthCreatingTicketContext(ticket, Context, Options, Backchannel, tokens, payload);
+            await Options.Events.CreatingTicket(context);
+
+            return context.Ticket;
+        }
+    }
+}

--- a/src/AspNet.Security.OAuth.Autodesk/AutodeskAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Autodesk/AutodeskAuthenticationHandler.cs
@@ -15,14 +15,18 @@ using Microsoft.AspNetCore.Authentication.OAuth;
 using Microsoft.AspNetCore.Http.Authentication;
 using Newtonsoft.Json.Linq;
 
-namespace AspNet.Security.OAuth.Autodesk {
-    public class AutodeskAuthenticationHandler : OAuthHandler<AutodeskAuthenticationOptions> {
+namespace AspNet.Security.OAuth.Autodesk
+{
+    public class AutodeskAuthenticationHandler : OAuthHandler<AutodeskAuthenticationOptions>
+    {
         public AutodeskAuthenticationHandler([NotNull] HttpClient client)
-            : base(client) {
+            : base(client)
+        {
         }
 
         protected override async Task<AuthenticationTicket> CreateTicketAsync([NotNull] ClaimsIdentity identity,
-            [NotNull] AuthenticationProperties properties, [NotNull] OAuthTokenResponse tokens) {
+            [NotNull] AuthenticationProperties properties, [NotNull] OAuthTokenResponse tokens)
+        {
             var request = new HttpRequestMessage(HttpMethod.Get, Options.UserInformationEndpoint);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", tokens.AccessToken);

--- a/src/AspNet.Security.OAuth.Autodesk/AutodeskAuthenticationHelper.cs
+++ b/src/AspNet.Security.OAuth.Autodesk/AutodeskAuthenticationHelper.cs
@@ -1,0 +1,91 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using Newtonsoft.Json.Linq;
+
+namespace AspNet.Security.OAuth.Autodesk {
+    /// <summary>
+    /// Contains static methods that allow to extract user's information from a <see cref="JObject"/>
+    /// instance retrieved from Autodesk after a successful authentication process.
+    /// </summary>
+    public static class AutodeskAuthenticationHelper {
+        /// <summary>
+        /// Key for claim containing a boolean value indicating whether the user's email has been verified
+        /// </summary>
+        public static readonly string EmailVerifiedClaim = "urn:autodesk:emailverified";
+
+        /// <summary>
+        /// Key for claim containing a boolean value indicating whether the user has enabled two factor authentication
+        /// </summary>
+        public static readonly string TwoFactorEnabledClaim = "urn:autodesk:twofactorenabled";
+
+        /// <summary>
+        /// Unique user identifier
+        /// </summary>
+        /// <remarks>
+        /// Usually alphanumeric. Some older IDs may reflect username.
+        /// </remarks>
+        /// <param name="user">User info JSON</param>
+        /// <returns>User Id</returns>
+        public static string GetUserId(JObject user) => user.Value<string>("userId");
+
+        /// <summary>
+        /// Username e.g. John Doe or john.doe
+        /// </summary>
+        /// <remarks>
+        /// Usually the content of the email address before the @ symbol.
+        /// Can be used for sign-in.
+        /// </remarks>
+        /// <param name="user">User info JSON</param>
+        /// <returns>User name</returns>
+        public static string GetUserName(JObject user) => user.Value<string>("userName");
+
+        /// <summary>
+        /// User email address e.g. john.doe@autodesk.com
+        /// </summary>
+        /// <remarks>
+        /// Directly supplied by the user at signup.
+        /// Can be used for sign-in.
+        /// </remarks>
+        /// <param name="user">User info JSON</param>
+        /// <returns>Email address</returns>
+        public static string GetEmailAddress(JObject user) => user.Value<string>("emailId");
+
+        /// <summary>
+        /// User first name e.g. John
+        /// </summary>
+        /// <remarks>
+        /// Directly supplied by the user at signup.
+        /// </remarks>
+        /// <param name="user">User info JSON</param>
+        /// <returns>First name</returns>
+        public static string GetFirstName(JObject user) => user.Value<string>("firstName");
+
+        /// <summary>
+        /// User last name e.g. Doe
+        /// </summary>
+        /// <remarks>
+        /// Directly supplied by the user at signup.
+        /// </remarks>
+        /// <param name="user">User info JSON</param>
+        /// <returns>Last name</returns>
+        public static string GetLastName(JObject user) => user.Value<string>("lastName");
+
+        /// <summary>
+        /// Boolean value indicating whether or not the user's email address has been verified
+        /// </summary>
+        /// <param name="user">User info JSON</param>
+        /// <returns>Status of email verification</returns>
+        public static string GetEmailVerified(JObject user) => user.Value<string>("emailVerified");
+
+        /// <summary>
+        /// Boolean value indicating whether or not the user has enabled two-factor authentication
+        /// </summary>
+        /// <param name="user">User info JSON</param>
+        /// <returns>Status of 2FA</returns>
+        public static string GetTwoFactorEnabled(JObject user) => user.Value<string>("2FaEnabled");
+    }
+}

--- a/src/AspNet.Security.OAuth.Autodesk/AutodeskAuthenticationHelper.cs
+++ b/src/AspNet.Security.OAuth.Autodesk/AutodeskAuthenticationHelper.cs
@@ -15,16 +15,6 @@ namespace AspNet.Security.OAuth.Autodesk
     public static class AutodeskAuthenticationHelper
     {
         /// <summary>
-        /// Key for claim containing a boolean value indicating whether the user's email has been verified
-        /// </summary>
-        public static readonly string EmailVerifiedClaim = "urn:autodesk:emailverified";
-
-        /// <summary>
-        /// Key for claim containing a boolean value indicating whether the user has enabled two factor authentication
-        /// </summary>
-        public static readonly string TwoFactorEnabledClaim = "urn:autodesk:twofactorenabled";
-
-        /// <summary>
         /// Unique user identifier
         /// </summary>
         /// <remarks>

--- a/src/AspNet.Security.OAuth.Autodesk/AutodeskAuthenticationHelper.cs
+++ b/src/AspNet.Security.OAuth.Autodesk/AutodeskAuthenticationHelper.cs
@@ -6,12 +6,14 @@
 
 using Newtonsoft.Json.Linq;
 
-namespace AspNet.Security.OAuth.Autodesk {
+namespace AspNet.Security.OAuth.Autodesk
+{
     /// <summary>
     /// Contains static methods that allow to extract user's information from a <see cref="JObject"/>
     /// instance retrieved from Autodesk after a successful authentication process.
     /// </summary>
-    public static class AutodeskAuthenticationHelper {
+    public static class AutodeskAuthenticationHelper
+    {
         /// <summary>
         /// Key for claim containing a boolean value indicating whether the user's email has been verified
         /// </summary>

--- a/src/AspNet.Security.OAuth.Autodesk/AutodeskAuthenticationMiddleware.cs
+++ b/src/AspNet.Security.OAuth.Autodesk/AutodeskAuthenticationMiddleware.cs
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.OAuth;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using JetBrains.Annotations;
+
+namespace AspNet.Security.OAuth.Autodesk {
+    public class AutodeskAuthenticationMiddleware : OAuthMiddleware<AutodeskAuthenticationOptions> {
+        public AutodeskAuthenticationMiddleware(
+            [NotNull] RequestDelegate next,
+            [NotNull] IDataProtectionProvider dataProtectionProvider,
+            [NotNull] ILoggerFactory loggerFactory,
+            [NotNull] UrlEncoder encoder,
+            [NotNull] IOptions<SharedAuthenticationOptions> sharedOptions,
+            [NotNull] IOptions<AutodeskAuthenticationOptions> options)
+            : base(next, dataProtectionProvider, loggerFactory, encoder, sharedOptions, options) {
+        }
+
+        protected override AuthenticationHandler<AutodeskAuthenticationOptions> CreateHandler() {
+            return new AutodeskAuthenticationHandler(Backchannel);
+        }
+    }
+}

--- a/src/AspNet.Security.OAuth.Autodesk/AutodeskAuthenticationMiddleware.cs
+++ b/src/AspNet.Security.OAuth.Autodesk/AutodeskAuthenticationMiddleware.cs
@@ -13,8 +13,10 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using JetBrains.Annotations;
 
-namespace AspNet.Security.OAuth.Autodesk {
-    public class AutodeskAuthenticationMiddleware : OAuthMiddleware<AutodeskAuthenticationOptions> {
+namespace AspNet.Security.OAuth.Autodesk
+{
+    public class AutodeskAuthenticationMiddleware : OAuthMiddleware<AutodeskAuthenticationOptions>
+    {
         public AutodeskAuthenticationMiddleware(
             [NotNull] RequestDelegate next,
             [NotNull] IDataProtectionProvider dataProtectionProvider,
@@ -22,10 +24,12 @@ namespace AspNet.Security.OAuth.Autodesk {
             [NotNull] UrlEncoder encoder,
             [NotNull] IOptions<SharedAuthenticationOptions> sharedOptions,
             [NotNull] IOptions<AutodeskAuthenticationOptions> options)
-            : base(next, dataProtectionProvider, loggerFactory, encoder, sharedOptions, options) {
+            : base(next, dataProtectionProvider, loggerFactory, encoder, sharedOptions, options)
+        {
         }
 
-        protected override AuthenticationHandler<AutodeskAuthenticationOptions> CreateHandler() {
+        protected override AuthenticationHandler<AutodeskAuthenticationOptions> CreateHandler()
+        {
             return new AutodeskAuthenticationHandler(Backchannel);
         }
     }

--- a/src/AspNet.Security.OAuth.Autodesk/AutodeskAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Autodesk/AutodeskAuthenticationOptions.cs
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+namespace AspNet.Security.OAuth.Autodesk {
+    /// <summary>
+    /// Defines a set of options used by <see cref="AutodeskAuthenticationHandler"/>.
+    /// </summary>
+    public class AutodeskAuthenticationOptions : OAuthOptions {
+        public AutodeskAuthenticationOptions() {
+            AuthenticationScheme = AutodeskAuthenticationDefaults.AuthenticationScheme;
+            DisplayName = AutodeskAuthenticationDefaults.DisplayName;
+            ClaimsIssuer = AutodeskAuthenticationDefaults.Issuer;
+
+            CallbackPath = new PathString(AutodeskAuthenticationDefaults.CallbackPath);
+
+            AuthorizationEndpoint = AutodeskAuthenticationDefaults.AuthorizationEndpoint;
+            TokenEndpoint = AutodeskAuthenticationDefaults.TokenEndpoint;
+            UserInformationEndpoint = AutodeskAuthenticationDefaults.UserInformationEndpoint;
+
+            foreach (var scope in AutodeskAuthenticationDefaults.Scope)
+            {
+                Scope.Add(scope);
+            }
+        }
+    }
+}

--- a/src/AspNet.Security.OAuth.Autodesk/AutodeskAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Autodesk/AutodeskAuthenticationOptions.cs
@@ -7,12 +7,15 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 
-namespace AspNet.Security.OAuth.Autodesk {
+namespace AspNet.Security.OAuth.Autodesk
+{
     /// <summary>
     /// Defines a set of options used by <see cref="AutodeskAuthenticationHandler"/>.
     /// </summary>
-    public class AutodeskAuthenticationOptions : OAuthOptions {
-        public AutodeskAuthenticationOptions() {
+    public class AutodeskAuthenticationOptions : OAuthOptions
+    {
+        public AutodeskAuthenticationOptions()
+        {
             AuthenticationScheme = AutodeskAuthenticationDefaults.AuthenticationScheme;
             DisplayName = AutodeskAuthenticationDefaults.DisplayName;
             ClaimsIssuer = AutodeskAuthenticationDefaults.Issuer;

--- a/src/AspNet.Security.OAuth.Autodesk/project.json
+++ b/src/AspNet.Security.OAuth.Autodesk/project.json
@@ -1,0 +1,49 @@
+{
+    "version": "1.0.0-beta2-*",
+    "description": "ASP.NET Core security middleware enabling Autodesk authentication.",
+    "authors": [ "Jeff Hotchkiss" ],
+
+  "packOptions": {
+    "owners": [ "Kévin Chalet", "Jerrie Pelser" ],
+
+    "projectUrl": "https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers",
+    "iconUrl": "https://avatars3.githubusercontent.com/u/7998081?s=64",
+    "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0.html",
+
+    "repository": {
+      "type": "git",
+      "url": "git://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers"
+    },
+
+    "tags": [
+      "aspnetcore",
+      "authentication",
+      "autodesk",
+      "oauth",
+      "security"
+    ]
+  },
+
+  "buildOptions": {
+    "warningsAsErrors": true,
+    "nowarn": [ "CS1591" ],
+    "xmlDoc": true
+  },
+
+  "dependencies": {
+    "AspNet.Security.OAuth.Extensions": { "target": "project", "type": "build" },
+    "JetBrains.Annotations": { "type": "build", "version": "10.1.4" },
+    "Microsoft.AspNetCore.Authentication.OAuth": "1.0.0"
+  },
+
+  "frameworks": {
+    "net451": { },
+
+    "netstandard1.3": {
+      "imports": [
+        "dotnet5.4",
+        "portable-net451+win8"
+      ]
+    }
+  }
+}

--- a/src/AspNet.Security.OAuth.Autodesk/project.json
+++ b/src/AspNet.Security.OAuth.Autodesk/project.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.0-beta2-*",
+    "version": "1.0.0-beta3-*",
     "description": "ASP.NET Core security middleware enabling Autodesk authentication.",
     "authors": [ "Jeff Hotchkiss" ],
 

--- a/src/AspNet.Security.OAuth.Extensions/ClaimsExtensions.cs
+++ b/src/AspNet.Security.OAuth.Extensions/ClaimsExtensions.cs
@@ -10,6 +10,10 @@ using System.Security.Claims;
 namespace AspNet.Security.OAuth.Extensions {
     public static class ClaimsExtensions {
         public static ClaimsIdentity AddOptionalClaim(this ClaimsIdentity identity, string type, string value, string issuer) {
+            return AddOptionalClaim(identity, type, value, ClaimValueTypes.String, issuer);
+        }
+
+        public static ClaimsIdentity AddOptionalClaim(this ClaimsIdentity identity, string type, string value, string types, string issuer) {
             if (identity == null) {
                 throw new ArgumentNullException(nameof(identity));
             }
@@ -19,7 +23,7 @@ namespace AspNet.Security.OAuth.Extensions {
                 return identity;
             }
 
-            identity.AddClaim(new Claim(type, value, ClaimValueTypes.String, issuer ?? ClaimsIdentity.DefaultIssuer));
+            identity.AddClaim(new Claim(type, value, types, issuer ?? ClaimsIdentity.DefaultIssuer));
             return identity;
         }
     }

--- a/src/AspNet.Security.OAuth.Extensions/ClaimsExtensions.cs
+++ b/src/AspNet.Security.OAuth.Extensions/ClaimsExtensions.cs
@@ -9,12 +9,16 @@ using System.Security.Claims;
 
 namespace AspNet.Security.OAuth.Extensions
 {
-    public static class ClaimsExtensions {
-        public static ClaimsIdentity AddOptionalClaim(this ClaimsIdentity identity, string type, string value, string issuer) {
+    public static class ClaimsExtensions
+    {
+        public static ClaimsIdentity AddOptionalClaim(this ClaimsIdentity identity, string type, string value, string issuer)
+        {
             return AddOptionalClaim(identity, type, value, ClaimValueTypes.String, issuer);
         }
 
-            public static ClaimsIdentity AddOptionalClaim(this ClaimsIdentity identity, string type, string value, string types, string issuer) {
+        public static ClaimsIdentity AddOptionalClaim(this ClaimsIdentity identity, string type, string value, string types, string issuer)
+        {
+            if (identity == null)
             {
                 throw new ArgumentNullException(nameof(identity));
             }

--- a/src/AspNet.Security.OAuth.Extensions/ClaimsExtensions.cs
+++ b/src/AspNet.Security.OAuth.Extensions/ClaimsExtensions.cs
@@ -16,7 +16,7 @@ namespace AspNet.Security.OAuth.Extensions
             return AddOptionalClaim(identity, type, value, ClaimValueTypes.String, issuer);
         }
 
-        public static ClaimsIdentity AddOptionalClaim(this ClaimsIdentity identity, string type, string value, string types, string issuer)
+        public static ClaimsIdentity AddOptionalClaim(this ClaimsIdentity identity, string type, string value, string valueType, string issuer)
         {
             if (identity == null)
             {
@@ -29,7 +29,7 @@ namespace AspNet.Security.OAuth.Extensions
                 return identity;
             }
 
-            identity.AddClaim(new Claim(type, value, types, issuer ?? ClaimsIdentity.DefaultIssuer));
+            identity.AddClaim(new Claim(type, value, valueType, issuer ?? ClaimsIdentity.DefaultIssuer));
             return identity;
         }
     }

--- a/src/AspNet.Security.OAuth.GitHub/GitHubAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.GitHub/GitHubAuthenticationOptions.cs
@@ -28,6 +28,6 @@ namespace AspNet.Security.OAuth.GitHub {
         /// Gets or sets the address of the endpoint exposing
         /// the email addresses associated with the logged in user.
         /// </summary>
-        public string UserEmailsEndpoint { get; } = GitHubAuthenticationDefaults.UserEmailsEndpoint;
+        public string UserEmailsEndpoint { get; set; } = GitHubAuthenticationDefaults.UserEmailsEndpoint;
     }
 }


### PR DESCRIPTION
Generated from the Yeoman scripting, issue #120.
Tested with the sample MvcClient against https://developer.autodesk.com/ with an external account.
Added an extension that allows other claim types beyond string.

Let me know if I've missed anything from the contributing guide, thanks!