### PR TITLE
Convert AspNet.Security.OAuth.Extensions to a non-packable shared sources project

### DIFF
--- a/AspNet.Security.OAuth.Providers.sln
+++ b/AspNet.Security.OAuth.Providers.sln
@@ -11,7 +11,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNet.Security.OAuth.GitHu
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mvc.Client", "samples\Mvc.Client\Mvc.Client.csproj", "{68631868-902A-46FB-9A44-BACF1812FBDE}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNet.Security.OAuth.Extensions", "src\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj", "{FE52A431-57AD-45FA-AA59-C63CB6EA3F31}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNet.Security.OAuth.Extensions", "shared\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj", "{FE52A431-57AD-45FA-AA59-C63CB6EA3F31}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNet.Security.OAuth.LinkedIn", "src\AspNet.Security.OAuth.LinkedIn\AspNet.Security.OAuth.LinkedIn.csproj", "{0351689C-EAB7-42D0-966F-4021B89EF553}"
 EndProject
@@ -98,6 +98,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNet.Security.OAuth.Amazon", "src\AspNet.Security.OAuth.Amazon\AspNet.Security.OAuth.Amazon.csproj", "{C66A6EDB-D29A-49EE-841E-75F239DE5A04}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNet.Security.OAuth.Discord", "src\AspNet.Security.OAuth.Discord\AspNet.Security.OAuth.Discord.csproj", "{86614CB9-0768-40BF-8C27-699E3990B733}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "shared", "shared", "{CA7BFFF8-0DC9-4621-8DFE-D3E6A116C509}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -296,7 +298,7 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{9DFEE19E-C170-4F20-93F3-EC952B1532F2} = {C1352FD3-AE8B-43EE-B45B-F6E0B3FBAC6D}
 		{68631868-902A-46FB-9A44-BACF1812FBDE} = {BAC7067D-88FE-4385-8AC9-1A325FFBDE69}
-		{FE52A431-57AD-45FA-AA59-C63CB6EA3F31} = {C1352FD3-AE8B-43EE-B45B-F6E0B3FBAC6D}
+		{FE52A431-57AD-45FA-AA59-C63CB6EA3F31} = {CA7BFFF8-0DC9-4621-8DFE-D3E6A116C509}
 		{0351689C-EAB7-42D0-966F-4021B89EF553} = {C1352FD3-AE8B-43EE-B45B-F6E0B3FBAC6D}
 		{38E5DB77-7F35-4E3C-9719-8A25CE4130CA} = {C1352FD3-AE8B-43EE-B45B-F6E0B3FBAC6D}
 		{F79E8D15-F296-424C-A50E-AE39EB2C609F} = {C1352FD3-AE8B-43EE-B45B-F6E0B3FBAC6D}

--- a/samples/Mvc.Client/Startup.cs
+++ b/samples/Mvc.Client/Startup.cs
@@ -4,7 +4,6 @@
  * for more information concerning the license and the contributors participating to this project.
  */
 
-using AspNet.Security.OAuth.GitHub;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -46,13 +45,6 @@ namespace Mvc.Client
             {
                 ConsumerKey = "6XaCTaLbMqfj6ww3zvZ5g",
                 ConsumerSecret = "Il2eFzGIrYhz6BWjYhVXBPQSfZuS4xoHpSSyD9PI"
-            });
-
-            app.UseGitHubAuthentication(new GitHubAuthenticationOptions
-            {
-                ClientId = "49e302895d8b09ea5656",
-                ClientSecret = "98f1bf028608901e9df91d64ee61536fe562064b",
-                Scope = { "user:email" }
             });
 
             app.UseMvc();

--- a/shared/AspNet.Security.OAuth.Extensions/AspNet.Security.OAuth.Extensions.csproj
+++ b/shared/AspNet.Security.OAuth.Extensions/AspNet.Security.OAuth.Extensions.csproj
@@ -1,15 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="..\..\build\packages.props" />
+  <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
     <TargetFrameworks>net451;netstandard1.3</TargetFrameworks>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <Description>ASP.NET Core extensions making OAuth2 authentication easier to use.</Description>
-    <Authors>Kévin Chalet;Jerrie Pelser</Authors>
-    <PackageTags>aspnetcore;authentication;oauth;security</PackageTags>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">

