### PR TITLE
ASP.NET Core 3.0 preparation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ project.lock.json
 
 # Build results
 
+artifacts/
 [Dd]ebug/
 [Rr]elease/
 x64/

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
   global:
     - DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     - DOTNET_CLI_TELEMETRY_OPTOUT: 1
+    - NUGET_XMLDOC_MODE: skip
 mono: none
 os:
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ addons:
     - libicu-dev
     - libssl-dev
     - libunwind8
-    - zlib1g
 env:
   global:
     - DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
@@ -18,8 +17,6 @@ mono: none
 os:
   - linux
   - osx
-before_install:
-  - if test "$TRAVIS_OS_NAME" == "osx"; then brew update; brew install openssl; ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/; ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/; fi
 osx_image: xcode8.3
 script:
   - ./build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ mono: none
 os:
   - linux
   - osx
-osx_image: xcode8.2
 before_install:
   - if test "$TRAVIS_OS_NAME" == "osx"; then brew update; brew install openssl; ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/; ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/; fi
+osx_image: xcode8.3
 script:
   - ./build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: csharp
 sudo: false
-dist: trusty
+dist: xenial
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: csharp
+mono: none
 sudo: false
 dist: xenial
 addons:

--- a/AspNet.Security.OAuth.Providers.sln
+++ b/AspNet.Security.OAuth.Providers.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26430.16
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28803.156
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{8DCAEA78-86AE-4183-93C0-41C7F8850AAA}"
 	ProjectSection(SolutionItems) = preProject

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -2,9 +2,9 @@
 
   <PropertyGroup Label="Package Versions">
     <AspNetCoreVersion>2.0.0</AspNetCoreVersion>
+    <GoogleProviderVersion>2.2.2</GoogleProviderVersion>
     <JetBrainsVersion>10.3.0</JetBrainsVersion>
-    <NetStandardImplicitPackageVersion>2.0.0</NetStandardImplicitPackageVersion>
-    <RuntimeFrameworkVersion>2.0.0</RuntimeFrameworkVersion>
+    <TwitterProviderVersion>2.2.0</TwitterProviderVersion>
   </PropertyGroup>
 
 </Project>

--- a/build/packages.props
+++ b/build/packages.props
@@ -15,7 +15,7 @@
     <Product>aspnet-contrib</Product>
     <PackageIconUrl>https://avatars3.githubusercontent.com/u/7998081?s=64</PackageIconUrl>
     <PackageProjectUrl>https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers</PackageProjectUrl>
-    <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0.html</PackageLicenseUrl>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers</RepositoryUrl>
   </PropertyGroup>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,8 @@
+{
+    "sdk": {
+        "version": "2.2.106"
+    },
+    "msbuild-sdks": {
+        "Internal.AspNetCore.Sdk": "2.2.1-build-20190508.1"
+    }
+}

--- a/korebuild-lock.txt
+++ b/korebuild-lock.txt
@@ -1,2 +1,2 @@
-version:2.1.0-rtm-15783
-commithash:5fc2b2f607f542a2ffde11c19825e786fc1a3774
+version:2.2.1-build-20190508.1
+commithash:c3299b1979b3cdae35844bcbaa8b9d753c4d2737

--- a/korebuild.json
+++ b/korebuild.json
@@ -1,4 +1,4 @@
 {
-  "$schema": "https://raw.githubusercontent.com/aspnet/BuildTools/release/2.1/tools/korebuild.schema.json",
-  "channel": "release/2.1"
+  "$schema": "https://raw.githubusercontent.com/aspnet/BuildTools/release/2.2/tools/korebuild.schema.json",
+  "channel": "release/2.2"
 }

--- a/samples/Mvc.Client/Mvc.Client.csproj
+++ b/samples/Mvc.Client/Mvc.Client.csproj
@@ -3,7 +3,8 @@
   <Import Project="..\..\build\dependencies.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
