### PR TITLE
Removing automatic scope addition

### DIFF
--- a/src/AspNet.Security.OAuth.VisualStudio/VisualStudioAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.VisualStudio/VisualStudioAuthenticationOptions.cs
@@ -25,8 +25,6 @@ namespace AspNet.Security.OAuth.VisualStudio
             AuthorizationEndpoint = VisualStudioAuthenticationDefaults.AuthorizationEndpoint;
             TokenEndpoint = VisualStudioAuthenticationDefaults.TokenEndpoint;
             UserInformationEndpoint = VisualStudioAuthenticationDefaults.UserInformationEndpoint;
-
-            Scope.Add("vso.profile");
         }
     }
 }


### PR DESCRIPTION
Automatically adding vso.profile as a scope will cause any VSTS applications to return error=InvalidScope if the vso.profile scope was implicit instead of explicit.