### PR TITLE
Fix Stack Exchange authentication handler

### DIFF
--- a/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationOptions.cs
@@ -30,10 +30,10 @@ namespace AspNet.Security.OAuth.StackExchange
             UserInformationEndpoint = StackExchangeAuthenticationDefaults.UserInformationEndpoint;
             BackchannelHttpHandler = new HttpClientHandler { AutomaticDecompression = DecompressionMethods.GZip };
 
-            ClaimActions.MapCustomJson(ClaimTypes.NameIdentifier, user => user["items"]?[0]?.Value<string>("account_id"));
-            ClaimActions.MapCustomJson(ClaimTypes.Name, user => user["items"]?[0]?.Value<string>("display_name"));
-            ClaimActions.MapCustomJson(ClaimTypes.Webpage, user => user["items"]?[0]?.Value<string>("website_url"));
-            ClaimActions.MapCustomJson(Claims.Link, user => user["items"]?[0]?.Value<string>("link"));
+            ClaimActions.MapCustomJson(ClaimTypes.NameIdentifier, user => user.Value<string>("account_id"));
+            ClaimActions.MapCustomJson(ClaimTypes.Name, user => user.Value<string>("display_name"));
+            ClaimActions.MapCustomJson(ClaimTypes.Webpage, user => user.Value<string>("website_url"));
+            ClaimActions.MapCustomJson(Claims.Link, user => user.Value<string>("link"));
         }
 
         /// <summary>


### PR DESCRIPTION
The payload from the SE API contains an `items` array which contains a single user object that contains all the claims. As such, the authentication handler should extract that user object already and run the claims actions on that single user object.

Previously, the array was attempted to be parsed as an object (which failed) and the built-in claims mapping did expect the result to contain the raw payload (with the `items` array).

Also, although specifying a `key` is recommended for Stack Exchange to receive higher request quotas, it is not a mandatory argument to pass in the API.