### PR TITLE
Add mapper for email to claims

### DIFF
--- a/src/AspNet.Security.OAuth.Vkontakte/VkontakteAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Vkontakte/VkontakteAuthenticationOptions.cs
@@ -31,6 +31,7 @@ namespace AspNet.Security.OAuth.Vkontakte
             ClaimActions.MapJsonKey(ClaimTypes.NameIdentifier, "id");
             ClaimActions.MapJsonKey(ClaimTypes.GivenName, "first_name");
             ClaimActions.MapJsonKey(ClaimTypes.Surname, "last_name");
+            ClaimActions.MapJsonKey(ClaimTypes.Email, "email");
             ClaimActions.MapJsonKey(ClaimTypes.Hash, "hash");
             ClaimActions.MapJsonKey(Claims.PhotoUrl, "photo");
             ClaimActions.MapJsonKey(Claims.ThumbnailUrl, "photo_rec");


### PR DESCRIPTION
https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/blob/af1e3373cf00e82b186ea2a4bba0696d476b0dff/src/AspNet.Security.OAuth.Vkontakte/VkontakteAuthenticationHandler.cs#L69

At this line email field from payload has not been added to identity claims