### PR TITLE
Update the .csproj files to ensure AspNet.Security.OAuth.Extensions is not referenced by the NuGet packages

### DIFF
--- a/src/AspNet.Security.OAuth.Amazon/AspNet.Security.OAuth.Amazon.csproj
+++ b/src/AspNet.Security.OAuth.Amazon/AspNet.Security.OAuth.Amazon.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" />
+    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.ArcGIS/AspNet.Security.OAuth.ArcGIS.csproj
+++ b/src/AspNet.Security.OAuth.ArcGIS/AspNet.Security.OAuth.ArcGIS.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" />
+    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Asana/AspNet.Security.OAuth.Asana.csproj
+++ b/src/AspNet.Security.OAuth.Asana/AspNet.Security.OAuth.Asana.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" />
+    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Autodesk/AspNet.Security.OAuth.Autodesk.csproj
+++ b/src/AspNet.Security.OAuth.Autodesk/AspNet.Security.OAuth.Autodesk.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" />
+    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Automatic/AspNet.Security.OAuth.Automatic.csproj
+++ b/src/AspNet.Security.OAuth.Automatic/AspNet.Security.OAuth.Automatic.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" />
+    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.BattleNet/AspNet.Security.OAuth.BattleNet.csproj
+++ b/src/AspNet.Security.OAuth.BattleNet/AspNet.Security.OAuth.BattleNet.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" />
+    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Beam/AspNet.Security.OAuth.Beam.csproj
+++ b/src/AspNet.Security.OAuth.Beam/AspNet.Security.OAuth.Beam.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" />
+    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Bitbucket/AspNet.Security.OAuth.Bitbucket.csproj
+++ b/src/AspNet.Security.OAuth.Bitbucket/AspNet.Security.OAuth.Bitbucket.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" />
+    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Buffer/AspNet.Security.OAuth.Buffer.csproj
+++ b/src/AspNet.Security.OAuth.Buffer/AspNet.Security.OAuth.Buffer.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" />
+    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.CiscoSpark/AspNet.Security.OAuth.CiscoSpark.csproj
+++ b/src/AspNet.Security.OAuth.CiscoSpark/AspNet.Security.OAuth.CiscoSpark.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" />
+    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.DeviantArt/AspNet.Security.OAuth.DeviantArt.csproj
+++ b/src/AspNet.Security.OAuth.DeviantArt/AspNet.Security.OAuth.DeviantArt.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" />
+    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Discord/AspNet.Security.OAuth.Discord.csproj
+++ b/src/AspNet.Security.OAuth.Discord/AspNet.Security.OAuth.Discord.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" />
+    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Dropbox/AspNet.Security.OAuth.Dropbox.csproj
+++ b/src/AspNet.Security.OAuth.Dropbox/AspNet.Security.OAuth.Dropbox.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" />
+    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.EVEOnline/AspNet.Security.OAuth.EVEOnline.csproj
+++ b/src/AspNet.Security.OAuth.EVEOnline/AspNet.Security.OAuth.EVEOnline.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" />
+    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Fitbit/AspNet.Security.OAuth.Fitbit.csproj
+++ b/src/AspNet.Security.OAuth.Fitbit/AspNet.Security.OAuth.Fitbit.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" />
+    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Foursquare/AspNet.Security.OAuth.Foursquare.csproj
+++ b/src/AspNet.Security.OAuth.Foursquare/AspNet.Security.OAuth.Foursquare.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" />
+    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.GitHub/AspNet.Security.OAuth.GitHub.csproj
+++ b/src/AspNet.Security.OAuth.GitHub/AspNet.Security.OAuth.GitHub.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" />
+    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Gitter/AspNet.Security.OAuth.Gitter.csproj
+++ b/src/AspNet.Security.OAuth.Gitter/AspNet.Security.OAuth.Gitter.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" />
+    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.HealthGraph/AspNet.Security.OAuth.HealthGraph.csproj
+++ b/src/AspNet.Security.OAuth.HealthGraph/AspNet.Security.OAuth.HealthGraph.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" />
+    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Imgur/AspNet.Security.OAuth.Imgur.csproj
+++ b/src/AspNet.Security.OAuth.Imgur/AspNet.Security.OAuth.Imgur.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" />
+    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Instagram/AspNet.Security.OAuth.Instagram.csproj
+++ b/src/AspNet.Security.OAuth.Instagram/AspNet.Security.OAuth.Instagram.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" />
+    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.LinkedIn/AspNet.Security.OAuth.LinkedIn.csproj
+++ b/src/AspNet.Security.OAuth.LinkedIn/AspNet.Security.OAuth.LinkedIn.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" />
+    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.MailChimp/AspNet.Security.OAuth.MailChimp.csproj
+++ b/src/AspNet.Security.OAuth.MailChimp/AspNet.Security.OAuth.MailChimp.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" />
+    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Myob/AspNet.Security.OAuth.Myob.csproj
+++ b/src/AspNet.Security.OAuth.Myob/AspNet.Security.OAuth.Myob.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" />
+    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Onshape/AspNet.Security.OAuth.Onshape.csproj
+++ b/src/AspNet.Security.OAuth.Onshape/AspNet.Security.OAuth.Onshape.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" />
+    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Paypal/AspNet.Security.OAuth.Paypal.csproj
+++ b/src/AspNet.Security.OAuth.Paypal/AspNet.Security.OAuth.Paypal.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" />
+    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Reddit/AspNet.Security.OAuth.Reddit.csproj
+++ b/src/AspNet.Security.OAuth.Reddit/AspNet.Security.OAuth.Reddit.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" />
+    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Salesforce/AspNet.Security.OAuth.Salesforce.csproj
+++ b/src/AspNet.Security.OAuth.Salesforce/AspNet.Security.OAuth.Salesforce.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" />
+    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Slack/AspNet.Security.OAuth.Slack.csproj
+++ b/src/AspNet.Security.OAuth.Slack/AspNet.Security.OAuth.Slack.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" />
+    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.SoundCloud/AspNet.Security.OAuth.SoundCloud.csproj
+++ b/src/AspNet.Security.OAuth.SoundCloud/AspNet.Security.OAuth.SoundCloud.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" />
+    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Spotify/AspNet.Security.OAuth.Spotify.csproj
+++ b/src/AspNet.Security.OAuth.Spotify/AspNet.Security.OAuth.Spotify.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" />
+    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.StackExchange/AspNet.Security.OAuth.StackExchange.csproj
+++ b/src/AspNet.Security.OAuth.StackExchange/AspNet.Security.OAuth.StackExchange.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" />
+    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Strava/AspNet.Security.OAuth.Strava.csproj
+++ b/src/AspNet.Security.OAuth.Strava/AspNet.Security.OAuth.Strava.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" />
+    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Twitch/AspNet.Security.OAuth.Twitch.csproj
+++ b/src/AspNet.Security.OAuth.Twitch/AspNet.Security.OAuth.Twitch.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" />
+    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Untappd/AspNet.Security.OAuth.Untappd.csproj
+++ b/src/AspNet.Security.OAuth.Untappd/AspNet.Security.OAuth.Untappd.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" />
+    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Vimeo/AspNet.Security.OAuth.Vimeo.csproj
+++ b/src/AspNet.Security.OAuth.Vimeo/AspNet.Security.OAuth.Vimeo.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" />
+    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.VisualStudio/AspNet.Security.OAuth.VisualStudio.csproj
+++ b/src/AspNet.Security.OAuth.VisualStudio/AspNet.Security.OAuth.VisualStudio.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" />
+    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Vkontakte/AspNet.Security.OAuth.Vkontakte.csproj
+++ b/src/AspNet.Security.OAuth.Vkontakte/AspNet.Security.OAuth.Vkontakte.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" />
+    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Weibo/AspNet.Security.OAuth.Weibo.csproj
+++ b/src/AspNet.Security.OAuth.Weibo/AspNet.Security.OAuth.Weibo.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" />
+    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Weixin/AspNet.Security.OAuth.Weixin.csproj
+++ b/src/AspNet.Security.OAuth.Weixin/AspNet.Security.OAuth.Weixin.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" />
+    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.WordPress/AspNet.Security.OAuth.WordPress.csproj
+++ b/src/AspNet.Security.OAuth.WordPress/AspNet.Security.OAuth.WordPress.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" />
+    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Yahoo/AspNet.Security.OAuth.Yahoo.csproj
+++ b/src/AspNet.Security.OAuth.Yahoo/AspNet.Security.OAuth.Yahoo.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" />
+    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Yammer/AspNet.Security.OAuth.Yammer.csproj
+++ b/src/AspNet.Security.OAuth.Yammer/AspNet.Security.OAuth.Yammer.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" />
+    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Yandex/AspNet.Security.OAuth.Yandex.csproj
+++ b/src/AspNet.Security.OAuth.Yandex/AspNet.Security.OAuth.Yandex.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" />
+    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
All the OAuth2 rc1-final packages can't be installed due to the unwanted `AspNet.Security.OAuth.Extensions` dependency added to the .nuspec definitions. Since this package is a sources project, we don't publish it and NuGet displays an errors stating that `AspNet.Security.OAuth.Extensions` `rc1-final` cannot be found.