### PR TITLE
Fix an issue with the LinkedIn provider not parsing the standard profile request fields not being parsed correctly

### DIFF
--- a/src/AspNet.Security.OAuth.LinkedIn/LinkedInAuthenticationHelper.cs
+++ b/src/AspNet.Security.OAuth.LinkedIn/LinkedInAuthenticationHelper.cs
@@ -130,12 +130,12 @@ namespace AspNet.Security.OAuth.LinkedIn
         /// Gets the URL representing the resource one would request
         /// for programmatic access to the member's profile.
         /// </summary>
-        public static string GetApiStandardProfileRequest([NotNull] JObject user) => user.Value<string>("apiStandardProfileRequest");
+        public static string GetApiStandardProfileRequest([NotNull] JObject user) => user["apiStandardProfileRequest"]?.ToString();
 
         /// <summary>
         /// Gets the URL to the member's authenticated profile on LinkedIn.
         /// Note: one must be logged into LinkedIn to view this URL.
         /// </summary>
-        public static string GetSiteStandardProfileRequest([NotNull] JObject user) => user.Value<string>("siteStandardProfileRequest");
+        public static string GetSiteStandardProfileRequest([NotNull] JObject user) => user["siteStandardProfileRequest"]?.Value<string>("url");
     }
 }


### PR DESCRIPTION
Fix the `InvalidCastException: Cannot cast Newtonsoft.Json.Linq.JObject to Newtonsoft.Json.Linq.JToken.` thrown when adding `api-standard-profile-request` and `site-standard-profile-request` to the option fields to retrieve.

I used a similar pattern to the one from the above fields.