### PR TITLE
Add force_verify option to Twitch Provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ We would love it if you could help contributing to this repository.
 * [Tathagata Chakraborty](https://github.com/tatx)
 * [Tommy Parnell](https://github.com/tparnell8)
 * [Yannic Smeets](https://github.com/yannicsmeets)
+* [zAfLu](https://github.com/zAfLu)
 * [zhengchun](https://github.com/zhengchun)
 
 ## Support

--- a/src/AspNet.Security.OAuth.Twitch/TwitchAuthenticationDefaults.cs
+++ b/src/AspNet.Security.OAuth.Twitch/TwitchAuthenticationDefaults.cs
@@ -48,5 +48,12 @@ namespace AspNet.Security.OAuth.Twitch
         /// Default value for <see cref="OAuthOptions.UserInformationEndpoint"/>.
         /// </summary>
         public const string UserInformationEndpoint = "https://api.twitch.tv/helix/users/";
+
+        /// <summary>
+        /// Default value for <see cref="TwitchAuthenticationOptions.ForceVerify"/>
+        /// true: Every authentication request need to be accepted by user interaction
+        /// false: Automated pass through if you already logged in
+        /// </summary>
+        public const bool ForceVerify = false;
     }
 }

--- a/src/AspNet.Security.OAuth.Twitch/TwitchAuthenticationDefaults.cs
+++ b/src/AspNet.Security.OAuth.Twitch/TwitchAuthenticationDefaults.cs
@@ -48,12 +48,5 @@ namespace AspNet.Security.OAuth.Twitch
         /// Default value for <see cref="OAuthOptions.UserInformationEndpoint"/>.
         /// </summary>
         public const string UserInformationEndpoint = "https://api.twitch.tv/helix/users/";
-
-        /// <summary>
-        /// Default value for <see cref="TwitchAuthenticationOptions.ForceVerify"/>
-        /// true: Every authentication request need to be accepted by user interaction
-        /// false: Automated pass through if you already logged in
-        /// </summary>
-        public const bool ForceVerify = false;
     }
 }

--- a/src/AspNet.Security.OAuth.Twitch/TwitchAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Twitch/TwitchAuthenticationHandler.cs
@@ -32,21 +32,15 @@ namespace AspNet.Security.OAuth.Twitch
         }
 
         protected override string BuildChallengeUrl(AuthenticationProperties properties, string redirectUri)
-        {
-            var scope = FormatScope();
-
-            var state = Options.StateDataFormat.Protect(properties);
-            var parameters = new Dictionary<string, string>
+            => QueryHelpers.AddQueryString(Options.AuthorizationEndpoint, new Dictionary<string, string>
             {
-                { "client_id", Options.ClientId },
-                { "scope", scope },
-                { "response_type", "code" },
-                { "redirect_uri", redirectUri },
-                { "state", state },
-                { "force_verify", Options.ForceVerify.ToString().ToLower()}
-            };
-            return QueryHelpers.AddQueryString(Options.AuthorizationEndpoint, parameters);
-        }
+                ["client_id"] = Options.ClientId,
+                ["scope"] = FormatScope(),
+                ["response_type"] = "code",
+                ["redirect_uri"] = redirectUri,
+                ["state"] = Options.StateDataFormat.Protect(properties),
+                ["force_verify"] = Options.ForceVerify ? "true" : "false"
+            });
 
         protected override async Task<AuthenticationTicket> CreateTicketAsync([NotNull] ClaimsIdentity identity,
             [NotNull] AuthenticationProperties properties, [NotNull] OAuthTokenResponse tokens)

