### PR TITLE
Remove explicit reference to ASPNET Core 1.0 in headline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 AspNet.Security.OAuth.Providers
 ==================================
 
-**AspNet.Security.OAuth.Providers** is a **collection of security middleware** that you can use in your **ASP.NET Core 1.0** application to support social authentication providers like **[GitHub](https://github.com/)**, **[Foursquare](https://foursquare.com/)** or **[Dropbox](https://www.dropbox.com/)**. It is directly inspired by **[Jerrie Pelser](https://github.com/jerriep)**'s initiative, **[Owin.Security.Providers](https://github.com/RockstarLabs/OwinOAuthProviders)**.
+**AspNet.Security.OAuth.Providers** is a **collection of security middleware** that you can use in your **ASP.NET Core** application to support social authentication providers like **[GitHub](https://github.com/)**, **[Foursquare](https://foursquare.com/)** or **[Dropbox](https://www.dropbox.com/)**. It is directly inspired by **[Jerrie Pelser](https://github.com/jerriep)**'s initiative, **[Owin.Security.Providers](https://github.com/RockstarLabs/OwinOAuthProviders)**.
 
 **The latest official release can be found on [NuGet](https://www.nuget.org/profiles/aspnet-contrib) and the nightly builds on [MyGet](https://www.myget.org/gallery/aspnet-contrib)**.
 


### PR DESCRIPTION
The deps are for 2.0 so let's just remove this so that future visitors aren't as confused as I was :)