### PR TITLE
Fix Foursquare handler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ env:
     - DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     - DOTNET_CLI_TELEMETRY_OPTOUT: 1
     - NUGET_XMLDOC_MODE: skip
-mono: none
 os:
   - linux
   - osx

--- a/src/AspNet.Security.OAuth.Foursquare/FoursquareAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Foursquare/FoursquareAuthenticationHandler.cs
@@ -60,7 +60,7 @@ namespace AspNet.Security.OAuth.Foursquare
 
             var principal = new ClaimsPrincipal(identity);
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload);
-            context.RunClaimActions(payload.Value<JObject>("response")?.Value<JObject>("payload"));
+            context.RunClaimActions(payload.Value<JObject>("response")?.Value<JObject>("user"));
 
             await Options.Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal, context.Properties, Scheme.Name);


### PR DESCRIPTION
Fix the Foursquare provider not working due to incorrect property name.

Found and then validated after porting #282 to target .NET Core 2.2.
