### PR TITLE
Update Slack provider

### DIFF
--- a/src/AspNet.Security.OAuth.Slack/SlackAuthenticationDefaults.cs
+++ b/src/AspNet.Security.OAuth.Slack/SlackAuthenticationDefaults.cs
@@ -45,8 +45,8 @@ namespace AspNet.Security.OAuth.Slack
 
         /// <summary>
         /// Default value for <see cref="OAuthOptions.UserInformationEndpoint"/>.
-        /// For more info about this endpoint, see https://api.slack.com/methods/auth.test.
+        /// For more info about this endpoint, see https://api.slack.com/methods/users.identity.
         /// </summary>
-        public const string UserInformationEndpoint = "https://slack.com/api/auth.test";
+        public const string UserInformationEndpoint = "https://slack.com/api/users.identity";
     }
 }

--- a/src/AspNet.Security.OAuth.Slack/SlackAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Slack/SlackAuthenticationHandler.cs
@@ -48,16 +48,13 @@ namespace AspNet.Security.OAuth.Slack
 
             var payload = JObject.Parse(await response.Content.ReadAsStringAsync());
 
-            identity.AddOptionalClaim(ClaimTypes.NameIdentifier, SlackAuthenticationHelper.GetUserIdentifier(payload), Options.ClaimsIssuer)
+            identity.AddOptionalClaim(ClaimTypes.NameIdentifier, SlackAuthenticationHelper.GetUniqueIdentifier(payload), Options.ClaimsIssuer)
                     .AddOptionalClaim(ClaimTypes.Name, SlackAuthenticationHelper.GetUserName(payload), Options.ClaimsIssuer)
+                    .AddOptionalClaim(ClaimTypes.Email, SlackAuthenticationHelper.GetUserEmail(payload), Options.ClaimsIssuer)
+                    .AddOptionalClaim("urn:slack:user_id", SlackAuthenticationHelper.GetUserIdentifier(payload), Options.ClaimsIssuer)
                     .AddOptionalClaim("urn:slack:team_id", SlackAuthenticationHelper.GetTeamIdentifier(payload), Options.ClaimsIssuer)
                     .AddOptionalClaim("urn:slack:team_name", SlackAuthenticationHelper.GetTeamName(payload), Options.ClaimsIssuer)
-                    .AddOptionalClaim("urn:slack:team_url", SlackAuthenticationHelper.GetTeamLink(payload), Options.ClaimsIssuer)
-                    .AddOptionalClaim("urn:slack:bot:user_id", SlackAuthenticationHelper.GetBotUserId(payload), Options.ClaimsIssuer)
-                    .AddOptionalClaim("urn:slack:bot:access_token", SlackAuthenticationHelper.GetBotAccessToken(payload), Options.ClaimsIssuer)
-                    .AddOptionalClaim("urn:slack:webhook:channel", SlackAuthenticationHelper.GetWebhookChannel(payload), Options.ClaimsIssuer)
-                    .AddOptionalClaim("urn:slack:webhook:url", SlackAuthenticationHelper.GetWebhookURL(payload), Options.ClaimsIssuer)
-                    .AddOptionalClaim("urn:slack:webhook:configuration_url", SlackAuthenticationHelper.GetWebhookConfigurationURL(payload), Options.ClaimsIssuer);
+                    ;
 
             var principal = new ClaimsPrincipal(identity);
             var ticket = new AuthenticationTicket(principal, properties, Options.AuthenticationScheme);

--- a/src/AspNet.Security.OAuth.Slack/SlackAuthenticationHelper.cs
+++ b/src/AspNet.Security.OAuth.Slack/SlackAuthenticationHelper.cs
@@ -17,6 +17,40 @@ namespace AspNet.Security.OAuth.Slack
     public static class SlackAuthenticationHelper
     {
         /// <summary>
+        /// Returns a unique identifer for the authenticated user.
+        /// </summary>
+        /// <remarks>
+        /// According to the Slack API documentation at https://api.slack.com/methods/users.identity, user IDs are
+        /// not guaranteed to be globally unique across all Slack users.  The combination of user ID and team ID, 
+        /// on the other hand, is guaranteed to be globally unique.
+        /// </remarks>
+        public static string GetUniqueIdentifier([NotNull] JObject user)
+        {
+            if (user == null)
+            {
+                throw new ArgumentNullException(nameof(user));
+            }
+
+            string userId = user.Value<JObject>("user")?.Value<string>("id");
+            string teamId = user.Value<JObject>("team")?.Value<string>("id");
+
+            return $"{teamId}|{userId}";
+        }
+
+        /// <summary>
+        /// Gets the email address corresponding to the authenticated user.
+        /// </summary>
+        public static string GetUserEmail([NotNull] JObject user)
+        {
+            if (user == null)
+            {
+                throw new ArgumentNullException(nameof(user));
+            }
+
+            return user.Value<JObject>("user")?.Value<string>("email");
+        }
+
+        /// <summary>
         /// Gets the identifier corresponding to the authenticated user.
         /// </summary>
         public static string GetUserIdentifier([NotNull] JObject user)
@@ -26,7 +60,7 @@ namespace AspNet.Security.OAuth.Slack
                 throw new ArgumentNullException(nameof(user));
             }
 
