### PR TITLE
Added required version parameter to VK Api call

### DIFF
--- a/src/AspNet.Security.OAuth.Vkontakte/AspNet.Security.OAuth.Vkontakte.csproj
+++ b/src/AspNet.Security.OAuth.Vkontakte/AspNet.Security.OAuth.Vkontakte.csproj
@@ -16,5 +16,5 @@
     <PackageReference Include="JetBrains.Annotations" Version="$(JetBrainsVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OAuth" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
-  
+
 </Project>

--- a/src/AspNet.Security.OAuth.Vkontakte/AspNet.Security.OAuth.Vkontakte.csproj
+++ b/src/AspNet.Security.OAuth.Vkontakte/AspNet.Security.OAuth.Vkontakte.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="..\..\build\packages.props" />
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -13,8 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="$(JetBrainsVersion)" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OAuth" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="JetBrains.Annotations" Version="11.1.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OAuth" Version="2.0.3" />
   </ItemGroup>
 
 </Project>

--- a/src/AspNet.Security.OAuth.Vkontakte/AspNet.Security.OAuth.Vkontakte.csproj
+++ b/src/AspNet.Security.OAuth.Vkontakte/AspNet.Security.OAuth.Vkontakte.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="..\..\build\packages.props" />
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -12,8 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="11.1.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OAuth" Version="2.0.3" />
+    <PackageReference Include="JetBrains.Annotations" Version="$(JetBrainsVersion)" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OAuth" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
-
 </Project>

--- a/src/AspNet.Security.OAuth.Vkontakte/AspNet.Security.OAuth.Vkontakte.csproj
+++ b/src/AspNet.Security.OAuth.Vkontakte/AspNet.Security.OAuth.Vkontakte.csproj
@@ -16,4 +16,5 @@
     <PackageReference Include="JetBrains.Annotations" Version="$(JetBrainsVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OAuth" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
+  
 </Project>

--- a/src/AspNet.Security.OAuth.Vkontakte/VkontakteAuthenticationDefaults.cs
+++ b/src/AspNet.Security.OAuth.Vkontakte/VkontakteAuthenticationDefaults.cs
@@ -48,5 +48,10 @@ namespace AspNet.Security.OAuth.Vkontakte
         /// Default value for <see cref="OAuthOptions.UserInformationEndpoint"/>.
         /// </summary>
         public const string UserInformationEndpoint = "https://api.vk.com/method/users.get.json";
+
+        /// <summary>
+        /// Default VK API version
+        /// </summary>
+        public const string ApiVersion = "5.73";
     }
 }

--- a/src/AspNet.Security.OAuth.Vkontakte/VkontakteAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Vkontakte/VkontakteAuthenticationHandler.cs
@@ -4,6 +4,7 @@
  * for more information concerning the license and the contributors participating to this project.
  */
 
+using System;
 using System.Net.Http;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
@@ -27,6 +28,11 @@ namespace AspNet.Security.OAuth.Vkontakte
             [NotNull] ISystemClock clock)
             : base(options, logger, encoder, clock)
         {
+            if (string.IsNullOrEmpty(Options.ApiVersion))
+            {
+                throw new ArgumentException("ApiVersion in VkontakteAuthenticationOptions can't be null or empty.");
+                
+            }
         }
 
         protected override async Task<AuthenticationTicket> CreateTicketAsync([NotNull] ClaimsIdentity identity,
@@ -38,6 +44,7 @@ namespace AspNet.Security.OAuth.Vkontakte
             {
                 address = QueryHelpers.AddQueryString(address, "fields", string.Join(",", Options.Fields));
             }
+            address = QueryHelpers.AddQueryString(address, "v", Options.ApiVersion);
 
             var response = await Backchannel.GetAsync(address, Context.RequestAborted);
             if (!response.IsSuccessStatusCode)
@@ -61,9 +68,9 @@ namespace AspNet.Security.OAuth.Vkontakte
 
             var principal = new ClaimsPrincipal(identity);
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload);
-            context.RunClaimActions(payload);
+            context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal, context.Properties, Scheme.Name);
         }
     }

--- a/src/AspNet.Security.OAuth.Vkontakte/VkontakteAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Vkontakte/VkontakteAuthenticationOptions.cs
@@ -29,7 +29,7 @@ namespace AspNet.Security.OAuth.Vkontakte
             
             ApiVersion = VkontakteAuthenticationDefaults.ApiVersion;
 
-            ClaimActions.MapJsonKey(ClaimTypes.NameIdentifier, "uid");
+            ClaimActions.MapJsonKey(ClaimTypes.NameIdentifier, "id");
             ClaimActions.MapJsonKey(ClaimTypes.GivenName, "first_name");
             ClaimActions.MapJsonKey(ClaimTypes.Surname, "last_name");
             ClaimActions.MapJsonKey(ClaimTypes.Hash, "hash");
@@ -43,7 +43,7 @@ namespace AspNet.Security.OAuth.Vkontakte
         /// </summary>
         public ISet<string> Fields { get; } = new HashSet<string>
         {
-            "uid",
+            "id",
             "first_name",
             "last_name",
             "photo_rec",

--- a/src/AspNet.Security.OAuth.Vkontakte/VkontakteAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Vkontakte/VkontakteAuthenticationOptions.cs
@@ -26,6 +26,8 @@ namespace AspNet.Security.OAuth.Vkontakte
             AuthorizationEndpoint = VkontakteAuthenticationDefaults.AuthorizationEndpoint;
             TokenEndpoint = VkontakteAuthenticationDefaults.TokenEndpoint;
             UserInformationEndpoint = VkontakteAuthenticationDefaults.UserInformationEndpoint;
+            
+            ApiVersion = VkontakteAuthenticationDefaults.ApiVersion;
 
             ClaimActions.MapJsonKey(ClaimTypes.NameIdentifier, "uid");
             ClaimActions.MapJsonKey(ClaimTypes.GivenName, "first_name");
@@ -48,5 +50,12 @@ namespace AspNet.Security.OAuth.Vkontakte
             "photo",
             "hash"
         };
+
+        /// <summary>
+        /// Gets or sets required VK API version
+        /// See https://vk.com/dev/versions for more information.
+        /// </summary>
+        /// <returns></returns>
+        public string ApiVersion { get; set; }
     }
 }


### PR DESCRIPTION
VK removed default api version from their calls and "v" parameter is required for all API calls.

See more: https://vk.com/dev/version_update