+    <AspNetCoreVersion>2.2.4</AspNetCoreVersion>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -54,19 +55,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Twitter" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="$(GoogleProviderVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Twitter" Version="$(TwitterProviderVersion)" />
   </ItemGroup>
 
 </Project>

--- a/samples/Mvc.Client/Mvc.Client.csproj
+++ b/samples/Mvc.Client/Mvc.Client.csproj
@@ -8,50 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\AspNet.Security.OAuth.Amazon\AspNet.Security.OAuth.Amazon.csproj" />
-    <ProjectReference Include="..\..\src\AspNet.Security.OAuth.ArcGIS\AspNet.Security.OAuth.ArcGIS.csproj" />
-    <ProjectReference Include="..\..\src\AspNet.Security.OAuth.Asana\AspNet.Security.OAuth.Asana.csproj" />
-    <ProjectReference Include="..\..\src\AspNet.Security.OAuth.Autodesk\AspNet.Security.OAuth.Autodesk.csproj" />
-    <ProjectReference Include="..\..\src\AspNet.Security.OAuth.Automatic\AspNet.Security.OAuth.Automatic.csproj" />
-    <ProjectReference Include="..\..\src\AspNet.Security.OAuth.BattleNet\AspNet.Security.OAuth.BattleNet.csproj" />
-    <ProjectReference Include="..\..\src\AspNet.Security.OAuth.Beam\AspNet.Security.OAuth.Beam.csproj" />
-    <ProjectReference Include="..\..\src\AspNet.Security.OAuth.Bitbucket\AspNet.Security.OAuth.Bitbucket.csproj" />
-    <ProjectReference Include="..\..\src\AspNet.Security.OAuth.Buffer\AspNet.Security.OAuth.Buffer.csproj" />
-    <ProjectReference Include="..\..\src\AspNet.Security.OAuth.CiscoSpark\AspNet.Security.OAuth.CiscoSpark.csproj" />
-    <ProjectReference Include="..\..\src\AspNet.Security.OAuth.DeviantArt\AspNet.Security.OAuth.DeviantArt.csproj" />
-    <ProjectReference Include="..\..\src\AspNet.Security.OAuth.Discord\AspNet.Security.OAuth.Discord.csproj" />
-    <ProjectReference Include="..\..\src\AspNet.Security.OAuth.Dropbox\AspNet.Security.OAuth.Dropbox.csproj" />
-    <ProjectReference Include="..\..\src\AspNet.Security.OAuth.EVEOnline\AspNet.Security.OAuth.EVEOnline.csproj" />
-    <ProjectReference Include="..\..\src\AspNet.Security.OAuth.Fitbit\AspNet.Security.OAuth.Fitbit.csproj" />
-    <ProjectReference Include="..\..\src\AspNet.Security.OAuth.Foursquare\AspNet.Security.OAuth.Foursquare.csproj" />
-    <ProjectReference Include="..\..\src\AspNet.Security.OAuth.GitHub\AspNet.Security.OAuth.GitHub.csproj" />
-    <ProjectReference Include="..\..\src\AspNet.Security.OAuth.Gitter\AspNet.Security.OAuth.Gitter.csproj" />
-    <ProjectReference Include="..\..\src\AspNet.Security.OAuth.HealthGraph\AspNet.Security.OAuth.HealthGraph.csproj" />
-    <ProjectReference Include="..\..\src\AspNet.Security.OAuth.Imgur\AspNet.Security.OAuth.Imgur.csproj" />
-    <ProjectReference Include="..\..\src\AspNet.Security.OAuth.Instagram\AspNet.Security.OAuth.Instagram.csproj" />
-    <ProjectReference Include="..\..\src\AspNet.Security.OAuth.LinkedIn\AspNet.Security.OAuth.LinkedIn.csproj" />
-    <ProjectReference Include="..\..\src\AspNet.Security.OAuth.MailChimp\AspNet.Security.OAuth.MailChimp.csproj" />
-    <ProjectReference Include="..\..\src\AspNet.Security.OAuth.Myob\AspNet.Security.OAuth.Myob.csproj" />
-    <ProjectReference Include="..\..\src\AspNet.Security.OAuth.Onshape\AspNet.Security.OAuth.Onshape.csproj" />
-    <ProjectReference Include="..\..\src\AspNet.Security.OAuth.Patreon\AspNet.Security.OAuth.Patreon.csproj" />
-    <ProjectReference Include="..\..\src\AspNet.Security.OAuth.Paypal\AspNet.Security.OAuth.Paypal.csproj" />
-    <ProjectReference Include="..\..\src\AspNet.Security.OAuth.Reddit\AspNet.Security.OAuth.Reddit.csproj" />
-    <ProjectReference Include="..\..\src\AspNet.Security.OAuth.Salesforce\AspNet.Security.OAuth.Salesforce.csproj" />
-    <ProjectReference Include="..\..\src\AspNet.Security.OAuth.Slack\AspNet.Security.OAuth.Slack.csproj" />
-    <ProjectReference Include="..\..\src\AspNet.Security.OAuth.SoundCloud\AspNet.Security.OAuth.SoundCloud.csproj" />
-    <ProjectReference Include="..\..\src\AspNet.Security.OAuth.StackExchange\AspNet.Security.OAuth.StackExchange.csproj" />
-    <ProjectReference Include="..\..\src\AspNet.Security.OAuth.Strava\AspNet.Security.OAuth.Strava.csproj" />
-    <ProjectReference Include="..\..\src\AspNet.Security.OAuth.Twitch\AspNet.Security.OAuth.Twitch.csproj" />
-    <ProjectReference Include="..\..\src\AspNet.Security.OAuth.Untappd\AspNet.Security.OAuth.Untappd.csproj" />
-    <ProjectReference Include="..\..\src\AspNet.Security.OAuth.Vimeo\AspNet.Security.OAuth.Vimeo.csproj" />
-    <ProjectReference Include="..\..\src\AspNet.Security.OAuth.VisualStudio\AspNet.Security.OAuth.VisualStudio.csproj" />
-    <ProjectReference Include="..\..\src\AspNet.Security.OAuth.Vkontakte\AspNet.Security.OAuth.Vkontakte.csproj" />
-    <ProjectReference Include="..\..\src\AspNet.Security.OAuth.Weibo\AspNet.Security.OAuth.Weibo.csproj" />
-    <ProjectReference Include="..\..\src\AspNet.Security.OAuth.Weixin\AspNet.Security.OAuth.Weixin.csproj" />
-    <ProjectReference Include="..\..\src\AspNet.Security.OAuth.WordPress\AspNet.Security.OAuth.WordPress.csproj" />
-    <ProjectReference Include="..\..\src\AspNet.Security.OAuth.Yahoo\AspNet.Security.OAuth.Yahoo.csproj" />
-    <ProjectReference Include="..\..\src\AspNet.Security.OAuth.Yammer\AspNet.Security.OAuth.Yammer.csproj" />
-    <ProjectReference Include="..\..\src\AspNet.Security.OAuth.Yandex\AspNet.Security.OAuth.Yandex.csproj" />
+    <ProjectReference Include="..\..\src\AspNet.Security.OAuth.*\*.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Mvc.Client/Program.cs
+++ b/samples/Mvc.Client/Program.cs
@@ -5,12 +5,13 @@ namespace Mvc.Client
 {
     public static class Program
     {
-        public static void Main(string[] args) =>
-            BuildWebHost(args).Run();
+        public static void Main(string[] args)
+        {
+            CreateWebHostBuilder(args).Build().Run();
+        }
 
-        public static IWebHost BuildWebHost(string[] args) =>
+        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
-                .UseStartup<Startup>()
-                .Build();
+                   .UseStartup<Startup>();
     }
 }

--- a/samples/Mvc.Client/Properties/launchSettings.json
+++ b/samples/Mvc.Client/Properties/launchSettings.json
@@ -16,7 +16,9 @@
       }
     },
     "web": {
-      "commandName": "web",
+      "commandName": "Project",
+      "launchBrowser": true,
+      "launchUrl": "http://localhost:5000/",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/samples/Mvc.Client/Startup.cs
+++ b/samples/Mvc.Client/Startup.cs
@@ -6,6 +6,7 @@
 
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Mvc.Client
@@ -50,7 +51,7 @@ namespace Mvc.Client
                 options.ClientSecret = "qbxvkjk5la7mjp6";
             });
 