-            return user.Value<string>("user_id");
+            return user.Value<JObject>("user")?.Value<string>("id");
         }
 
         /// <summary>
@@ -39,7 +73,7 @@ namespace AspNet.Security.OAuth.Slack
                 throw new ArgumentNullException(nameof(user));
             }
 
-            return user.Value<string>("user");
+            return user.Value<JObject>("user")?.Value<string>("name");
         }
 
         /// <summary>
@@ -52,7 +86,7 @@ namespace AspNet.Security.OAuth.Slack
                 throw new ArgumentNullException(nameof(user));
             }
 
-            return user.Value<string>("team_id");
+            return user.Value<JObject>("team")?.Value<string>("id");
         }
 
         /// <summary>
@@ -65,85 +99,7 @@ namespace AspNet.Security.OAuth.Slack
                 throw new ArgumentNullException(nameof(user));
             }
 
-            return user.Value<string>("team");
-        }
-
-        /// <summary>
-        /// Gets the URL corresponding to the authenticated user.
-        /// </summary>
-        public static string GetTeamLink([NotNull] JObject user)
-        {
-            if (user == null)
-            {
-                throw new ArgumentNullException(nameof(user));
-            }
-
-            return user.Value<string>("url");
-        }
-
-        /// <summary>
-        /// Gets the identifier associated with the bot.
-        /// </summary>
-        public static string GetBotUserId([NotNull] JObject user)
-        {
-            if (user == null)
-            {
-                throw new ArgumentNullException(nameof(user));
-            }
-
-            return user["bot"]?.Value<string>("bot_user_id");
-        }
-
-        /// <summary>
-        /// Gets the access token associated with the bot.
-        /// </summary>
-        public static string GetBotAccessToken([NotNull] JObject user)
-        {
-            if (user == null)
-            {
-                throw new ArgumentNullException(nameof(user));
-            }
-
-            return user["bot"]?.Value<string>("bot_access_token");
-        }
-
-        /// <summary>
-        /// Gets the channel name of the selected webhook.
-        /// </summary>
-        public static string GetWebhookChannel([NotNull] JObject user)
-        {
-            if (user == null)
-            {
-                throw new ArgumentNullException(nameof(user));
-            }
-
-            return user["incoming_webhook"]?.Value<string>("channel");
-        }
-
-        /// <summary>
-        /// Gets the URL of the selected webhook.
-        /// </summary>
-        public static string GetWebhookURL([NotNull] JObject user)
-        {
-            if (user == null)
-            {
-                throw new ArgumentNullException(nameof(user));
-            }
-
-            return user["incoming_webhook"]?.Value<string>("url");
-        }
-
-        /// <summary>
-        /// Gets the channel configuration URL of the selected webhook.
-        /// </summary>
-        public static string GetWebhookConfigurationURL([NotNull] JObject user)
-        {
-            if (user == null)
-            {
-                throw new ArgumentNullException(nameof(user));
-            }
-
-            return user["incoming_webhook"]?.Value<string>("configuration_url");
+            return user.Value<JObject>("team")?.Value<string>("name");
         }
     }
 }

--- a/src/AspNet.Security.OAuth.Slack/SlackAuthenticationHelper.cs
+++ b/src/AspNet.Security.OAuth.Slack/SlackAuthenticationHelper.cs
@@ -31,10 +31,7 @@ namespace AspNet.Security.OAuth.Slack
                 throw new ArgumentNullException(nameof(user));
             }
 
-            string userId = user.Value<JObject>("user")?.Value<string>("id");
-            string teamId = user.Value<JObject>("team")?.Value<string>("id");
-
-            return $"{teamId}|{userId}";
+            return $"{GetTeamIdentifier(user)}|{GetUserIdentifier(user)}";
         }
 
         /// <summary>

--- a/src/AspNet.Security.OAuth.Slack/SlackAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Slack/SlackAuthenticationOptions.cs
@@ -25,6 +25,8 @@ namespace AspNet.Security.OAuth.Slack
             AuthorizationEndpoint = SlackAuthenticationDefaults.AuthorizationEndpoint;
             TokenEndpoint = SlackAuthenticationDefaults.TokenEndpoint;
             UserInformationEndpoint = SlackAuthenticationDefaults.UserInformationEndpoint;
+
+            Scope.Add("identity.basic");
         }
     }
 }


### PR DESCRIPTION
Updates the Slack provider as follows:
* Retrieves user profile information from the `users.identity` endpoint
* Updates `NameIdentifier` claim to be a combination of Team ID and User ID
* Sets default scope of `identity.basic`
* Removes a bunch of claims for information which was not present in `users.identity` endpoint

Closes  #184