--- a/src/AspNet.Security.OAuth.Twitch/TwitchAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Twitch/TwitchAuthenticationHandler.cs
@@ -4,6 +4,7 @@
  * for more information concerning the license and the contributors participating to this project.
  */
 
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Security.Claims;
@@ -12,6 +13,7 @@ using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
+using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json.Linq;
@@ -27,6 +29,23 @@ namespace AspNet.Security.OAuth.Twitch
             [NotNull] ISystemClock clock)
             : base(options, logger, encoder, clock)
         {
+        }
+
+        protected override string BuildChallengeUrl(AuthenticationProperties properties, string redirectUri)
+        {
+            var scope = FormatScope();
+
+            var state = Options.StateDataFormat.Protect(properties);
+            var parameters = new Dictionary<string, string>
+            {
+                { "client_id", Options.ClientId },
+                { "scope", scope },
+                { "response_type", "code" },
+                { "redirect_uri", redirectUri },
+                { "state", state },
+                { "force_verify", Options.ForceVerify.ToString().ToLower()}
+            };
+            return QueryHelpers.AddQueryString(Options.AuthorizationEndpoint, parameters);
         }
 
         protected override async Task<AuthenticationTicket> CreateTicketAsync([NotNull] ClaimsIdentity identity,

--- a/src/AspNet.Security.OAuth.Twitch/TwitchAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Twitch/TwitchAuthenticationOptions.cs
@@ -25,7 +25,6 @@ namespace AspNet.Security.OAuth.Twitch
             AuthorizationEndpoint = TwitchAuthenticationDefaults.AuthorizationEndPoint;
             TokenEndpoint = TwitchAuthenticationDefaults.TokenEndpoint;
             UserInformationEndpoint = TwitchAuthenticationDefaults.UserInformationEndpoint;
-            ForceVerify = TwitchAuthenticationDefaults.ForceVerify;
 
             Scope.Add("user:read:email");
 

--- a/src/AspNet.Security.OAuth.Twitch/TwitchAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Twitch/TwitchAuthenticationOptions.cs
@@ -17,6 +17,8 @@ namespace AspNet.Security.OAuth.Twitch
     /// </summary>
     public class TwitchAuthenticationOptions : OAuthOptions
     {
+        public bool ForceVerify { get; set; }
+
         public TwitchAuthenticationOptions()
         {
             ClaimsIssuer = TwitchAuthenticationDefaults.Issuer;
@@ -25,6 +27,7 @@ namespace AspNet.Security.OAuth.Twitch
             AuthorizationEndpoint = TwitchAuthenticationDefaults.AuthorizationEndPoint;
             TokenEndpoint = TwitchAuthenticationDefaults.TokenEndpoint;
             UserInformationEndpoint = TwitchAuthenticationDefaults.UserInformationEndpoint;
+            ForceVerify = TwitchAuthenticationDefaults.ForceVerify;
 
             Scope.Add("user:read:email");
 

--- a/src/AspNet.Security.OAuth.Twitch/TwitchAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Twitch/TwitchAuthenticationOptions.cs
@@ -17,8 +17,6 @@ namespace AspNet.Security.OAuth.Twitch
     /// </summary>
     public class TwitchAuthenticationOptions : OAuthOptions
     {
-        public bool ForceVerify { get; set; }
-
         public TwitchAuthenticationOptions()
         {
             ClaimsIssuer = TwitchAuthenticationDefaults.Issuer;
@@ -76,5 +74,12 @@ namespace AspNet.Security.OAuth.Twitch
                 return user["data"]?[0]?.Value<string>("offline_image_url");
             });
         }
+
+        /// <summary>
+        /// Gets or sets a boolean indicating whether the "force_verify=true" flag should be sent to Twitch.
+        /// When set to <c>true</c>, Twitch displays the consent screen for every authorization request.
+        /// When left to <c>false</c>, the consent screen is skipped if the user is already logged in.
+        /// </summary>
+        public bool ForceVerify { get; set; }
     }
 }


### PR DESCRIPTION
Adding an option for the twitch force_verify parameter. 

You can enable or disable this option. I choose disabled as default value, so it works like the previous version. 
If you enable it, you always get the following window on every authorization request.

![image](https://user-images.githubusercontent.com/6201114/43360902-c6857726-92c1-11e8-94c0-50f71c9ff557.png)


Test and build with Microsoft.AspNetCore.Authentication.OAuth 2.0.0