--- a/shared/AspNet.Security.OAuth.Extensions/ClaimsExtensions.cs
+++ b/shared/AspNet.Security.OAuth.Extensions/ClaimsExtensions.cs
@@ -9,7 +9,7 @@ using System.Security.Claims;
 
 namespace AspNet.Security.OAuth.Extensions
 {
-    public static class ClaimsExtensions
+    internal static class ClaimsExtensions
     {
         public static ClaimsIdentity AddOptionalClaim(this ClaimsIdentity identity, string name, string value, string issuer)
         {

--- a/src/AspNet.Security.OAuth.Amazon/AmazonAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Amazon/AmazonAuthenticationHandler.cs
@@ -18,25 +18,15 @@ using Newtonsoft.Json.Linq;
 
 namespace AspNet.Security.OAuth.Amazon
 {
-    /// <summary>
-    /// A class representing an authentication handler for Amazon.
-    /// </summary>
     public class AmazonAuthenticationHandler : OAuthHandler<AmazonAuthenticationOptions>
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AmazonAuthenticationHandler"/> class.
-        /// </summary>
-        /// <param name="client">The <see cref="HttpClient"/> to use.</param>
         public AmazonAuthenticationHandler([NotNull] HttpClient client)
             : base(client)
         {
         }
 
-        /// <inheritdoc />
-        protected override async Task<AuthenticationTicket> CreateTicketAsync(
-            [NotNull] ClaimsIdentity identity,
-            [NotNull] AuthenticationProperties properties, 
-            [NotNull] OAuthTokenResponse tokens)
+        protected override async Task<AuthenticationTicket> CreateTicketAsync([NotNull] ClaimsIdentity identity,
+            [NotNull] AuthenticationProperties properties, [NotNull] OAuthTokenResponse tokens)
         {
             var endpoint = Options.UserInformationEndpoint;
 

--- a/src/AspNet.Security.OAuth.Amazon/AspNet.Security.OAuth.Amazon.csproj
+++ b/src/AspNet.Security.OAuth.Amazon/AspNet.Security.OAuth.Amazon.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
+    <Compile Include="..\..\shared\AspNet.Security.OAuth.Extensions\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.ArcGIS/AspNet.Security.OAuth.ArcGIS.csproj
+++ b/src/AspNet.Security.OAuth.ArcGIS/AspNet.Security.OAuth.ArcGIS.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
+    <Compile Include="..\..\shared\AspNet.Security.OAuth.Extensions\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Asana/AspNet.Security.OAuth.Asana.csproj
+++ b/src/AspNet.Security.OAuth.Asana/AspNet.Security.OAuth.Asana.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
+    <Compile Include="..\..\shared\AspNet.Security.OAuth.Extensions\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Autodesk/AspNet.Security.OAuth.Autodesk.csproj
+++ b/src/AspNet.Security.OAuth.Autodesk/AspNet.Security.OAuth.Autodesk.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
+    <Compile Include="..\..\shared\AspNet.Security.OAuth.Extensions\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Automatic/AspNet.Security.OAuth.Automatic.csproj
+++ b/src/AspNet.Security.OAuth.Automatic/AspNet.Security.OAuth.Automatic.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
+    <Compile Include="..\..\shared\AspNet.Security.OAuth.Extensions\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.BattleNet/AspNet.Security.OAuth.BattleNet.csproj
+++ b/src/AspNet.Security.OAuth.BattleNet/AspNet.Security.OAuth.BattleNet.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
+    <Compile Include="..\..\shared\AspNet.Security.OAuth.Extensions\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Beam/AspNet.Security.OAuth.Beam.csproj
+++ b/src/AspNet.Security.OAuth.Beam/AspNet.Security.OAuth.Beam.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
+    <Compile Include="..\..\shared\AspNet.Security.OAuth.Extensions\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Bitbucket/AspNet.Security.OAuth.Bitbucket.csproj
+++ b/src/AspNet.Security.OAuth.Bitbucket/AspNet.Security.OAuth.Bitbucket.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
+    <Compile Include="..\..\shared\AspNet.Security.OAuth.Extensions\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Buffer/AspNet.Security.OAuth.Buffer.csproj
+++ b/src/AspNet.Security.OAuth.Buffer/AspNet.Security.OAuth.Buffer.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
+    <Compile Include="..\..\shared\AspNet.Security.OAuth.Extensions\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.CiscoSpark/AspNet.Security.OAuth.CiscoSpark.csproj
+++ b/src/AspNet.Security.OAuth.CiscoSpark/AspNet.Security.OAuth.CiscoSpark.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
+    <Compile Include="..\..\shared\AspNet.Security.OAuth.Extensions\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.DeviantArt/AspNet.Security.OAuth.DeviantArt.csproj
+++ b/src/AspNet.Security.OAuth.DeviantArt/AspNet.Security.OAuth.DeviantArt.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
+    <Compile Include="..\..\shared\AspNet.Security.OAuth.Extensions\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Discord/AspNet.Security.OAuth.Discord.csproj
+++ b/src/AspNet.Security.OAuth.Discord/AspNet.Security.OAuth.Discord.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
+    <Compile Include="..\..\shared\AspNet.Security.OAuth.Extensions\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Dropbox/AspNet.Security.OAuth.Dropbox.csproj
+++ b/src/AspNet.Security.OAuth.Dropbox/AspNet.Security.OAuth.Dropbox.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
+    <Compile Include="..\..\shared\AspNet.Security.OAuth.Extensions\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.EVEOnline/AspNet.Security.OAuth.EVEOnline.csproj
+++ b/src/AspNet.Security.OAuth.EVEOnline/AspNet.Security.OAuth.EVEOnline.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
+    <Compile Include="..\..\shared\AspNet.Security.OAuth.Extensions\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Fitbit/AspNet.Security.OAuth.Fitbit.csproj
+++ b/src/AspNet.Security.OAuth.Fitbit/AspNet.Security.OAuth.Fitbit.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
+    <Compile Include="..\..\shared\AspNet.Security.OAuth.Extensions\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Foursquare/AspNet.Security.OAuth.Foursquare.csproj
+++ b/src/AspNet.Security.OAuth.Foursquare/AspNet.Security.OAuth.Foursquare.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
+    <Compile Include="..\..\shared\AspNet.Security.OAuth.Extensions\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.GitHub/AspNet.Security.OAuth.GitHub.csproj
+++ b/src/AspNet.Security.OAuth.GitHub/AspNet.Security.OAuth.GitHub.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
+    <Compile Include="..\..\shared\AspNet.Security.OAuth.Extensions\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Gitter/AspNet.Security.OAuth.Gitter.csproj
+++ b/src/AspNet.Security.OAuth.Gitter/AspNet.Security.OAuth.Gitter.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
+    <Compile Include="..\..\shared\AspNet.Security.OAuth.Extensions\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.HealthGraph/AspNet.Security.OAuth.HealthGraph.csproj
+++ b/src/AspNet.Security.OAuth.HealthGraph/AspNet.Security.OAuth.HealthGraph.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
+    <Compile Include="..\..\shared\AspNet.Security.OAuth.Extensions\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Imgur/AspNet.Security.OAuth.Imgur.csproj
+++ b/src/AspNet.Security.OAuth.Imgur/AspNet.Security.OAuth.Imgur.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
+    <Compile Include="..\..\shared\AspNet.Security.OAuth.Extensions\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Instagram/AspNet.Security.OAuth.Instagram.csproj
+++ b/src/AspNet.Security.OAuth.Instagram/AspNet.Security.OAuth.Instagram.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
+    <Compile Include="..\..\shared\AspNet.Security.OAuth.Extensions\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.LinkedIn/AspNet.Security.OAuth.LinkedIn.csproj
+++ b/src/AspNet.Security.OAuth.LinkedIn/AspNet.Security.OAuth.LinkedIn.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
+    <Compile Include="..\..\shared\AspNet.Security.OAuth.Extensions\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.MailChimp/AspNet.Security.OAuth.MailChimp.csproj
+++ b/src/AspNet.Security.OAuth.MailChimp/AspNet.Security.OAuth.MailChimp.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
+    <Compile Include="..\..\shared\AspNet.Security.OAuth.Extensions\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Myob/AspNet.Security.OAuth.Myob.csproj
+++ b/src/AspNet.Security.OAuth.Myob/AspNet.Security.OAuth.Myob.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
+    <Compile Include="..\..\shared\AspNet.Security.OAuth.Extensions\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Onshape/AspNet.Security.OAuth.Onshape.csproj
+++ b/src/AspNet.Security.OAuth.Onshape/AspNet.Security.OAuth.Onshape.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
+    <Compile Include="..\..\shared\AspNet.Security.OAuth.Extensions\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Paypal/AspNet.Security.OAuth.Paypal.csproj
+++ b/src/AspNet.Security.OAuth.Paypal/AspNet.Security.OAuth.Paypal.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
+    <Compile Include="..\..\shared\AspNet.Security.OAuth.Extensions\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Reddit/AspNet.Security.OAuth.Reddit.csproj
+++ b/src/AspNet.Security.OAuth.Reddit/AspNet.Security.OAuth.Reddit.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
+    <Compile Include="..\..\shared\AspNet.Security.OAuth.Extensions\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Salesforce/AspNet.Security.OAuth.Salesforce.csproj
+++ b/src/AspNet.Security.OAuth.Salesforce/AspNet.Security.OAuth.Salesforce.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
+    <Compile Include="..\..\shared\AspNet.Security.OAuth.Extensions\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Slack/AspNet.Security.OAuth.Slack.csproj
+++ b/src/AspNet.Security.OAuth.Slack/AspNet.Security.OAuth.Slack.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
+    <Compile Include="..\..\shared\AspNet.Security.OAuth.Extensions\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.SoundCloud/AspNet.Security.OAuth.SoundCloud.csproj
+++ b/src/AspNet.Security.OAuth.SoundCloud/AspNet.Security.OAuth.SoundCloud.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
+    <Compile Include="..\..\shared\AspNet.Security.OAuth.Extensions\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Spotify/AspNet.Security.OAuth.Spotify.csproj
+++ b/src/AspNet.Security.OAuth.Spotify/AspNet.Security.OAuth.Spotify.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
+    <Compile Include="..\..\shared\AspNet.Security.OAuth.Extensions\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.StackExchange/AspNet.Security.OAuth.StackExchange.csproj
+++ b/src/AspNet.Security.OAuth.StackExchange/AspNet.Security.OAuth.StackExchange.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
+    <Compile Include="..\..\shared\AspNet.Security.OAuth.Extensions\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Strava/AspNet.Security.OAuth.Strava.csproj
+++ b/src/AspNet.Security.OAuth.Strava/AspNet.Security.OAuth.Strava.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
+    <Compile Include="..\..\shared\AspNet.Security.OAuth.Extensions\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Twitch/AspNet.Security.OAuth.Twitch.csproj
+++ b/src/AspNet.Security.OAuth.Twitch/AspNet.Security.OAuth.Twitch.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
+    <Compile Include="..\..\shared\AspNet.Security.OAuth.Extensions\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Untappd/AspNet.Security.OAuth.Untappd.csproj
+++ b/src/AspNet.Security.OAuth.Untappd/AspNet.Security.OAuth.Untappd.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
+    <Compile Include="..\..\shared\AspNet.Security.OAuth.Extensions\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Vimeo/AspNet.Security.OAuth.Vimeo.csproj
+++ b/src/AspNet.Security.OAuth.Vimeo/AspNet.Security.OAuth.Vimeo.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
+    <Compile Include="..\..\shared\AspNet.Security.OAuth.Extensions\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.VisualStudio/AspNet.Security.OAuth.VisualStudio.csproj
+++ b/src/AspNet.Security.OAuth.VisualStudio/AspNet.Security.OAuth.VisualStudio.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
+    <Compile Include="..\..\shared\AspNet.Security.OAuth.Extensions\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Vkontakte/AspNet.Security.OAuth.Vkontakte.csproj
+++ b/src/AspNet.Security.OAuth.Vkontakte/AspNet.Security.OAuth.Vkontakte.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
+    <Compile Include="..\..\shared\AspNet.Security.OAuth.Extensions\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Weibo/AspNet.Security.OAuth.Weibo.csproj
+++ b/src/AspNet.Security.OAuth.Weibo/AspNet.Security.OAuth.Weibo.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
+    <Compile Include="..\..\shared\AspNet.Security.OAuth.Extensions\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Weixin/AspNet.Security.OAuth.Weixin.csproj
+++ b/src/AspNet.Security.OAuth.Weixin/AspNet.Security.OAuth.Weixin.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
+    <Compile Include="..\..\shared\AspNet.Security.OAuth.Extensions\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.WordPress/AspNet.Security.OAuth.WordPress.csproj
+++ b/src/AspNet.Security.OAuth.WordPress/AspNet.Security.OAuth.WordPress.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
+    <Compile Include="..\..\shared\AspNet.Security.OAuth.Extensions\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Yahoo/AspNet.Security.OAuth.Yahoo.csproj
+++ b/src/AspNet.Security.OAuth.Yahoo/AspNet.Security.OAuth.Yahoo.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
+    <Compile Include="..\..\shared\AspNet.Security.OAuth.Extensions\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Yammer/AspNet.Security.OAuth.Yammer.csproj
+++ b/src/AspNet.Security.OAuth.Yammer/AspNet.Security.OAuth.Yammer.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
+    <Compile Include="..\..\shared\AspNet.Security.OAuth.Extensions\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNet.Security.OAuth.Yandex/AspNet.Security.OAuth.Yandex.csproj
+++ b/src/AspNet.Security.OAuth.Yandex/AspNet.Security.OAuth.Yandex.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AspNet.Security.OAuth.Extensions\AspNet.Security.OAuth.Extensions.csproj" PrivateAssets="All" />
+    <Compile Include="..\..\shared\AspNet.Security.OAuth.Extensions\*.cs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/issues/159.