-            services.AddMvc();
+            services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
         }
 
         public void Configure(IApplicationBuilder app)

--- a/samples/Mvc.Client/web.config
+++ b/samples/Mvc.Client/web.config
@@ -2,7 +2,7 @@
 <configuration>
   <system.webServer>
     <handlers>
-      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified"/>
+      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModuleV2" resourceType="Unspecified"/>
     </handlers>
     <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false"/>
   </system.webServer>

--- a/src/AspNet.Security.OAuth.Amazon/AmazonAuthenticationDefaults.cs
+++ b/src/AspNet.Security.OAuth.Amazon/AmazonAuthenticationDefaults.cs
@@ -6,7 +6,6 @@
 
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
-using Microsoft.AspNetCore.Builder;
 
 namespace AspNet.Security.OAuth.Amazon
 {

--- a/src/AspNet.Security.OAuth.Amazon/AmazonAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Amazon/AmazonAuthenticationHandler.cs
@@ -19,8 +19,18 @@ using Newtonsoft.Json.Linq;
 
 namespace AspNet.Security.OAuth.Amazon
 {
+    /// <summary>
+    /// Defines a handler for authentication using Amazon.
+    /// </summary>
     public class AmazonAuthenticationHandler : OAuthHandler<AmazonAuthenticationOptions>
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AmazonAuthenticationHandler"/> class.
+        /// </summary>
+        /// <param name="options">The authentication options.</param>
+        /// <param name="logger">The logger to use.</param>
+        /// <param name="encoder">The URL encoder to use.</param>
+        /// <param name="clock">The system clock to use.</param>
         public AmazonAuthenticationHandler(
             [NotNull] IOptionsMonitor<AmazonAuthenticationOptions> options,
             [NotNull] ILoggerFactory logger,
@@ -30,6 +40,7 @@ namespace AspNet.Security.OAuth.Amazon
         {
         }
 
+        /// <inheritdoc />
         protected override async Task<AuthenticationTicket> CreateTicketAsync([NotNull] ClaimsIdentity identity,
             [NotNull] AuthenticationProperties properties, [NotNull] OAuthTokenResponse tokens)
         {

--- a/src/AspNet.Security.OAuth.Amazon/AmazonAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Amazon/AmazonAuthenticationOptions.cs
@@ -17,12 +17,11 @@ namespace AspNet.Security.OAuth.Amazon
     public class AmazonAuthenticationOptions : OAuthOptions
     {
         /// <summary>
-        /// Initialize a new instance of the <see cref="AmazonAuthenticationOptions"/> class.
+        /// Initializes a new instance of the <see cref="AmazonAuthenticationOptions"/> class.
         /// </summary>
         public AmazonAuthenticationOptions()
         {
             ClaimsIssuer = AmazonAuthenticationDefaults.Issuer;
-
             CallbackPath = AmazonAuthenticationDefaults.CallbackPath;
 
             AuthorizationEndpoint = AmazonAuthenticationDefaults.AuthorizationEndpoint;

--- a/src/AspNet.Security.OAuth.Salesforce/SalesforceAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Salesforce/SalesforceAuthenticationOptions.cs
@@ -27,11 +27,11 @@ namespace AspNet.Security.OAuth.Salesforce
             Environment = SalesforceAuthenticationDefaults.Environment;
 
             ClaimActions.MapJsonKey(ClaimTypes.NameIdentifier, "user_id");
-            ClaimActions.MapJsonKey(ClaimTypes.Name, "user_name");
+            ClaimActions.MapJsonKey(ClaimTypes.Name, "username");
             ClaimActions.MapJsonKey(Claims.Email, "email");
-            ClaimActions.MapJsonKey(Claims.ThumbnailPhoto, "thumbnail");
             ClaimActions.MapJsonKey(Claims.UtcOffset, "utcOffset");
             ClaimActions.MapCustomJson(Claims.RestUrl, user => user["urls"]?.Value<string>("rest"));
+            ClaimActions.MapCustomJson(Claims.ThumbnailPhoto, user => user["photos"]?.Value<string>("thumbnail"));
         }
 
         public SalesforceAuthenticationEnvironment Environment

--- a/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationHandler.cs
@@ -74,15 +74,17 @@ namespace AspNet.Security.OAuth.StackExchange
 
         protected override async Task<OAuthTokenResponse> ExchangeCodeAsync([NotNull] string code, [NotNull] string redirectUri)
         {
-            var request = new HttpRequestMessage(HttpMethod.Post, Options.TokenEndpoint);
-            request.Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            var request = new HttpRequestMessage(HttpMethod.Post, Options.TokenEndpoint)
             {
-                ["client_id"] = Options.ClientId,
-                ["redirect_uri"] = redirectUri,
-                ["client_secret"] = Options.ClientSecret,
-                ["code"] = code,
-                ["grant_type"] = "authorization_code"
-            });
+                Content = new FormUrlEncodedContent(new Dictionary<string, string>
+                {
+                    ["client_id"] = Options.ClientId,
+                    ["redirect_uri"] = redirectUri,
+                    ["client_secret"] = Options.ClientSecret,
+                    ["code"] = code,
+                    ["grant_type"] = "authorization_code"
+                })
+            };
 
             var response = await Backchannel.SendAsync(request, Context.RequestAborted);
             if (!response.IsSuccessStatusCode)
@@ -97,7 +99,7 @@ namespace AspNet.Security.OAuth.StackExchange
             }
 
             // Note: StackExchange's token endpoint doesn't return JSON but uses application/x-www-form-urlencoded.
-            // Since OAuthTokenResponse expects a JSON payload, a JObject is manually created using the returned values.
+            // Since OAuthTokenResponse expects a JSON payload, a response is manually created using the returned values.
             var content = QueryHelpers.ParseQuery(await response.Content.ReadAsStringAsync());
 
             var payload = new JObject();


### PR DESCRIPTION
Ports various changes from #280 to `dev` to reduce the size of the PR to support 3.0 itself.

Also includes fixes to the Salesforce provider to resolve #284.
