### PR TITLE
Add integration tests

### DIFF
--- a/AspNet.Security.OAuth.Providers.sln
+++ b/AspNet.Security.OAuth.Providers.sln
@@ -110,6 +110,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNet.Security.OAuth.Patre
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNet.Security.OAuth.QQ", "src\AspNet.Security.OAuth.QQ\AspNet.Security.OAuth.QQ.csproj", "{7C2E82CE-F6EC-41A8-AA22-3466505F95D8}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{D7CEAA0A-50F4-4BE9-90B8-EED43F4CB39B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNet.Security.OAuth.Providers.Tests", "test\AspNet.Security.OAuth.Providers.Tests\AspNet.Security.OAuth.Providers.Tests.csproj", "{842A4AA5-A82B-468E-9C25-BCD63C9C8E48}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -304,6 +308,10 @@ Global
 		{7C2E82CE-F6EC-41A8-AA22-3466505F95D8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7C2E82CE-F6EC-41A8-AA22-3466505F95D8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7C2E82CE-F6EC-41A8-AA22-3466505F95D8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{842A4AA5-A82B-468E-9C25-BCD63C9C8E48}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{842A4AA5-A82B-468E-9C25-BCD63C9C8E48}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{842A4AA5-A82B-468E-9C25-BCD63C9C8E48}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{842A4AA5-A82B-468E-9C25-BCD63C9C8E48}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -356,6 +364,7 @@ Global
 		{86614CB9-0768-40BF-8C27-699E3990B733} = {C1352FD3-AE8B-43EE-B45B-F6E0B3FBAC6D}
 		{ED8A220C-45FE-45C6-9B8F-BB009ACE972E} = {C1352FD3-AE8B-43EE-B45B-F6E0B3FBAC6D}
 		{7C2E82CE-F6EC-41A8-AA22-3466505F95D8} = {C1352FD3-AE8B-43EE-B45B-F6E0B3FBAC6D}
+		{842A4AA5-A82B-468E-9C25-BCD63C9C8E48} = {D7CEAA0A-50F4-4BE9-90B8-EED43F4CB39B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C7B54DE2-6407-4802-AD9C-CE54BF414C8C}

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -2,9 +2,14 @@
 
   <PropertyGroup Label="Package Versions">
     <AspNetCoreVersion>2.0.0</AspNetCoreVersion>
+    <DotNetTestSdkVersion>16.1.0</DotNetTestSdkVersion>
     <GoogleProviderVersion>2.2.2</GoogleProviderVersion>
-    <JetBrainsVersion>10.3.0</JetBrainsVersion>
+    <JetBrainsVersion>2019.1.1</JetBrainsVersion>
+    <JustEatHttpClientInterceptionVersion>2.0.1</JustEatHttpClientInterceptionVersion>
+    <MartinCostelloLoggingXUnitVersion>0.1.0</MartinCostelloLoggingXUnitVersion>
+    <ShouldlyVersion>3.0.2</ShouldlyVersion>
     <TwitterProviderVersion>2.2.0</TwitterProviderVersion>
+    <XunitVersion>2.4.1</XunitVersion>
   </PropertyGroup>
 
 </Project>

--- a/test/AspNet.Security.OAuth.Providers.Tests/Amazon/AmazonTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Amazon/AmazonTests.cs
@@ -1,0 +1,52 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AspNet.Security.OAuth.Amazon
+{
+    public class AmazonTests : OAuthTests<AmazonAuthenticationOptions>
+    {
+        public AmazonTests(ITestOutputHelper outputHelper)
+        {
+            OutputHelper = outputHelper;
+        }
+
+        public override string DefaultScheme => AmazonAuthenticationDefaults.AuthenticationScheme;
+
+        protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
+        {
+            builder.AddAmazon(options =>
+            {
+                ConfigureDefaults(builder, options);
+                options.Fields.Add("postal_code");
+            });
+        }
+
+        [Theory]
+        [InlineData(ClaimTypes.NameIdentifier, "my-id")]
+        [InlineData(ClaimTypes.Name, "John Smith")]
+        [InlineData(ClaimTypes.Email, "john@john-smith.local")]
+        [InlineData(ClaimTypes.PostalCode, "90210")]
+        public async Task Can_Sign_In_Using_Amazon(string claimType, string claimValue)
+        {
+            // Arrange
+            using (var server = CreateTestServer())
+            {
+                // Act
+                var claims = await AuthenticateUserAsync(server);
+
+                // Assert
+                AssertClaim(claims, claimType, claimValue);
+            }
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Amazon/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Amazon/bundle.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/master/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
+  "items": [
+    {
+      "uri": "https://api.amazon.com/auth/o2/token",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "secret-access-token",
+        "token_type": "access",
+        "refresh_token": "secret-refresh-token",
+        "expires_in": "300"
+      }
+    },
+    {
+      "uri": "https://api.amazon.com/user/profile?fields=email,name,user_id,postal_code",
+      "contentFormat": "json",
+      "contentJson": {
+        "user_id": "my-id",
+        "name": "John Smith",
+        "email": "john@john-smith.local",
+        "postal_code": "90210"
+      }
+    }
+  ]
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/ArcGIS/ArcGISTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/ArcGIS/ArcGISTests.cs
@@ -1,0 +1,47 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AspNet.Security.OAuth.ArcGIS
+{
+    public class ArcGISTests : OAuthTests<ArcGISAuthenticationOptions>
+    {
+        public ArcGISTests(ITestOutputHelper outputHelper)
+        {
+            OutputHelper = outputHelper;
+        }
+
+        public override string DefaultScheme => ArcGISAuthenticationDefaults.AuthenticationScheme;
+
+        protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
+        {
+            builder.AddArcGIS(options => ConfigureDefaults(builder, options));
+        }
+
+        [Theory]
+        [InlineData(ClaimTypes.NameIdentifier, "my-id")]
+        [InlineData(ClaimTypes.Name, "John Smith")]
+        [InlineData(ClaimTypes.Email, "john@john-smith.local")]
+        public async Task Can_Sign_In_Using_ArcGIS(string claimType, string claimValue)
+        {
+            // Arrange
+            using (var server = CreateTestServer())
+            {
+                // Act
+                var claims = await AuthenticateUserAsync(server);
+
+                // Assert
+                AssertClaim(claims, claimType, claimValue);
+            }
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/ArcGIS/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/ArcGIS/bundle.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/master/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
+  "items": [
+    {
+      "uri": "https://www.arcgis.com/sharing/rest/oauth2/token",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "secret-access-token",
+        "token_type": "access",
+        "refresh_token": "secret-refresh-token",
+        "expires_in": "300"
+      }
+    },
+    {
+      "uri": "https://www.arcgis.com/sharing/rest/community/self?f=json&token=secret-access-token",
+      "contentFormat": "json",
+      "contentJson": {
+        "username": "my-id",
+        "fullName": "John Smith",
+        "email": "john@john-smith.local"
+      }
+    }
+  ]
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Asana/AsanaTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Asana/AsanaTests.cs
@@ -1,0 +1,47 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AspNet.Security.OAuth.Asana
+{
+    public class AsanaTests : OAuthTests<AsanaAuthenticationOptions>
+    {
+        public AsanaTests(ITestOutputHelper outputHelper)
+        {
+            OutputHelper = outputHelper;
+        }
+
+        public override string DefaultScheme => AsanaAuthenticationDefaults.AuthenticationScheme;
+
+        protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
+        {
+            builder.AddAsana(options => ConfigureDefaults(builder, options));
+        }
+
+        [Theory]
+        [InlineData(ClaimTypes.NameIdentifier, "my-id")]
+        [InlineData(ClaimTypes.Name, "John Smith")]
+        [InlineData(ClaimTypes.Email, "john@john-smith.local")]
+        public async Task Can_Sign_In_Using_Asana(string claimType, string claimValue)
+        {
+            // Arrange
+            using (var server = CreateTestServer())
+            {
+                // Act
+                var claims = await AuthenticateUserAsync(server);
+
+                // Assert
+                AssertClaim(claims, claimType, claimValue);
+            }
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Asana/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Asana/bundle.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/master/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
+  "items": [
+    {
+      "uri": "https://app.asana.com/-/oauth_token",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "secret-access-token",
+        "token_type": "access",
+        "refresh_token": "secret-refresh-token",
+        "expires_in": "300"
+      }
+    },
+    {
+      "uri": "https://app.asana.com/api/1.0/users/me",
+      "contentFormat": "json",
+      "contentJson": {
+        "data": {
+          "id": "my-id",
+          "name": "John Smith",
+          "email": "john@john-smith.local"
+        }
+      }
+    }
+  ]
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/AspNet.Security.OAuth.Providers.Tests.csproj
+++ b/test/AspNet.Security.OAuth.Providers.Tests/AspNet.Security.OAuth.Providers.Tests.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\build\packages.props" />
+  <PropertyGroup>
+    <AspNetCoreVersion>2.2.0</AspNetCoreVersion>
+    <RootNamespace>AspNet.Security.OAuth</RootNamespace>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <Content Include="xunit.runner.json;**\bundle.json" Exclude="bin\**\bundle.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\AspNet.Security.OAuth.*\*.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="JustEat.HttpClientInterception" Version="$(JustEatHttpClientInterceptionVersion)" />
+    <PackageReference Include="MartinCostello.Logging.XUnit" Version="$(MartinCostelloLoggingXUnitVersion)" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(DotNetTestSdkVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Shouldly" Version="$(ShouldlyVersion)" />
+    <PackageReference Include="xunit" Version="$(XunitVersion)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
+  </ItemGroup>
+</Project>

--- a/test/AspNet.Security.OAuth.Providers.Tests/Autodesk/AutodeskTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Autodesk/AutodeskTests.cs
@@ -1,0 +1,51 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AspNet.Security.OAuth.Autodesk
+{
+    public class AutodeskTests : OAuthTests<AutodeskAuthenticationOptions>
+    {
+        public AutodeskTests(ITestOutputHelper outputHelper)
+        {
+            OutputHelper = outputHelper;
+        }
+
+        public override string DefaultScheme => AutodeskAuthenticationDefaults.AuthenticationScheme;
+
+        protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
+        {
+            builder.AddAutodesk(options => ConfigureDefaults(builder, options));
+        }
+
+        [Theory]
+        [InlineData(ClaimTypes.NameIdentifier, "my-id")]
+        [InlineData(ClaimTypes.Name, "John Smith")]
+        [InlineData(ClaimTypes.Email, "john@john-smith.local")]
+        [InlineData(ClaimTypes.GivenName, "John")]
+        [InlineData(ClaimTypes.Surname, "Smith")]
+        [InlineData("urn:autodesk:emailverified", "True")]
+        [InlineData("urn:autodesk:twofactorenabled", "False")]
+        public async Task Can_Sign_In_Using_Autodesk(string claimType, string claimValue)
+        {
+            // Arrange
+            using (var server = CreateTestServer())
+            {
+                // Act
+                var claims = await AuthenticateUserAsync(server);
+
+                // Assert
+                AssertClaim(claims, claimType, claimValue);
+            }
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Autodesk/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Autodesk/bundle.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/master/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
+  "items": [
+    {
+      "uri": "https://developer.api.autodesk.com/authentication/v1/gettoken",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "secret-access-token",
+        "token_type": "access",
+        "refresh_token": "secret-refresh-token",
+        "expires_in": "300"
+      }
+    },
+    {
+      "uri": "https://developer.api.autodesk.com/userprofile/v1/users/@me",
+      "contentFormat": "json",
+      "contentJson": {
+        "userId": "my-id",
+        "userName": "John Smith",
+        "firstName": "John",
+        "lastName": "Smith",
+        "emailId": "john@john-smith.local",
+        "emailVerified": true,
+        "2FaEnabled": false
+      }
+    }
+  ]
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Automatic/AutomaticTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Automatic/AutomaticTests.cs
@@ -1,0 +1,52 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AspNet.Security.OAuth.Automatic
+{
+    public class AutomaticTests : OAuthTests<AutomaticAuthenticationOptions>
+    {
+        public AutomaticTests(ITestOutputHelper outputHelper)
+        {
+            OutputHelper = outputHelper;
+        }
+
+        public override string DefaultScheme => AutomaticAuthenticationDefaults.AuthenticationScheme;
+
+        protected override string RedirectUri => "http://localhost/signin-automatic";
+
+        protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
+        {
+            builder.AddAutomatic(options => ConfigureDefaults(builder, options));
+        }
+
+        [Theory]
+        [InlineData(ClaimTypes.NameIdentifier, "my-id")]
+        [InlineData(ClaimTypes.Name, "John Smith")]
+        [InlineData(ClaimTypes.Email, "john@john-smith.local")]
+        [InlineData(ClaimTypes.GivenName, "John")]
+        [InlineData(ClaimTypes.Surname, "Smith")]
+        [InlineData(ClaimTypes.Uri, "https://automatic.local/JohnSmith")]
+        public async Task Can_Sign_In_Using_Automatic(string claimType, string claimValue)
+        {
+            // Arrange
+            using (var server = CreateTestServer())
+            {
+                // Act
+                var claims = await AuthenticateUserAsync(server);
+
+                // Assert
+                AssertClaim(claims, claimType, claimValue);
+            }
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Automatic/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Automatic/bundle.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/master/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
+  "items": [
+    {
+      "uri": "https://accounts.automatic.com/oauth/access_token",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "secret-access-token",
+        "token_type": "access",
+        "refresh_token": "secret-refresh-token",
+        "expires_in": "300"
+      }
+    },
+    {
+      "uri": "https://api.automatic.com/user/me/",
+      "contentFormat": "json",
+      "contentJson": {
+        "id": "my-id",
+        "first_name": "John",
+        "last_name": "Smith",
+        "username": "John Smith",
+        "email": "john@john-smith.local",
+        "url": "https://automatic.local/JohnSmith"
+      }
+    }
+  ]
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/BattleNet/BattleNetTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/BattleNet/BattleNetTests.cs
@@ -1,0 +1,46 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AspNet.Security.OAuth.BattleNet
+{
+    public class BattleNetTests : OAuthTests<BattleNetAuthenticationOptions>
+    {
+        public BattleNetTests(ITestOutputHelper outputHelper)
+        {
+            OutputHelper = outputHelper;
+        }
+
+        public override string DefaultScheme => BattleNetAuthenticationDefaults.AuthenticationScheme;
+
+        protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
+        {
+            builder.AddBattleNet(options => ConfigureDefaults(builder, options));
+        }
+
+        [Theory]
+        [InlineData(ClaimTypes.NameIdentifier, "my-id")]
+        [InlineData(ClaimTypes.Name, "John Smith")]
+        public async Task Can_Sign_In_Using_BattleNet(string claimType, string claimValue)
+        {
+            // Arrange
+            using (var server = CreateTestServer())
+            {
+                // Act
+                var claims = await AuthenticateUserAsync(server);
+
+                // Assert
+                AssertClaim(claims, claimType, claimValue);
+            }
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/BattleNet/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/BattleNet/bundle.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/master/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
+  "items": [
+    {
+      "uri": "https://us.battle.net/oauth/token",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "secret-access-token",
+        "token_type": "access",
+        "refresh_token": "secret-refresh-token",
+        "expires_in": "300"
+      }
+    },
+    {
+      "uri": "https://us.battle.net/oauth/userinfo?access_token=secret-access-token",
+      "contentFormat": "json",
+      "contentJson": {
+        "id": "my-id",
+        "battletag": "John Smith"
+      }
+    }
+  ]
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Beam/BeamTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Beam/BeamTests.cs
@@ -1,0 +1,47 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AspNet.Security.OAuth.Beam
+{
+    public class BeamTests : OAuthTests<BeamAuthenticationOptions>
+    {
+        public BeamTests(ITestOutputHelper outputHelper)
+        {
+            OutputHelper = outputHelper;
+        }
+
+        public override string DefaultScheme => BeamAuthenticationDefaults.AuthenticationScheme;
+
+        protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
+        {
+            builder.AddBeam(options => ConfigureDefaults(builder, options));
+        }
+
+        [Theory]
+        [InlineData(ClaimTypes.NameIdentifier, "my-id")]
+        [InlineData(ClaimTypes.Name, "John Smith")]
+        [InlineData(ClaimTypes.Email, "john@john-smith.local")]
+        public async Task Can_Sign_In_Using_Beam(string claimType, string claimValue)
+        {
+            // Arrange
+            using (var server = CreateTestServer())
+            {
+                // Act
+                var claims = await AuthenticateUserAsync(server);
+
+                // Assert
+                AssertClaim(claims, claimType, claimValue);
+            }
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Beam/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Beam/bundle.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/master/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
+  "items": [
+    {
+      "uri": "https://beam.pro/api/v1/oauth/token",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "secret-access-token",
+        "token_type": "access",
+        "refresh_token": "secret-refresh-token",
+        "expires_in": "300"
+      }
+    },
+    {
+      "uri": "https://beam.pro/api/v1/users/current",
+      "contentFormat": "json",
+      "contentJson": {
+        "id": "my-id",
+        "name": "John Smith",
+        "email": "john@john-smith.local"
+      }
+    }
+  ]
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Bitbucket/BitbucketTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Bitbucket/BitbucketTests.cs
@@ -1,0 +1,54 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AspNet.Security.OAuth.Bitbucket
+{
+    public class BitbucketTests : OAuthTests<BitbucketAuthenticationOptions>
+    {
+        public BitbucketTests(ITestOutputHelper outputHelper)
+        {
+            OutputHelper = outputHelper;
+        }
+
+        public override string DefaultScheme => BitbucketAuthenticationDefaults.AuthenticationScheme;
+
+        protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
+        {
+            builder.AddBitbucket(options =>
+            {
+                ConfigureDefaults(builder, options);
+                options.Scope.Add("account");
+                options.Scope.Add("email");
+            });
+        }
+
+        [Theory]
+        [InlineData(ClaimTypes.NameIdentifier, "my-id")]
+        [InlineData(ClaimTypes.Name, "johnsmith")]
+        [InlineData(ClaimTypes.Email, "john@john-smith.local")]
+        [InlineData("urn:bitbucket:name", "John Smith")]
+        [InlineData("urn:bitbucket:url", "https://bitbucket.org")]
+        public async Task Can_Sign_In_Using_Bitbucket(string claimType, string claimValue)
+        {
+            // Arrange
+            using (var server = CreateTestServer())
+            {
+                // Act
+                var claims = await AuthenticateUserAsync(server);
+
+                // Assert
+                AssertClaim(claims, claimType, claimValue);
+            }
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Bitbucket/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Bitbucket/bundle.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/master/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
+  "items": [
+    {
+      "comment": "https://developer.github.com/apps/building-oauth-apps/authorizing-oauth-apps/#2-users-are-redirected-back-to-your-site-by-github",
+      "uri": "https://bitbucket.org/site/oauth2/access_token",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "secret-access-token",
+        "token_type": "bearer",
+        "scope": "repo,gist"
+      }
+    },
+    {
+      "comment": "https://developer.atlassian.com/bitbucket/api/2/reference/resource/user",
+      "uri": "https://api.bitbucket.org/2.0/user",
+      "contentFormat": "json",
+      "contentJson": {
+        "username": "johnsmith",
+        "nickname": "John",
+        "account_status": "Active",
+        "display_name": "John Smith",
+        "website": "https://bitbucket.org",
+        "created_on": "2019-03-17T10:57:00+00:00",
+        "uuid": "e0a0e4ca-7f38-4e54-9c45-e68904b663da",
+        "has_2fa_enabled": true,
+        "is_staff": false,
+        "account_id": "my-id"
+      }
+    },
+    {
+      "comment": "https://developer.atlassian.com/bitbucket/api/2/reference/resource/user/emails",
+      "uri": "https://api.bitbucket.org/2.0/user/emails",
+      "contentFormat": "json",
+      "contentJson": {
+        "values": [
+          {
+            "email": "john@john-smith.local",
+            "is_primary": true
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Buffer/BufferTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Buffer/BufferTests.cs
@@ -1,0 +1,45 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AspNet.Security.OAuth.Buffer
+{
+    public class BufferTests : OAuthTests<BufferAuthenticationOptions>
+    {
+        public BufferTests(ITestOutputHelper outputHelper)
+        {
+            OutputHelper = outputHelper;
+        }
+
+        public override string DefaultScheme => BufferAuthenticationDefaults.AuthenticationScheme;
+
+        protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
+        {
+            builder.AddBuffer(options => ConfigureDefaults(builder, options));
+        }
+
+        [Theory]
+        [InlineData(ClaimTypes.NameIdentifier, "my-id")]
+        public async Task Can_Sign_In_Using_Buffer(string claimType, string claimValue)
+        {
+            // Arrange
+            using (var server = CreateTestServer())
+            {
+                // Act
+                var claims = await AuthenticateUserAsync(server);
+
+                // Assert
+                AssertClaim(claims, claimType, claimValue);
+            }
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Buffer/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Buffer/bundle.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/master/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
+  "items": [
+    {
+      "uri": "https://api.bufferapp.com/1/oauth2/token.json",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "secret-access-token",
+        "token_type": "access",
+        "refresh_token": "secret-refresh-token",
+        "expires_in": "300"
+      }
+    },
+    {
+      "uri": "https://api.bufferapp.com/1/user.json",
+      "contentFormat": "json",
+      "contentJson": {
+        "id": "my-id"
+      }
+    }
+  ]
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/CiscoSpark/CiscoSparkTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/CiscoSpark/CiscoSparkTests.cs
@@ -1,0 +1,47 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AspNet.Security.OAuth.CiscoSpark
+{
+    public class CiscoSparkTests : OAuthTests<CiscoSparkAuthenticationOptions>
+    {
+        public CiscoSparkTests(ITestOutputHelper outputHelper)
+        {
+            OutputHelper = outputHelper;
+        }
+
+        public override string DefaultScheme => CiscoSparkAuthenticationDefaults.AuthenticationScheme;
+
+        protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
+        {
+            builder.AddCiscoSpark(options => ConfigureDefaults(builder, options));
+        }
+
+        [Theory]
+        [InlineData(ClaimTypes.NameIdentifier, "my-id")]
+        [InlineData(ClaimTypes.Name, "John Smith")]
+        [InlineData(ClaimTypes.Email, "john@john-smith.local")]
+        public async Task Can_Sign_In_Using_CiscoSpark(string claimType, string claimValue)
+        {
+            // Arrange
+            using (var server = CreateTestServer())
+            {
+                // Act
+                var claims = await AuthenticateUserAsync(server);
+
+                // Assert
+                AssertClaim(claims, claimType, claimValue);
+            }
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/CiscoSpark/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/CiscoSpark/bundle.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/master/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
+  "items": [
+    {
+      "uri": "https://api.ciscospark.com/v1/access_token",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "secret-access-token",
+        "token_type": "access",
+        "refresh_token": "secret-refresh-token",
+        "expires_in": "300"
+      }
+    },
+    {
+      "uri": "https://api.ciscospark.com/v1/people/me",
+      "contentFormat": "json",
+      "contentJson": {
+        "id": "my-id",
+        "displayName": "John Smith",
+        "emails": [
+          "john@john-smith.local"
+        ]
+      }
+    }
+  ]
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/DeviantArt/DeviantArtTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/DeviantArt/DeviantArtTests.cs
@@ -1,0 +1,47 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AspNet.Security.OAuth.DeviantArt
+{
+    public class DeviantArtTests : OAuthTests<DeviantArtAuthenticationOptions>
+    {
+        public DeviantArtTests(ITestOutputHelper outputHelper)
+        {
+            OutputHelper = outputHelper;
+        }
+
+        public override string DefaultScheme => DeviantArtAuthenticationDefaults.AuthenticationScheme;
+
+        protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
+        {
+            builder.AddDeviantArt(options => ConfigureDefaults(builder, options));
+        }
+
+        [Theory]
+        [InlineData(ClaimTypes.NameIdentifier, "my-id")]
+        [InlineData(ClaimTypes.Name, "John Smith")]
+        [InlineData("urn:deviantart:name", "John Smith")]
+        public async Task Can_Sign_In_Using_Deviant_Art(string claimType, string claimValue)
+        {
+            // Arrange
+            using (var server = CreateTestServer())
+            {
+                // Act
+                var claims = await AuthenticateUserAsync(server);
+
+                // Assert
+                AssertClaim(claims, claimType, claimValue);
+            }
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/DeviantArt/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/DeviantArt/bundle.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/master/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
+  "items": [
+    {
+      "uri": "https://www.deviantart.com/oauth2/token",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "secret-access-token",
+        "token_type": "access",
+        "refresh_token": "secret-refresh-token",
+        "expires_in": "300"
+      }
+    },
+    {
+      "uri": "https://www.deviantart.com/api/v1/oauth2/user/whoami/",
+      "contentFormat": "json",
+      "contentJson": {
+        "userid": "my-id",
+        "username": "John Smith"
+      }
+    }
+  ]
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Discord/DiscordTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Discord/DiscordTests.cs
@@ -1,0 +1,47 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AspNet.Security.OAuth.Discord
+{
+    public class DiscordTests : OAuthTests<DiscordAuthenticationOptions>
+    {
+        public DiscordTests(ITestOutputHelper outputHelper)
+        {
+            OutputHelper = outputHelper;
+        }
+
+        public override string DefaultScheme => DiscordAuthenticationDefaults.AuthenticationScheme;
+
+        protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
+        {
+            builder.AddDiscord(options => ConfigureDefaults(builder, options));
+        }
+
+        [Theory]
+        [InlineData(ClaimTypes.NameIdentifier, "my-id")]
+        [InlineData(ClaimTypes.Name, "John Smith")]
+        [InlineData(ClaimTypes.Email, "john@john-smith.local")]
+        public async Task Can_Sign_In_Using_Discord(string claimType, string claimValue)
+        {
+            // Arrange
+            using (var server = CreateTestServer())
+            {
+                // Act
+                var claims = await AuthenticateUserAsync(server);
+
+                // Assert
+                AssertClaim(claims, claimType, claimValue);
+            }
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Discord/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Discord/bundle.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/master/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
+  "items": [
+    {
+      "uri": "https://discordapp.com/api/oauth2/token",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "secret-access-token",
+        "token_type": "access",
+        "refresh_token": "secret-refresh-token",
+        "expires_in": "300"
+      }
+    },
+    {
+      "uri": "https://discordapp.com/api/users/@me",
+      "contentFormat": "json",
+      "contentJson": {
+        "id": "my-id",
+        "username": "John Smith",
+        "email": "john@john-smith.local"
+      }
+    }
+  ]
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Dropbox/DropboxTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Dropbox/DropboxTests.cs
@@ -1,0 +1,47 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AspNet.Security.OAuth.Dropbox
+{
+    public class DropboxTests : OAuthTests<DropboxAuthenticationOptions>
+    {
+        public DropboxTests(ITestOutputHelper outputHelper)
+        {
+            OutputHelper = outputHelper;
+        }
+
+        public override string DefaultScheme => DropboxAuthenticationDefaults.AuthenticationScheme;
+
+        protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
+        {
+            builder.AddDropbox(options => ConfigureDefaults(builder, options));
+        }
+
+        [Theory]
+        [InlineData(ClaimTypes.NameIdentifier, "dbid:AAH4f99T0taONIb-OurWxbNQ6ywGRopQngc")]
+        [InlineData(ClaimTypes.Name, "Franz Ferdinand (Personal)")]
+        [InlineData(ClaimTypes.Email, "franz@gmail.com")]
+        public async Task Can_Sign_In_Using_Dropbox(string claimType, string claimValue)
+        {
+            // Arrange
+            using (var server = CreateTestServer())
+            {
+                // Act
+                var claims = await AuthenticateUserAsync(server);
+
+                // Assert
+                AssertClaim(claims, claimType, claimValue);
+            }
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Dropbox/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Dropbox/bundle.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/master/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
+  "items": [
+    {
+      "comment": "https://www.dropbox.com/developers/documentation/http/documentation#oa2-token",
+      "uri": "https://api.dropboxapi.com/oauth2/token",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "ABCDEFG",
+        "token_type": "bearer",
+        "account_id": "dbid:AAH4f99T0taONIb-OurWxbNQ6ywGRopQngc",
+        "uid": "12345"
+      }
+    },
+    {
+      "comment": "https://www.dropbox.com/developers/documentation/http/documentation#users-get_current_account",
+      "uri": "https://api.dropboxapi.com/2/users/get_current_account",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "account_id": "dbid:AAH4f99T0taONIb-OurWxbNQ6ywGRopQngc",
+        "name": {
+          "given_name": "Franz",
+          "surname": "Ferdinand",
+          "familiar_name": "Franz",
+          "display_name": "Franz Ferdinand (Personal)",
+          "abbreviated_name": "FF"
+        },
+        "email": "franz@gmail.com",
+        "email_verified": false,
+        "disabled": false,
+        "locale": "en",
+        "referral_link": "https://db.tt/ZITNuhtI",
+        "is_paired": false,
+        "account_type": {
+          ".tag": "basic"
+        },
+        "root_info": {
+          ".tag": "user",
+          "root_namespace_id": "3235641",
+          "home_namespace_id": "3235641"
+        },
+        "profile_photo_url": "https://dl-web.dropbox.com/account_photo/get/dbid%3AAAH4f99T0taONIb-OurWxbNQ6ywGRopQngc?vers=1453416673259\u0026size=128x128",
+        "country": "US"
+      }
+    }
+  ]
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/EVEOnline/EVEOnlineTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/EVEOnline/EVEOnlineTests.cs
@@ -30,7 +30,7 @@ namespace AspNet.Security.OAuth.EVEOnline
         [Theory]
         [InlineData(ClaimTypes.NameIdentifier, "my-id")]
         [InlineData(ClaimTypes.Name, "John Smith")]
-        [InlineData(ClaimTypes.Expiration, "2099-12-31T23:59:59+00:00")]
+        [InlineData(ClaimTypes.Expiration, "2019-12-31T23:59:59+00:00")]
         [InlineData("urn:eveonline:scopes", "my-scopes")]
         public async Task Can_Sign_In_Using_EVE_Online(string claimType, string claimValue)
         {

--- a/test/AspNet.Security.OAuth.Providers.Tests/EVEOnline/EVEOnlineTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/EVEOnline/EVEOnlineTests.cs
@@ -1,0 +1,48 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AspNet.Security.OAuth.EVEOnline
+{
+    public class EVEOnlineTests : OAuthTests<EVEOnlineAuthenticationOptions>
+    {
+        public EVEOnlineTests(ITestOutputHelper outputHelper)
+        {
+            OutputHelper = outputHelper;
+        }
+
+        public override string DefaultScheme => EVEOnlineAuthenticationDefaults.AuthenticationScheme;
+
+        protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
+        {
+            builder.AddEVEOnline(options => ConfigureDefaults(builder, options));
+        }
+
+        [Theory]
+        [InlineData(ClaimTypes.NameIdentifier, "my-id")]
+        [InlineData(ClaimTypes.Name, "John Smith")]
+        [InlineData(ClaimTypes.Expiration, "2099-12-31T23:59:59+00:00")]
+        [InlineData("urn:eveonline:scopes", "my-scopes")]
+        public async Task Can_Sign_In_Using_EVE_Online(string claimType, string claimValue)
+        {
+            // Arrange
+            using (var server = CreateTestServer())
+            {
+                // Act
+                var claims = await AuthenticateUserAsync(server);
+
+                // Assert
+                AssertClaim(claims, claimType, claimValue);
+            }
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/EVEOnline/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/EVEOnline/bundle.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/master/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
+  "items": [
+    {
+      "uri": "https://login.eveonline.com/oauth/token",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "secret-access-token",
+        "token_type": "access",
+        "refresh_token": "secret-refresh-token",
+        "expires_in": "300"
+      }
+    },
+    {
+      "uri": "https://login.eveonline.com/oauth/verify",
+      "contentFormat": "json",
+      "contentJson": {
+        "CharacterID": "my-id",
+        "CharacterName": "John Smith",
+        "ExpiresOn": "2099-12-31T23:59:59+00:00",
+        "Scopes": "my-scopes"
+      }
+    }
+  ]
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/EVEOnline/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/EVEOnline/bundle.json
@@ -18,7 +18,7 @@
       "contentJson": {
         "CharacterID": "my-id",
         "CharacterName": "John Smith",
-        "ExpiresOn": "2099-12-31T23:59:59+00:00",
+        "ExpiresOn": "2019-12-31T23:59:59+00:00",
         "Scopes": "my-scopes"
       }
     }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Fitbit/FitbitTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Fitbit/FitbitTests.cs
@@ -1,0 +1,48 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AspNet.Security.OAuth.Fitbit
+{
+    public class FitbitTests : OAuthTests<FitbitAuthenticationOptions>
+    {
+        public FitbitTests(ITestOutputHelper outputHelper)
+        {
+            OutputHelper = outputHelper;
+        }
+
+        public override string DefaultScheme => FitbitAuthenticationDefaults.AuthenticationScheme;
+
+        protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
+        {
+            builder.AddFitbit(options => ConfigureDefaults(builder, options));
+        }
+
+        [Theory]
+        [InlineData(ClaimTypes.NameIdentifier, "my-id")]
+        [InlineData(ClaimTypes.Name, "John Smith")]
+        [InlineData("urn:fitbit:avatar", "https://fitbit.local/john-smith/avatar.png")]
+        [InlineData("urn:fitbit:avatar150", "https://fitbit.local/john-smith/avatar-150.png")]
+        public async Task Can_Sign_In_Using_Fitbit(string claimType, string claimValue)
+        {
+            // Arrange
+            using (var server = CreateTestServer())
+            {
+                // Act
+                var claims = await AuthenticateUserAsync(server);
+
+                // Assert
+                AssertClaim(claims, claimType, claimValue);
+            }
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Fitbit/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Fitbit/bundle.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/master/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
+  "items": [
+    {
+      "uri": "https://api.fitbit.com/oauth2/token",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "secret-access-token",
+        "token_type": "access",
+        "refresh_token": "secret-refresh-token",
+        "expires_in": "300"
+      }
+    },
+    {
+      "uri": "https://api.fitbit.com/1/user/-/profile.json",
+      "contentFormat": "json",
+      "contentJson": {
+        "user": {
+          "encodedId": "my-id",
+          "displayName": "John Smith",
+          "avatar": "https://fitbit.local/john-smith/avatar.png",
+          "avatar150": "https://fitbit.local/john-smith/avatar-150.png"
+        }
+      }
+    }
+  ]
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Foursquare/FoursquareTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Foursquare/FoursquareTests.cs
@@ -1,0 +1,51 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AspNet.Security.OAuth.Foursquare
+{
+    public class FoursquareTests : OAuthTests<FoursquareAuthenticationOptions>
+    {
+        public FoursquareTests(ITestOutputHelper outputHelper)
+        {
+            OutputHelper = outputHelper;
+        }
+
+        public override string DefaultScheme => FoursquareAuthenticationDefaults.AuthenticationScheme;
+
+        protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
+        {
+            builder.AddFoursquare(options => ConfigureDefaults(builder, options));
+        }
+
+        [Theory]
+        [InlineData(ClaimTypes.NameIdentifier, "my-id")]
+        [InlineData(ClaimTypes.Name, "John Smith")]
+        [InlineData(ClaimTypes.Email, "john@john-smith.local")]
+        [InlineData(ClaimTypes.GivenName, "John")]
+        [InlineData(ClaimTypes.Surname, "Smith")]
+        [InlineData(ClaimTypes.Gender, "Male")]
+        [InlineData(ClaimTypes.Uri, "https://foursquare.local/john-smith")]
+        public async Task Can_Sign_In_Using_Foursquare(string claimType, string claimValue)
+        {
+            // Arrange
+            using (var server = CreateTestServer())
+            {
+                // Act
+                var claims = await AuthenticateUserAsync(server);
+
+                // Assert
+                AssertClaim(claims, claimType, claimValue);
+            }
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Foursquare/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Foursquare/bundle.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/master/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
+  "items": [
+    {
+      "uri": "https://foursquare.com/oauth2/access_token",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "secret-access-token",
+        "token_type": "access",
+        "refresh_token": "secret-refresh-token",
+        "expires_in": "300"
+      }
+    },
+    {
+      "uri": "https://api.foursquare.com/v2/users/self?m=foursquare&v=20150927&oauth_token=secret-access-token",
+      "contentFormat": "json",
+      "contentJson": {
+        "meta": {
+          "code": 200,
+          "requestId": "5cd83c44351e3d1d4e51989c"
+        },
+        "notifications": [
+          {
+            "type": "notificationTray",
+            "item": { "unreadCount": 0 }
+          }
+        ],
+        "response": {
+          "user": {
+            "id": "my-id",
+            "lastName": "Smith",
+            "firstName": "John",
+            "gender": "Male",
+            "name": "John Smith",
+            "canonicalUrl": "https://foursquare.local/john-smith",
+            "contact": {
+              "email": "john@john-smith.local"
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/GitHub/GitHubTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/GitHub/GitHubTests.cs
@@ -1,0 +1,53 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AspNet.Security.OAuth.GitHub
+{
+    public class GitHubTests : OAuthTests<GitHubAuthenticationOptions>
+    {
+        public GitHubTests(ITestOutputHelper outputHelper)
+        {
+            OutputHelper = outputHelper;
+        }
+
+        public override string DefaultScheme => GitHubAuthenticationDefaults.AuthenticationScheme;
+
+        protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
+        {
+            builder.AddGitHub(options =>
+            {
+                ConfigureDefaults(builder, options);
+                options.Scope.Add("user:email");
+            });
+        }
+
+        [Theory]
+        [InlineData(ClaimTypes.NameIdentifier, "1")]
+        [InlineData(ClaimTypes.Name, "octocat")]
+        [InlineData(ClaimTypes.Email, "octocat@github.com")]
+        [InlineData("urn:github:name", "monalisa octocat")]
+        [InlineData("urn:github:url", "https://api.github.com/users/octocat")]
+        public async Task Can_Sign_In_Using_GitHub(string claimType, string claimValue)
+        {
+            // Arrange
+            using (var server = CreateTestServer())
+            {
+                // Act
+                var claims = await AuthenticateUserAsync(server);
+
+                // Assert
+                AssertClaim(claims, claimType, claimValue);
+            }
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/GitHub/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/GitHub/bundle.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/master/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
+  "items": [
+    {
+      "comment": "https://developer.github.com/apps/building-oauth-apps/authorizing-oauth-apps/#2-users-are-redirected-back-to-your-site-by-github",
+      "uri": "https://github.com/login/oauth/access_token",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "secret-access-token",
+        "token_type": "bearer",
+        "scope": "repo,gist"
+      }
+    },
+    {
+      "comment": "See https://developer.github.com/v3/users/#get-the-authenticated-user",
+      "uri": "https://api.github.com/user",
+      "contentFormat": "json",
+      "contentJson": {
+        "login": "octocat",
+        "id": 1,
+        "node_id": "MDQ6VXNlcjE=",
+        "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/octocat",
+        "html_url": "https://github.com/octocat",
+        "followers_url": "https://api.github.com/users/octocat/followers",
+        "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+        "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+        "organizations_url": "https://api.github.com/users/octocat/orgs",
+        "repos_url": "https://api.github.com/users/octocat/repos",
+        "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/octocat/received_events",
+        "type": "User",
+        "site_admin": false,
+        "name": "monalisa octocat",
+        "company": "GitHub",
+        "blog": "https://github.com/blog",
+        "location": "San Francisco",
+        "hireable": false,
+        "bio": "There once was...",
+        "public_repos": 2,
+        "public_gists": 1,
+        "followers": 20,
+        "following": 0,
+        "created_at": "2008-01-14T04:33:35Z",
+        "updated_at": "2008-01-14T04:33:35Z",
+        "private_gists": 81,
+        "total_private_repos": 100,
+        "owned_private_repos": 100,
+        "disk_usage": 10000,
+        "collaborators": 8,
+        "two_factor_authentication": true,
+        "plan": {
+          "name": "Medium",
+          "space": 400,
+          "private_repos": 20,
+          "collaborators": 0
+        }
+      }
+    },
+    {
+      "comment": "See https://developer.github.com/v3/users/emails/#list-email-addresses-for-a-user",
+      "uri": "https://api.github.com/user/emails",
+      "contentFormat": "json",
+      "contentJson": [
+        {
+          "email": "octocat@github.com",
+          "verified": true,
+          "primary": true,
+          "visibility": "public"
+        }
+      ]
+    }
+  ]
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Gitter/GitterTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Gitter/GitterTests.cs
@@ -1,0 +1,46 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AspNet.Security.OAuth.Gitter
+{
+    public class GitterTests : OAuthTests<GitterAuthenticationOptions>
+    {
+        public GitterTests(ITestOutputHelper outputHelper)
+        {
+            OutputHelper = outputHelper;
+        }
+
+        public override string DefaultScheme => GitterAuthenticationDefaults.AuthenticationScheme;
+
+        protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
+        {
+            builder.AddGitter(options => ConfigureDefaults(builder, options));
+        }
+
+        [Theory]
+        [InlineData(ClaimTypes.NameIdentifier, "my-id")]
+        [InlineData(ClaimTypes.Name, "John Smith")]
+        public async Task Can_Sign_In_Using_Gitter(string claimType, string claimValue)
+        {
+            // Arrange
+            using (var server = CreateTestServer())
+            {
+                // Act
+                var claims = await AuthenticateUserAsync(server);
+
+                // Assert
+                AssertClaim(claims, claimType, claimValue);
+            }
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Gitter/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Gitter/bundle.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/master/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
+  "items": [
+    {
+      "uri": "https://gitter.im/login/oauth/token",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "secret-access-token",
+        "token_type": "access",
+        "refresh_token": "secret-refresh-token",
+        "expires_in": "300"
+      }
+    },
+    {
+      "uri": "https://api.gitter.im/v1/user",
+      "contentFormat": "json",
+      "contentJson": {
+        "id": "my-id",
+        "displayName": "John Smith"
+      }
+    }
+  ]
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/HealthGraph/HealthGraphTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/HealthGraph/HealthGraphTests.cs
@@ -1,0 +1,45 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AspNet.Security.OAuth.HealthGraph
+{
+    public class HealthGraphTests : OAuthTests<HealthGraphAuthenticationOptions>
+    {
+        public HealthGraphTests(ITestOutputHelper outputHelper)
+        {
+            OutputHelper = outputHelper;
+        }
+
+        public override string DefaultScheme => HealthGraphAuthenticationDefaults.AuthenticationScheme;
+
+        protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
+        {
+            builder.AddHealthGraph(options => ConfigureDefaults(builder, options));
+        }
+
+        [Theory]
+        [InlineData(ClaimTypes.NameIdentifier, "my-id")]
+        public async Task Can_Sign_In_Using_HealthGraph(string claimType, string claimValue)
+        {
+            // Arrange
+            using (var server = CreateTestServer())
+            {
+                // Act
+                var claims = await AuthenticateUserAsync(server);
+
+                // Assert
+                AssertClaim(claims, claimType, claimValue);
+            }
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/HealthGraph/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/HealthGraph/bundle.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/master/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
+  "items": [
+    {
+      "uri": "https://runkeeper.com/apps/token",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "secret-access-token",
+        "token_type": "access",
+        "refresh_token": "secret-refresh-token",
+        "expires_in": "300"
+      }
+    },
+    {
+      "uri": "https://api.runkeeper.com/user",
+      "contentFormat": "json",
+      "contentJson": {
+        "userID": "my-id"
+      }
+    }
+  ]
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Imgur/ImgurTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Imgur/ImgurTests.cs
@@ -1,0 +1,50 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AspNet.Security.OAuth.Imgur
+{
+    public class ImgurTests : OAuthTests<ImgurAuthenticationOptions>
+    {
+        public ImgurTests(ITestOutputHelper outputHelper)
+        {
+            OutputHelper = outputHelper;
+        }
+
+        public override string DefaultScheme => ImgurAuthenticationDefaults.AuthenticationScheme;
+
+        protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
+        {
+            builder.AddImgur(options => ConfigureDefaults(builder, options));
+        }
+
+        [Theory]
+        [InlineData(ClaimTypes.NameIdentifier, "my-id")]
+        [InlineData(ClaimTypes.Name, "John Smith")]
+        [InlineData("urn:imgur:bio", "Software developer")]
+        [InlineData("urn:imgur:created", "2019-03-17T13:57:00+00:00")]
+        [InlineData("urn:imgur:proexpiration", "2019-03-17T14:00:00+00:00")]
+        [InlineData("urn:imgur:reputation", "0")]
+        public async Task Can_Sign_In_Using_Imgur(string claimType, string claimValue)
+        {
+            // Arrange
+            using (var server = CreateTestServer())
+            {
+                // Act
+                var claims = await AuthenticateUserAsync(server);
+
+                // Assert
+                AssertClaim(claims, claimType, claimValue);
+            }
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Imgur/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Imgur/bundle.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/master/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
+  "items": [
+    {
+      "uri": "https://api.imgur.com/oauth2/token",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "secret-access-token",
+        "token_type": "access",
+        "refresh_token": "secret-refresh-token",
+        "expires_in": "300"
+      }
+    },
+    {
+      "uri": "https://api.imgur.com/3/account/me",
+      "contentFormat": "json",
+      "contentJson": {
+        "data": {
+          "id": "my-id",
+          "url": "John Smith",
+          "bio": "Software developer",
+          "reputation": "0",
+          "created": "2019-03-17T13:57:00+00:00",
+          "pro_expiration": "2019-03-17T14:00:00+00:00"
+        }
+      }
+    }
+  ]
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Infrastructure/ApplicationFactory.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Infrastructure/ApplicationFactory.cs
@@ -88,24 +88,24 @@ namespace AspNet.Security.OAuth.Infrastructure
             // or returns the logged in user's claims as XML if the request is authenticated.
             app.UseAuthentication();
 
-            app.Map("/me", (app2) =>
-                    app2.Run(async context =>
+            app.Map("/me", childApp => childApp.Run(
+                async context =>
+                {
+                    if (context.User.Identity.IsAuthenticated)
                     {
-                        if (context.User.Identity.IsAuthenticated)
-                        {
-                            var xml = IdentityToXmlString(context.User);
-                            var buffer = Encoding.UTF8.GetBytes(xml.ToString());
+                        var xml = IdentityToXmlString(context.User);
+                        var buffer = Encoding.UTF8.GetBytes(xml.ToString());
 
-                            context.Response.StatusCode = 200;
-                            context.Response.ContentType = "text/xml";
+                        context.Response.StatusCode = 200;
+                        context.Response.ContentType = "text/xml";
                                
-                            await context.Response.Body.WriteAsync(buffer, 0, buffer.Length);
-                        }
-                        else
-                        {
-                            await context.ChallengeAsync();
-                        }
-                    }));
+                        await context.Response.Body.WriteAsync(buffer, 0, buffer.Length);
+                    }
+                    else
+                    {
+                        await context.ChallengeAsync();
+                    }
+                }));
         }
 
         private static string IdentityToXmlString(ClaimsPrincipal user)

--- a/test/AspNet.Security.OAuth.Providers.Tests/Infrastructure/ApplicationFactory.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Infrastructure/ApplicationFactory.cs
@@ -1,0 +1,139 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System;
+using System.Security.Claims;
+using System.Text;
+using System.Xml.Linq;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.OAuth;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http;
+using Microsoft.Extensions.Logging;
+
+namespace AspNet.Security.OAuth.Infrastructure
+{
+    /// <summary>
+    /// Represents a factory that creates a test application for remote OAuth-based authentication providers.
+    /// </summary>
+    public static class ApplicationFactory
+    {
+        /// <summary>
+        /// Creates a test application for the specified type of authentication.
+        /// </summary>
+        /// <typeparam name="TOptions">The type of the configuration options for the authentication provider.</typeparam>
+        /// <param name="tests">The test class to configure the application for.</param>
+        /// <param name="configureServices">An optional delegate to configure additional application services.</param>
+        /// <returns>
+        /// The test application to use for the authentication provider.
+        /// </returns>
+        public static WebApplicationFactory<Program> CreateApplication<TOptions>(OAuthTests<TOptions> tests, Action<IServiceCollection> configureServices = null)
+            where TOptions : OAuthOptions
+        {
+            return new TestApplicationFactory()
+                .WithWebHostBuilder(builder =>
+                {
+                    Configure(builder, tests);
+
+                    if (configureServices != null)
+                    {
+                        builder.ConfigureServices(configureServices);
+                    }
+                });
+        }
+
+        private static void Configure<TOptions>(IWebHostBuilder builder, OAuthTests<TOptions> tests)
+            where TOptions : OAuthOptions
+        {
+            // Use a dummy content root
+            builder.UseContentRoot(".");
+
+            // Route application logs to xunit output for debugging
+            builder.ConfigureLogging(logging =>
+            {
+                logging.AddXUnit(tests)
+                       .SetMinimumLevel(LogLevel.Information);
+            });
+
+            // Configure the test application
+            builder.Configure(ConfigureApplication)
+                   .ConfigureServices(services =>
+                    {
+                        // Allow HTTP requests to external services to be intercepted
+                        services.AddHttpClient();
+                        services.AddSingleton<IHttpMessageHandlerBuilderFilter, HttpRequestInterceptionFilter>(
+                            (_) => new HttpRequestInterceptionFilter(tests.Interceptor));
+
+                        // Set up the test endpoint
+                        services.AddRouting();
+
+                        // Configure authentication
+                        var authentication = services
+                            .AddAuthentication("External")
+                            .AddCookie("External", o => o.ForwardChallenge = tests.DefaultScheme);
+
+                        tests.RegisterAuthentication(authentication);
+                    });
+        }
+
+        private static void ConfigureApplication(IApplicationBuilder app)
+        {
+            // Configure a single HTTP resource that challenges the client if unauthenticated
+            // or returns the logged in user's claims as XML if the request is authenticated.
+            app.UseAuthentication();
+
+            app.Map("/me", (app2) =>
+                    app2.Run(async context =>
+                    {
+                        if (context.User.Identity.IsAuthenticated)
+                        {
+                            var xml = IdentityToXmlString(context.User);
+                            var buffer = Encoding.UTF8.GetBytes(xml.ToString());
+
+                            context.Response.StatusCode = 200;
+                            context.Response.ContentType = "text/xml";
+                               
+                            await context.Response.Body.WriteAsync(buffer, 0, buffer.Length);
+                        }
+                        else
+                        {
+                            await context.ChallengeAsync();
+                        }
+                    }));
+        }
+
+        private static string IdentityToXmlString(ClaimsPrincipal user)
+        {
+            var element = new XElement("claims");
+
+            foreach (var identity in user.Identities)
+            {
+                foreach (var claim in identity.Claims)
+                {
+                    var node = new XElement(
+                        "claim",
+                        new XAttribute("type", claim.Type),
+                        new XAttribute("value", claim.Value),
+                        new XAttribute("valueType", claim.ValueType),
+                        new XAttribute("issuer", claim.Issuer));
+
+                    element.Add(node);
+                }
+            }
+
+            return element.ToString();
+        }
+
+        private sealed class TestApplicationFactory : WebApplicationFactory<Program>
+        {
+            protected override IWebHostBuilder CreateWebHostBuilder()
+                => new WebHostBuilder();
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Infrastructure/HttpRequestInterceptionFilter.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Infrastructure/HttpRequestInterceptionFilter.cs
@@ -1,0 +1,34 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System;
+using JustEat.HttpClientInterception;
+using Microsoft.Extensions.Http;
+
+namespace AspNet.Security.OAuth.Infrastructure
+{
+    /// <summary>
+    /// Registers an delegating handler to intercept HTTP requests made by the test application.
+    /// </summary>
+    internal sealed class HttpRequestInterceptionFilter : IHttpMessageHandlerBuilderFilter
+    {
+        private readonly HttpClientInterceptorOptions _options;
+
+        internal HttpRequestInterceptionFilter(HttpClientInterceptorOptions options)
+        {
+            _options = options;
+        }
+
+        public Action<HttpMessageHandlerBuilder> Configure(Action<HttpMessageHandlerBuilder> next)
+        {
+            return builder =>
+            {
+                next(builder);
+                builder.AdditionalHandlers.Add(_options.CreateHttpMessageHandler());
+            };
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Infrastructure/LoopbackRedirectHandler.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Infrastructure/LoopbackRedirectHandler.cs
@@ -1,0 +1,64 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web;
+
+namespace AspNet.Security.OAuth.Infrastructure
+{
+    /// <summary>
+    /// A delegating HTTP handler that loops back HTTP requests to external login providers to the local sign-in endpoint.
+    /// </summary>
+    internal sealed class LoopbackRedirectHandler : DelegatingHandler
+    {
+        public string RedirectUri { get; set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var result = await base.SendAsync(request, cancellationToken);
+
+            // Follow the redirects to external services, assuming they are OAuth-based
+            if (result.StatusCode == System.Net.HttpStatusCode.Found &&
+                !string.Equals(result.Headers.Location?.Host, "localhost", StringComparison.OrdinalIgnoreCase))
+            {
+                // Rewrite the URI to loop back to the redirected URL to simulate the user having
+                // successfully authenticated with the external login page they were redirected to.
+                var queryString = HttpUtility.ParseQueryString(result.Headers.Location.Query);
+
+                string location = queryString["redirect_uri"] ?? RedirectUri;
+                string state = queryString["state"];
+
+                queryString.Clear();
+
+                queryString.Add("code", "a6ed8e7f-471f-44f1-903b-65946475f351");
+                queryString.Add("state", state);
+
+                var builder = new UriBuilder(location)
+                {
+                    Query = queryString.ToString(),
+                };
+
+                var redirectRequest = new HttpRequestMessage(request.Method, builder.Uri);
+
+                // Forward on the headers and cookies
+                foreach (var header in result.Headers)
+                {
+                    redirectRequest.Headers.Add(header.Key, header.Value);
+                }
+
+                redirectRequest.Headers.Add("Cookie", result.Headers.GetValues("Set-Cookie"));
+
+                // Follow the redirect URI
+                return await base.SendAsync(redirectRequest, cancellationToken);
+            }
+
+            return result;
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Infrastructure/Program.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Infrastructure/Program.cs
@@ -1,0 +1,15 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+namespace AspNet.Security.OAuth.Infrastructure
+{
+    /// <summary>
+    /// A stub class representing the program class for the test application.
+    /// </summary>
+    public sealed class Program
+    {
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Instagram/InstagramTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Instagram/InstagramTests.cs
@@ -1,0 +1,46 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AspNet.Security.OAuth.Instagram
+{
+    public class InstagramTests : OAuthTests<InstagramAuthenticationOptions>
+    {
+        public InstagramTests(ITestOutputHelper outputHelper)
+        {
+            OutputHelper = outputHelper;
+        }
+
+        public override string DefaultScheme => InstagramAuthenticationDefaults.AuthenticationScheme;
+
+        protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
+        {
+            builder.AddInstagram(options => ConfigureDefaults(builder, options));
+        }
+
+        [Theory]
+        [InlineData(ClaimTypes.NameIdentifier, "my-id")]
+        [InlineData(ClaimTypes.Name, "John Smith")]
+        public async Task Can_Sign_In_Using_Instagram(string claimType, string claimValue)
+        {
+            // Arrange
+            using (var server = CreateTestServer())
+            {
+                // Act
+                var claims = await AuthenticateUserAsync(server);
+
+                // Assert
+                AssertClaim(claims, claimType, claimValue);
+            }
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Instagram/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Instagram/bundle.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/master/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
+  "items": [
+    {
+      "uri": "https://api.instagram.com/oauth/access_token",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "secret-access-token",
+        "token_type": "access",
+        "refresh_token": "secret-refresh-token",
+        "expires_in": "300"
+      }
+    },
+    {
+      "uri": "https://api.instagram.com/v1/users/self?access_token=secret-access-token",
+      "contentFormat": "json",
+      "contentJson": {
+        "data": {
+          "id": "my-id",
+          "full_name": "John Smith"
+        }
+      }
+    }
+  ]
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/LinkedIn/LinkedInTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/LinkedIn/LinkedInTests.cs
@@ -1,0 +1,50 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AspNet.Security.OAuth.LinkedIn
+{
+    public class LinkedInTests : OAuthTests<LinkedInAuthenticationOptions>
+    {
+        public LinkedInTests(ITestOutputHelper outputHelper)
+        {
+            OutputHelper = outputHelper;
+        }
+
+        public override string DefaultScheme => LinkedInAuthenticationDefaults.AuthenticationScheme;
+
+        protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
+        {
+            builder.AddLinkedIn(options => ConfigureDefaults(builder, options));
+        }
+
+        [Theory]
+        [InlineData(ClaimTypes.NameIdentifier, "1R2RtA")]
+        [InlineData(ClaimTypes.Name, "Frodo Baggins")]
+        [InlineData(ClaimTypes.Email, "frodo@shire.middleearth")]
+        [InlineData(ClaimTypes.GivenName, "Frodo")]
+        [InlineData(ClaimTypes.Surname, "Baggins")]
+        [InlineData("urn:linkedin:headline", "Jewelery Repossession in Middle Earth")]
+        public async Task Can_Sign_In_Using_LinkedIn(string claimType, string claimValue)
+        {
+            // Arrange
+            using (var server = CreateTestServer())
+            {
+                // Act
+                var claims = await AuthenticateUserAsync(server);
+
+                // Assert
+                AssertClaim(claims, claimType, claimValue);
+            }
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/LinkedIn/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/LinkedIn/bundle.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/master/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
+  "items": [
+    {
+      "comment": "https://docs.microsoft.com/en-us/linkedin/shared/authentication/authorization-code-flow?context=linkedin/consumer/context",
+      "uri": "https://www.linkedin.com/oauth/v2/accessToken",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "secret-access-token",
+        "expires_in": "300"
+      }
+    },
+    {
+      "comment": "https://developer.linkedin.com/docs/signin-with-linkedin",
+      "uri": "https://api.linkedin.com/v1/people/~:(id,first-name,last-name,formatted-name,email-address)",
+      "contentFormat": "json",
+      "contentJson": {
+        "firstName": "Frodo",
+        "headline": "Jewelery Repossession in Middle Earth",
+        "id": "1R2RtA",
+        "lastName": "Baggins",
+        "formattedName": "Frodo Baggins",
+        "emailAddress": "frodo@shire.middleearth",
+        "siteStandardProfileRequest": {
+          "url": "https://www.linkedin.com/profile/view?id=frodo-baggins"
+        }
+      }
+    }
+  ]
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/MailChimp/MailChimpTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/MailChimp/MailChimpTests.cs
@@ -1,0 +1,47 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AspNet.Security.OAuth.MailChimp
+{
+    public class MailChimpTests : OAuthTests<MailChimpAuthenticationOptions>
+    {
+        public MailChimpTests(ITestOutputHelper outputHelper)
+        {
+            OutputHelper = outputHelper;
+        }
+
+        public override string DefaultScheme => MailChimpAuthenticationDefaults.AuthenticationScheme;
+
+        protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
+        {
+            builder.AddMailChimp(options => ConfigureDefaults(builder, options));
+        }
+
+        [Theory]
+        [InlineData(ClaimTypes.NameIdentifier, "my-id")]
+        [InlineData(ClaimTypes.Name, "John Smith")]
+        [InlineData(ClaimTypes.Email, "john@john-smith.local")]
+        public async Task Can_Sign_In_Using_MailChimp(string claimType, string claimValue)
+        {
+            // Arrange
+            using (var server = CreateTestServer())
+            {
+                // Act
+                var claims = await AuthenticateUserAsync(server);
+
+                // Assert
+                AssertClaim(claims, claimType, claimValue);
+            }
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/MailChimp/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/MailChimp/bundle.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/master/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
+  "items": [
+    {
+      "uri": "https://login.mailchimp.com/oauth2/token",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "secret-access-token",
+        "token_type": "access",
+        "refresh_token": "secret-refresh-token",
+        "expires_in": "300"
+      }
+    },
+    {
+      "uri": "https://login.mailchimp.com/oauth2/metadata",
+      "contentFormat": "json",
+      "contentJson": {
+        "accountname": "John Smith",
+        "login": {
+          "login_id": "my-id",
+          "login_email": "john@john-smith.local"
+        }
+      }
+    }
+  ]
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Myob/MyobTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Myob/MyobTests.cs
@@ -1,0 +1,46 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AspNet.Security.OAuth.Myob
+{
+    public class MyobTests : OAuthTests<MyobAuthenticationOptions>
+    {
+        public MyobTests(ITestOutputHelper outputHelper)
+        {
+            OutputHelper = outputHelper;
+        }
+
+        public override string DefaultScheme => MyobAuthenticationDefaults.AuthenticationScheme;
+
+        protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
+        {
+            builder.AddMyob(options => ConfigureDefaults(builder, options));
+        }
+
+        [Theory]
+        [InlineData(ClaimTypes.NameIdentifier, "my-id")]
+        [InlineData(ClaimTypes.Name, "John Smith")]
+        public async Task Can_Sign_In_Using_Myob(string claimType, string claimValue)
+        {
+            // Arrange
+            using (var server = CreateTestServer())
+            {
+                // Act
+                var claims = await AuthenticateUserAsync(server);
+
+                // Assert
+                AssertClaim(claims, claimType, claimValue);
+            }
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Myob/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Myob/bundle.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/master/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
+  "items": [
+    {
+      "uri": "https://secure.myob.com/oauth2/v1/authorize",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "secret-access-token",
+        "token_type": "access",
+        "refresh_token": "secret-refresh-token",
+        "expires_in": "300",
+        "user": {
+          "uid": "my-id",
+          "username": "John Smith"
+        }
+      }
+    }
+  ]
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/OAuthTests`1.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/OAuthTests`1.cs
@@ -171,7 +171,7 @@ namespace AspNet.Security.OAuth
             if (DateTimeOffset.TryParse(actualValue, out var actualAsDate) &&
                 DateTimeOffset.TryParse(claimValue, out var expectedAsDate))
             {
-                actualAsDate.ShouldBe(expectedAsDate);
+                actualAsDate.UtcDateTime.ShouldBe(expectedAsDate.UtcDateTime);
             }
             else
             {

--- a/test/AspNet.Security.OAuth.Providers.Tests/OAuthTests`1.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/OAuthTests`1.cs
@@ -1,0 +1,182 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using AspNet.Security.OAuth.Infrastructure;
+using JustEat.HttpClientInterception;
+using MartinCostello.Logging.XUnit;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.OAuth;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit.Abstractions;
+
+namespace AspNet.Security.OAuth
+{
+    /// <summary>
+    /// The base class for integration tests for OAuth-based authentication providers.
+    /// </summary>
+    /// <typeparam name="TOptions">The options type for the authentication provider being tested.</typeparam>
+    public abstract class OAuthTests<TOptions> : ITestOutputHelperAccessor
+        where TOptions : OAuthOptions
+    {
+        protected OAuthTests()
+        {
+            Interceptor = new HttpClientInterceptorOptions()
+                .ThrowsOnMissingRegistration()
+                .RegisterBundle(Path.Combine(GetType().Name.Replace("Tests", string.Empty), "bundle.json"));
+        }
+
+        /// <summary>
+        /// Gets or sets the xunit test output helper to route application logs to.
+        /// </summary>
+        public ITestOutputHelper OutputHelper { get; set; }
+
+        /// <summary>
+        /// Gets the interceptor to use for configuring stubbed HTTP responses.
+        /// </summary>
+        public HttpClientInterceptorOptions Interceptor { get; }
+
+        /// <summary>
+        /// Gets the name of the authentication scheme being tested.
+        /// </summary>
+        public abstract string DefaultScheme { get; }
+
+        /// <summary>
+        /// Gets the optional redirect URI to use for OAuth flows.
+        /// </summary>
+        protected virtual string RedirectUri { get; }
+
+        /// <summary>
+        /// Registers authentication for the test.
+        /// </summary>
+        /// <param name="builder">The authentication builder to register authentication with.</param>
+        protected internal abstract void RegisterAuthentication(AuthenticationBuilder builder);
+
+        /// <summary>
+        /// Configures the default authentication options.
+        /// </summary>
+        /// <param name="builder">The authentication builder to use.</param>
+        /// <param name="options">The authentication options to configure.</param>
+        protected virtual void ConfigureDefaults(AuthenticationBuilder builder, TOptions options)
+        {
+            options.ClientId = "my-client-id";
+            options.ClientSecret = "my-client-secret";
+            options.Backchannel = CreateBackchannel(builder);
+        }
+
+        /// <summary>
+        /// Creates the test application for authentication.
+        /// </summary>
+        /// <param name="configureServices">An optional method to configure additional application services.</param>
+        /// <returns>
+        /// The test application to use for authentication.
+        /// </returns>
+        protected WebApplicationFactory<Program> CreateTestServer(Action<IServiceCollection> configureServices = null)
+            => ApplicationFactory.CreateApplication(this, configureServices);
+
+        /// <summary>
+        /// Creates the backchannel for an authentication provider to configures interception for HTTP requests.
+        /// </summary>
+        /// <param name="builder">The authentication builder.</param>
+        /// <returns>
+        /// The HTTP client to use for the remote identity provider.
+        /// </returns>
+        protected HttpClient CreateBackchannel(AuthenticationBuilder builder)
+            => builder.Services.BuildServiceProvider().GetRequiredService<IHttpClientFactory>().CreateClient();
+
+        /// <summary>
+        /// Asynchronously authenticates the user and returns the claims associated with the authenticated user.
+        /// </summary>
+        /// <param name="server">The test server to use to authenticate the user.</param>
+        /// <returns>
+        /// A dictionary containing the claims for the authenticated user.
+        /// </returns>
+        protected async Task<IDictionary<string, Claim>> AuthenticateUserAsync(WebApplicationFactory<Program> server)
+        {
+            IEnumerable<string> cookies;
+
+            // Arrange - Force a request chain that challenges the request to the authentication
+            // handler and returns an authentication cookie to log the user in to the application.
+            using (var client = server.CreateDefaultClient(new LoopbackRedirectHandler() { RedirectUri = RedirectUri }))
+            {
+                // Act
+                using (var result = await client.GetAsync("/me"))
+                {
+                    // Assert
+                    result.StatusCode.ShouldBe(HttpStatusCode.Found);
+
+                    cookies = result.Headers.GetValues("Set-Cookie");
+                }
+            }
+
+            XElement element;
+
+            // Arrange - Perform an authenticated HTTP request to get the claims for the logged-in users
+            using (var client = server.CreateDefaultClient())
+            {
+                client.DefaultRequestHeaders.Add("Cookie", cookies);
+
+                // Act
+                using (var result = await client.GetAsync("/me"))
+                {
+                    // Assert
+                    result.StatusCode.ShouldBe(HttpStatusCode.OK);
+                    result.Content.Headers.ContentType.MediaType.ShouldBe("text/xml");
+
+                    string xml = await result.Content.ReadAsStringAsync();
+
+                    element = XElement.Parse(xml);
+                }
+            }
+
+            element.Name.ShouldBe("claims");
+            element.Elements("claim").Count().ShouldBeGreaterThanOrEqualTo(1);
+
+            var claims = new List<Claim>();
+
+            foreach (var claim in element.Elements("claim"))
+            {
+                claims.Add(
+                    new Claim(
+                        claim.Attribute("type").Value,
+                        claim.Attribute("value").Value,
+                        claim.Attribute("valueType").Value,
+                        claim.Attribute("issuer").Value));
+            }
+
+            return claims.ToDictionary((key) => key.Type, (value) => value);
+        }
+
+        protected void AssertClaim(IDictionary<string, Claim> actual, string claimType, string claimValue)
+        {
+            actual.ShouldContainKey(claimType);
+
+            string actualValue = actual[claimType].Value;
+
+            // Parse date strings as DateTimeOffsets so that local time zone differences
+            // do not cause claims which are ISO date values to fail to assert correctly.
+            if (DateTimeOffset.TryParse(actualValue, out var actualAsDate) &&
+                DateTimeOffset.TryParse(claimValue, out var expectedAsDate))
+            {
+                actualAsDate.ShouldBe(expectedAsDate);
+            }
+            else
+            {
+                actualValue.ShouldBe(claimValue);
+            }
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Onshape/OnshapeTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Onshape/OnshapeTests.cs
@@ -1,0 +1,46 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AspNet.Security.OAuth.Onshape
+{
+    public class OnshapeTests : OAuthTests<OnshapeAuthenticationOptions>
+    {
+        public OnshapeTests(ITestOutputHelper outputHelper)
+        {
+            OutputHelper = outputHelper;
+        }
+
+        public override string DefaultScheme => OnshapeAuthenticationDefaults.AuthenticationScheme;
+
+        protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
+        {
+            builder.AddOnshape(options => ConfigureDefaults(builder, options));
+        }
+
+        [Theory]
+        [InlineData(ClaimTypes.NameIdentifier, "my-id")]
+        [InlineData(ClaimTypes.Name, "John Smith")]
+        public async Task Can_Sign_In_Using_Onshape(string claimType, string claimValue)
+        {
+            // Arrange
+            using (var server = CreateTestServer())
+            {
+                // Act
+                var claims = await AuthenticateUserAsync(server);
+
+                // Assert
+                AssertClaim(claims, claimType, claimValue);
+            }
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Onshape/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Onshape/bundle.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/master/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
+  "items": [
+    {
+      "uri": "https://cad.onshape.com/oauth/token",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "secret-access-token",
+        "token_type": "access",
+        "refresh_token": "secret-refresh-token",
+        "expires_in": "300"
+      }
+    },
+    {
+      "uri": "https://cad.onshape.com/api/users/session",
+      "contentFormat": "json",
+      "contentJson": {
+        "id": "my-id",
+        "name": "John Smith"
+      }
+    }
+  ]
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Patreon/PatreonTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Patreon/PatreonTests.cs
@@ -1,0 +1,48 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AspNet.Security.OAuth.Patreon
+{
+    public class PatreonTests : OAuthTests<PatreonAuthenticationOptions>
+    {
+        public PatreonTests(ITestOutputHelper outputHelper)
+        {
+            OutputHelper = outputHelper;
+        }
+
+        public override string DefaultScheme => PatreonAuthenticationDefaults.AuthenticationScheme;
+
+        protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
+        {
+            builder.AddPatreon(options => ConfigureDefaults(builder, options));
+        }
+
+        [Theory]
+        [InlineData(ClaimTypes.NameIdentifier, "my-id")]
+        [InlineData(ClaimTypes.Name, "John Smith")]
+        [InlineData(ClaimTypes.Webpage, "https://patreon.local/JohnSmith")]
+        [InlineData("urn:patreon:avatar", "https://patreon.local/JohnSmith/avatar.png")]
+        public async Task Can_Sign_In_Using_Patreon(string claimType, string claimValue)
+        {
+            // Arrange
+            using (var server = CreateTestServer())
+            {
+                // Act
+                var claims = await AuthenticateUserAsync(server);
+
+                // Assert
+                AssertClaim(claims, claimType, claimValue);
+            }
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Patreon/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Patreon/bundle.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/master/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
+  "items": [
+    {
+      "uri": "https://api.patreon.com/oauth2/token",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "secret-access-token",
+        "token_type": "access",
+        "refresh_token": "secret-refresh-token",
+        "expires_in": "300"
+      }
+    },
+    {
+      "uri": "https://api.patreon.com/oauth2/api/current_user",
+      "contentFormat": "json",
+      "contentJson": {
+        "data": {
+          "id": "my-id",
+          "attributes": {
+            "full_name": "John Smith",
+            "url": "https://patreon.local/JohnSmith",
+            "thumb_url": "https://patreon.local/JohnSmith/avatar.png"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Paypal/PaypalTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Paypal/PaypalTests.cs
@@ -1,0 +1,49 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AspNet.Security.OAuth.Paypal
+{
+    public class PaypalTests : OAuthTests<PaypalAuthenticationOptions>
+    {
+        public PaypalTests(ITestOutputHelper outputHelper)
+        {
+            OutputHelper = outputHelper;
+        }
+
+        public override string DefaultScheme => PaypalAuthenticationDefaults.AuthenticationScheme;
+
+        protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
+        {
+            builder.AddPaypal(options => ConfigureDefaults(builder, options));
+        }
+
+        [Theory]
+        [InlineData(ClaimTypes.NameIdentifier, "mWq6_1sU85v5EG9yHdPxJRrhGHrnMJ-1PQKtX6pcsmA")]
+        [InlineData(ClaimTypes.Name, "identity test")]
+        [InlineData(ClaimTypes.Email, "user1@example.com")]
+        [InlineData(ClaimTypes.GivenName, "identity")]
+        [InlineData(ClaimTypes.Surname, "test")]
+        public async Task Can_Sign_In_Using_Paypal(string claimType, string claimValue)
+        {
+            // Arrange
+            using (var server = CreateTestServer())
+            {
+                // Act
+                var claims = await AuthenticateUserAsync(server);
+
+                // Assert
+                AssertClaim(claims, claimType, claimValue);
+            }
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Paypal/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Paypal/bundle.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/master/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
+  "items": [
+    {
+      "uri": "https://api.paypal.com/v1/identity/openidconnect/tokenservice",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "secret-access-token",
+        "token_type": "access",
+        "refresh_token": "secret-refresh-token",
+        "expires_in": "300"
+      }
+    },
+    {
+      "comment": "https://developer.paypal.com/docs/api/identity/v1/#userinfo",
+      "uri": "https://api.paypal.com/v1/identity/openidconnect/userinfo?schema=openid",
+      "contentFormat": "json",
+      "contentJson": {
+        "user_id": "https://www.paypal.com/webapps/auth/identity/user/mWq6_1sU85v5EG9yHdPxJRrhGHrnMJ-1PQKtX6pcsmA",
+        "name": "identity test",
+        "given_name": "identity",
+        "family_name": "test",
+        "payer_id": "WDJJHEBZ4X2LY",
+        "address": {
+          "street_address": "1 Main St",
+          "locality": "San Jose",
+          "region": "CA",
+          "postal_code": "95131",
+          "country": "US"
+        },
+        "verified_account": "true",
+        "email": "user1@example.com"
+      }
+    }
+  ]
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/QQ/QQTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/QQ/QQTests.cs
@@ -1,0 +1,51 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AspNet.Security.OAuth.QQ
+{
+    public class QQTests : OAuthTests<QQAuthenticationOptions>
+    {
+        public QQTests(ITestOutputHelper outputHelper)
+        {
+            OutputHelper = outputHelper;
+        }
+
+        public override string DefaultScheme => QQAuthenticationDefaults.AuthenticationScheme;
+
+        protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
+        {
+            builder.AddQQ(options => ConfigureDefaults(builder, options));
+        }
+
+        [Theory]
+        [InlineData(ClaimTypes.Name, "John Smith")]
+        [InlineData(ClaimTypes.Gender, "Male")]
+        [InlineData("urn:qq:picture", "https://qq.local/picture.png")]
+        [InlineData("urn:qq:picture_medium", "https://qq.local/picture-medium.png")]
+        [InlineData("urn:qq:picture_full", "https://qq.local/picture-large.png")]
+        [InlineData("urn:qq:avatar", "https://qq.local/avatar.png")]
+        [InlineData("urn:qq:avatar_full", "https://qq.local/avatar-large.png")]
+        public async Task Can_Sign_In_Using_QQ(string claimType, string claimValue)
+        {
+            // Arrange
+            using (var server = CreateTestServer())
+            {
+                // Act
+                var claims = await AuthenticateUserAsync(server);
+
+                // Assert
+                AssertClaim(claims, claimType, claimValue);
+            }
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/QQ/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/QQ/bundle.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/master/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
+  "items": [
+    {
+      "uri": "https://graph.qq.com/oauth2.0/token?client_id=my-client-id&client_secret=my-client-secret&redirect_uri=http%3A%2F%2Flocalhost%2Fsignin-qq&code=a6ed8e7f-471f-44f1-903b-65946475f351&grant_type=authorization_code",
+      "contentString": "access_token=secret-access-token&token_type=access&refresh_token=secret-refresh-token"
+    },
+    {
+      "uri": "https://graph.qq.com/oauth2.0/me?access_token=secret-access-token",
+      "contentFormat": "json",
+      "contentJson": {
+        "openid": "my-open-id"
+      }
+    },
+    {
+      "uri": "https://graph.qq.com/user/get_user_info?oauth_consumer_key=my-client-id&access_token=secret-access-token&openid=my-open-id",
+      "contentFormat": "json",
+      "contentJson": {
+        "ret": 0,
+        "nickname": "John Smith",
+        "gender": "Male",
+        "figureurl": "https://qq.local/picture.png",
+        "figureurl_1": "https://qq.local/picture-medium.png",
+        "figureurl_2": "https://qq.local/picture-large.png",
+        "figureurl_qq_1": "https://qq.local/avatar.png",
+        "figureurl_qq_2": "https://qq.local/avatar-large.png"
+      }
+    }
+  ]
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Reddit/RedditTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Reddit/RedditTests.cs
@@ -1,0 +1,47 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AspNet.Security.OAuth.Reddit
+{
+    public class RedditTests : OAuthTests<RedditAuthenticationOptions>
+    {
+        public RedditTests(ITestOutputHelper outputHelper)
+        {
+            OutputHelper = outputHelper;
+        }
+
+        public override string DefaultScheme => RedditAuthenticationDefaults.AuthenticationScheme;
+
+        protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
+        {
+            builder.AddReddit(options => ConfigureDefaults(builder, options));
+        }
+
+        [Theory]
+        [InlineData(ClaimTypes.NameIdentifier, "my-id")]
+        [InlineData(ClaimTypes.Name, "John Smith")]
+        [InlineData("urn:reddit:over18", "True")]
+        public async Task Can_Sign_In_Using_Reddit(string claimType, string claimValue)
+        {
+            // Arrange
+            using (var server = CreateTestServer())
+            {
+                // Act
+                var claims = await AuthenticateUserAsync(server);
+
+                // Assert
+                AssertClaim(claims, claimType, claimValue);
+            }
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Reddit/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Reddit/bundle.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/master/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
+  "items": [
+    {
+      "uri": "https://www.reddit.com/api/v1/access_token",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "secret-access-token",
+        "token_type": "access",
+        "refresh_token": "secret-refresh-token",
+        "expires_in": "300"
+      }
+    },
+    {
+      "uri": "https://oauth.reddit.com/api/v1/me",
+      "contentFormat": "json",
+      "contentJson": {
+        "id": "my-id",
+        "name": "John Smith",
+        "over_18": true
+      }
+    }
+  ]
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Salesforce/SalesforceTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Salesforce/SalesforceTests.cs
@@ -1,0 +1,50 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AspNet.Security.OAuth.Salesforce
+{
+    public class SalesforceTests : OAuthTests<SalesforceAuthenticationOptions>
+    {
+        public SalesforceTests(ITestOutputHelper outputHelper)
+        {
+            OutputHelper = outputHelper;
+        }
+
+        public override string DefaultScheme => SalesforceAuthenticationDefaults.AuthenticationScheme;
+
+        protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
+        {
+            builder.AddSalesforce(options => ConfigureDefaults(builder, options));
+        }
+
+        [Theory]
+        [InlineData(ClaimTypes.NameIdentifier, "005x0000001S2b9")]
+        [InlineData(ClaimTypes.Name, "alanvan")]
+        [InlineData("urn:salesforce:email", "admin@2060747062579699.com")]
+        [InlineData("urn:salesforce:rest_url", "https://yourInstance.salesforce.com/services/data/v{version}/")]
+        [InlineData("urn:salesforce:thumbnail_photo", "https://yourInstance.salesforce.com/profilephoto/005/T")]
+        [InlineData("urn:salesforce:utc_offset", "-28800000")]
+        public async Task Can_Sign_In_Using_Salesforce(string claimType, string claimValue)
+        {
+            // Arrange
+            using (var server = CreateTestServer())
+            {
+                // Act
+                var claims = await AuthenticateUserAsync(server);
+
+                // Assert
+                AssertClaim(claims, claimType, claimValue);
+            }
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Salesforce/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Salesforce/bundle.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/master/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
+  "items": [
+    {
+      "comment": "https://help.salesforce.com/articleView?id=remoteaccess_oauth_jwt_flow.htm&type=0",
+      "uri": "https://login.salesforce.com/services/oauth2/token",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "00Dxx0000001gPL!AR8AQJXg5oj8jXSgxJfA0lBog.39AsX.LVpxezPwuX5VAIrrbbHMuol7GQxnMeYMN7cj8EoWr78nt1u44zU31IbYNNJguseu",
+        "scope": "web openid api id",
+        "instance_url": "https://yourInstance.salesforce.com",
+        "id": "https://test-instance.salesforce.com/id/00Dxx0000001gPLEAY/005xx000001SwiUAAS",
+        "token_type": "Bearer"
+      }
+    },
+    {
+      "comment": "https://help.salesforce.com/articleView?id=remoteaccess_using_openid.htm&type=5",
+      "uri": "https://test-instance.salesforce.com/id/00Dxx0000001gPLEAY/005xx000001SwiUAAS",
+      "contentFormat": "json",
+      "contentJson": {
+        "id": "https://yourInstance.salesforce.com/id/00Dx0000001T0zk/005x0000001S2b9",
+        "asserted_user": true,
+        "user_id": "005x0000001S2b9",
+        "username": "alanvan",
+        "organization_id": "00Dx0000001T0zk",
+        "nick_name": "admin1.2777578168398293E12foofoofoofoo",
+        "display_name": "Alan Van",
+        "email": "admin@2060747062579699.com",
+        "status": {
+          "created_date": null,
+          "body": null
+        },
+        "photos": {
+          "picture": "https://yourInstance.salesforce.com/profilephoto/005/F",
+          "thumbnail": "https://yourInstance.salesforce.com/profilephoto/005/T"
+        },
+        "urls": {
+          "enterprise": "https://yourInstance.salesforce.com/services/Soap/c/{version}/00Dx0000001T0zk",
+          "metadata": "https://yourInstance.salesforce.com/services/Soap/m/{version}/00Dx0000001T0zk",
+          "partner": "https://yourInstance.salesforce.com/services/Soap/u/{version}/00Dx0000001T0zk",
+          "rest": "https://yourInstance.salesforce.com/services/data/v{version}/",
+          "sobjects": "https://yourInstance.salesforce.com/services/data/v{version}/sobjects/",
+          "search": "https://yourInstance.salesforce.com/services/data/v{version}/search/",
+          "query": "https://yourInstance.salesforce.com/services/data/v{version}/query/",
+          "profile": "https://yourInstance.salesforce.com/005x0000001S2b9"
+        },
+        "active": true,
+        "user_type": "STANDARD",
+        "language": "en_US",
+        "locale": "en_US",
+        "utcOffset": -28800000,
+        "last_modified_date": "2010-06-28T20:54:09.000+0000"
+      }
+    }
+  ]
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Slack/SlackTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Slack/SlackTests.cs
@@ -1,0 +1,56 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AspNet.Security.OAuth.Slack
+{
+    public class SlackTests : OAuthTests<SlackAuthenticationOptions>
+    {
+        public SlackTests(ITestOutputHelper outputHelper)
+        {
+            OutputHelper = outputHelper;
+        }
+
+        public override string DefaultScheme => SlackAuthenticationDefaults.AuthenticationScheme;
+
+        protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
+        {
+            builder.AddSlack(options =>
+            {
+                ConfigureDefaults(builder, options);
+                options.Scope.Add("identity.avatar");
+                options.Scope.Add("identity.email");
+                options.Scope.Add("identity.team");
+            });
+        }
+
+        [Theory]
+        [InlineData(ClaimTypes.NameIdentifier, "T0G9PQBBK|U0G9QF9C6")]
+        [InlineData(ClaimTypes.Name, "Sonny Whether")]
+        [InlineData(ClaimTypes.Email, "bobby@example.com")]
+        [InlineData("urn:slack:team_id", "T0G9PQBBK")]
+        [InlineData("urn:slack:team_name", "Captain Fabian's Naval Supply")]
+        [InlineData("urn:slack:user_id", "U0G9QF9C6")]
+        public async Task Can_Sign_In_Using_Slack(string claimType, string claimValue)
+        {
+            // Arrange
+            using (var server = CreateTestServer())
+            {
+                // Act
+                var claims = await AuthenticateUserAsync(server);
+
+                // Assert
+                AssertClaim(claims, claimType, claimValue);
+            }
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Slack/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Slack/bundle.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/master/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
+  "items": [
+    {
+      "comment": "https://api.slack.com/docs/oauth#flow",
+      "uri": "https://slack.com/api/oauth.access",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "xoxp-23984754863-2348975623103",
+        "scope": "read"
+      }
+    },
+    {
+      "comment": "https://api.slack.com/methods/users.identity",
+      "uri": "https://slack.com/api/users.identity?token=xoxp-23984754863-2348975623103",
+      "contentFormat": "json",
+      "contentJson": {
+        "ok": true,
+        "user": {
+          "name": "Sonny Whether",
+          "id": "U0G9QF9C6",
+          "email": "bobby@example.com",
+          "image_24": "https://cdn.example.com/sonny_24.jpg",
+          "image_32": "https://cdn.example.com/sonny_32.jpg",
+          "image_48": "https://cdn.example.com/sonny_48.jpg",
+          "image_72": "https://cdn.example.com/sonny_72.jpg",
+          "image_192": "https://cdn.example.com/sonny_192.jpg"
+        },
+        "team": {
+          "name": "Captain Fabian's Naval Supply",
+          "id": "T0G9PQBBK"
+        }
+      }
+    }
+  ]
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/SoundCloud/SoundCloudTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/SoundCloud/SoundCloudTests.cs
@@ -1,0 +1,50 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AspNet.Security.OAuth.SoundCloud
+{
+    public class SoundCloudTests : OAuthTests<SoundCloudAuthenticationOptions>
+    {
+        public SoundCloudTests(ITestOutputHelper outputHelper)
+        {
+            OutputHelper = outputHelper;
+        }
+
+        public override string DefaultScheme => SoundCloudAuthenticationDefaults.AuthenticationScheme;
+
+        protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
+        {
+            builder.AddSoundCloud(options => ConfigureDefaults(builder, options));
+        }
+
+        [Theory]
+        [InlineData(ClaimTypes.NameIdentifier, "my-id")]
+        [InlineData(ClaimTypes.Name, "John Smith")]
+        [InlineData(ClaimTypes.Country, "GB")]
+        [InlineData("urn:soundcloud:city", "London")]
+        [InlineData("urn:soundcloud:fullname", "John Q Smith")]
+        [InlineData("urn:soundcloud:profileurl", "https://soundcloud.local/JohnSmith")]
+        public async Task Can_Sign_In_Using_SoundCloud(string claimType, string claimValue)
+        {
+            // Arrange
+            using (var server = CreateTestServer())
+            {
+                // Act
+                var claims = await AuthenticateUserAsync(server);
+
+                // Assert
+                AssertClaim(claims, claimType, claimValue);
+            }
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/SoundCloud/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/SoundCloud/bundle.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/master/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
+  "items": [
+    {
+      "uri": "https://api.soundcloud.com/oauth2/token",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "secret-access-token",
+        "token_type": "access",
+        "refresh_token": "secret-refresh-token",
+        "expires_in": "300"
+      }
+    },
+    {
+      "uri": "https://api.soundcloud.com/me?oauth_token=secret-access-token",
+      "contentFormat": "json",
+      "contentJson": {
+        "id": "my-id",
+        "username": "John Smith",
+        "country": "GB",
+        "full_name": "John Q Smith",
+        "city": "London",
+        "permalink_url": "https://soundcloud.local/JohnSmith"
+      }
+    }
+  ]
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Spotify/SpotifyTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Spotify/SpotifyTests.cs
@@ -1,0 +1,53 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AspNet.Security.OAuth.Spotify
+{
+    public class SpotifyTests : OAuthTests<SpotifyAuthenticationOptions>
+    {
+        public SpotifyTests(ITestOutputHelper outputHelper)
+        {
+            OutputHelper = outputHelper;
+        }
+
+        public override string DefaultScheme => SpotifyAuthenticationDefaults.AuthenticationScheme;
+
+        protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
+        {
+            builder.AddSpotify(options => ConfigureDefaults(builder, options));
+        }
+
+        [Theory]
+        [InlineData(ClaimTypes.NameIdentifier, "wizzler")]
+        [InlineData(ClaimTypes.Name, "JM Wizzler")]
+        [InlineData(ClaimTypes.Email, "email@example.com")]
+        [InlineData(ClaimTypes.DateOfBirth, "1937-06-01")]
+        [InlineData(ClaimTypes.Country, "SE")]
+        [InlineData(ClaimTypes.Uri, "spotify:user:wizzler")]
+        [InlineData("urn:spotify:product", "premium")]
+        [InlineData("urn:spotify:url", "https://open.spotify.com/user/wizzler")]
+        [InlineData("urn:spotify:profilepicture", "https://fbcdn-profile-a.akamaihd.net/hprofile-ak-frc3/t1.0-1/1970403_10152215092574354_1798272330_n.jpg")]
+        public async Task Can_Sign_In_Using_Spotify(string claimType, string claimValue)
+        {
+            // Arrange
+            using (var server = CreateTestServer())
+            {
+                // Act
+                var claims = await AuthenticateUserAsync(server);
+
+                // Assert
+                AssertClaim(claims, claimType, claimValue);
+            }
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Spotify/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Spotify/bundle.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/master/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
+  "items": [
+    {
+      "uri": "https://accounts.spotify.com/api/token",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "secret-access-token",
+        "token_type": "access",
+        "refresh_token": "secret-refresh-token",
+        "expires_in": "300"
+      }
+    },
+    {
+      "comment": "https://developer.spotify.com/documentation/web-api/reference/users-profile/get-current-users-profile/",
+      "uri": "https://api.spotify.com/v1/me",
+      "contentFormat": "json",
+      "contentJson": {
+        "birthdate": "1937-06-01",
+        "country": "SE",
+        "display_name": "JM Wizzler",
+        "email": "email@example.com",
+        "external_urls": { "spotify": "https://open.spotify.com/user/wizzler" },
+        "followers": {
+          "href": null,
+          "total": 3829
+        },
+        "href": "https://api.spotify.com/v1/users/wizzler",
+        "id": "wizzler",
+        "images": [
+          {
+            "height": null,
+            "url": "https://fbcdn-profile-a.akamaihd.net/hprofile-ak-frc3/t1.0-1/1970403_10152215092574354_1798272330_n.jpg",
+            "width": null
+          }
+        ],
+        "product": "premium",
+        "type": "user",
+        "uri": "spotify:user:wizzler"
+      }
+    }
+  ]
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/StackExchange/StackExchangeTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/StackExchange/StackExchangeTests.cs
@@ -1,0 +1,48 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AspNet.Security.OAuth.StackExchange
+{
+    public class StackExchangeTests : OAuthTests<StackExchangeAuthenticationOptions>
+    {
+        public StackExchangeTests(ITestOutputHelper outputHelper)
+        {
+            OutputHelper = outputHelper;
+        }
+
+        public override string DefaultScheme => StackExchangeAuthenticationDefaults.AuthenticationScheme;
+
+        protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
+        {
+            builder.AddStackExchange(options => ConfigureDefaults(builder, options));
+        }
+
+        [Theory]
+        [InlineData(ClaimTypes.NameIdentifier, "1")]
+        [InlineData(ClaimTypes.Name, "Example User")]
+        [InlineData(ClaimTypes.Webpage, "https://example.com/")]
+        [InlineData("urn:stackexchange:link", "https://example.stackexchange.com/users/1/example-user")]
+        public async Task Can_Sign_In_Using_StackExchange(string claimType, string claimValue)
+        {
+            // Arrange
+            using (var server = CreateTestServer())
+            {
+                // Act
+                var claims = await AuthenticateUserAsync(server);
+
+                // Assert
+                AssertClaim(claims, claimType, claimValue);
+            }
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/StackExchange/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/StackExchange/bundle.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/master/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
+  "items": [
+    {
+      "comment": "https://api.stackexchange.com/docs/authentication",
+      "uri": "https://stackexchange.com/oauth/access_token",
+      "method": "POST",
+      "contentString": "access_token=secret-access-token"
+    },
+    {
+      "comment": "https://api.stackexchange.com/docs/me",
+      "uri": "https://api.stackexchange.com/2.2/me?access_token=secret-access-token&site=StackOverflow",
+      "contentFormat": "json",
+      "contentJson": {
+        "items": [
+          {
+            "badge_counts": {
+              "bronze": 3,
+              "silver": 2,
+              "gold": 1
+            },
+            "view_count": 1000,
+            "down_vote_count": 50,
+            "up_vote_count": 90,
+            "answer_count": 10,
+            "question_count": 12,
+            "account_id": 1,
+            "is_employee": false,
+            "last_modified_date": 1552753588,
+            "last_access_date": 1552796788,
+            "reputation_change_year": 9001,
+            "reputation_change_quarter": 400,
+            "reputation_change_month": 200,
+            "reputation_change_week": 800,
+            "reputation_change_day": 100,
+            "reputation": 9001,
+            "creation_date": 1552753588,
+            "user_type": "registered",
+            "user_id": 1,
+            "accept_rate": 55,
+            "about_me": "about me block",
+            "location": "An Imaginary World",
+            "website_url": "https://example.com/",
+            "link": "https://example.stackexchange.com/users/1/example-user",
+            "profile_image": "https://www.gravatar.com/avatar/a007be5a61f6aa8f3e85ae2fc18dd66e?d=identicon&r=PG",
+            "display_name": "Example User"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Strava/StravaTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Strava/StravaTests.cs
@@ -1,0 +1,58 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AspNet.Security.OAuth.Strava
+{
+    public class StravaTests : OAuthTests<StravaAuthenticationOptions>
+    {
+        public StravaTests(ITestOutputHelper outputHelper)
+        {
+            OutputHelper = outputHelper;
+        }
+
+        public override string DefaultScheme => StravaAuthenticationDefaults.AuthenticationScheme;
+
+        protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
+        {
+            builder.AddStrava(options => ConfigureDefaults(builder, options));
+        }
+
+        [Theory]
+        [InlineData(ClaimTypes.Country, "US")]
+        [InlineData(ClaimTypes.Email, "john@john-smith.local")]
+        [InlineData(ClaimTypes.Gender, "Male")]
+        [InlineData(ClaimTypes.GivenName, "John")]
+        [InlineData(ClaimTypes.Name, "John Smith")]
+        [InlineData(ClaimTypes.NameIdentifier, "my-id")]
+        [InlineData(ClaimTypes.StateOrProvince, "Washington")]
+        [InlineData(ClaimTypes.Surname, "Smith")]
+        [InlineData("urn:strava:city", "Seattle")]
+        [InlineData("urn:strava:created-at", "2019-03-17T16:12:00+00:00")]
+        [InlineData("urn:strava:premium", "False")]
+        [InlineData("urn:strava:profile", "https://strava.local/images/JohnSmith.png")]
+        [InlineData("urn:strava:profile-medium", "https://strava.local/images/JohnSmith-medium.png")]
+        [InlineData("urn:strava:updated-at", "2019-03-17T16:13:00+00:00")]
+        public async Task Can_Sign_In_Using_Strava(string claimType, string claimValue)
+        {
+            // Arrange
+            using (var server = CreateTestServer())
+            {
+                // Act
+                var claims = await AuthenticateUserAsync(server);
+
+                // Assert
+                AssertClaim(claims, claimType, claimValue);
+            }
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Strava/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Strava/bundle.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/master/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
+  "items": [
+    {
+      "uri": "https://www.strava.com/oauth/token",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "secret-access-token",
+        "token_type": "access",
+        "refresh_token": "secret-refresh-token",
+        "expires_in": "300"
+      }
+    },
+    {
+      "uri": "https://www.strava.com/api/v3/athlete",
+      "contentFormat": "json",
+      "contentJson": {
+        "id": "my-id",
+        "username": "John Smith",
+        "firstname": "John",
+        "lastname": "Smith",
+        "email": "john@john-smith.local",
+        "state": "Washington",
+        "country": "US",
+        "sex": "Male",
+        "city": "Seattle",
+        "profile": "https://strava.local/images/JohnSmith.png",
+        "profile_medium": "https://strava.local/images/JohnSmith-medium.png",
+        "created_at": "2019-03-17T16:12:00+00:00",
+        "updated_at": "2019-03-17T16:13:00+00:00",
+        "premium": false
+      }
+    }
+  ]
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Twitch/TwitchTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Twitch/TwitchTests.cs
@@ -1,0 +1,53 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AspNet.Security.OAuth.Twitch
+{
+    public class TwitchTests : OAuthTests<TwitchAuthenticationOptions>
+    {
+        public TwitchTests(ITestOutputHelper outputHelper)
+        {
+            OutputHelper = outputHelper;
+        }
+
+        public override string DefaultScheme => TwitchAuthenticationDefaults.AuthenticationScheme;
+
+        protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
+        {
+            builder.AddTwitch(options => ConfigureDefaults(builder, options));
+        }
+
+        [Theory]
+        [InlineData(ClaimTypes.NameIdentifier, "44322889")]
+        [InlineData(ClaimTypes.Name, "dallas")]
+        [InlineData(ClaimTypes.Email, "login@provider.com")]
+        [InlineData("urn:twitch:broadcastertype", "Broadcaster")]
+        [InlineData("urn:twitch:description", "Just a gamer playing games and chatting. :)")]
+        [InlineData("urn:twitch:displayname", "Dallas")]
+        [InlineData("urn:twitch:offlineimageurl", "https://static-cdn.jtvnw.net/jtv_user_pictures/dallas-channel_offline_image-1a2c906ee2c35f12-1920x1080.png")]
+        [InlineData("urn:twitch:profileimageurl", "https://static-cdn.jtvnw.net/jtv_user_pictures/dallas-profile_image-1a2c906ee2c35f12-300x300.png")]
+        [InlineData("urn:twitch:type", "staff")]
+        public async Task Can_Sign_In_Using_Twitch(string claimType, string claimValue)
+        {
+            // Arrange
+            using (var server = CreateTestServer())
+            {
+                // Act
+                var claims = await AuthenticateUserAsync(server);
+
+                // Assert
+                AssertClaim(claims, claimType, claimValue);
+            }
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Twitch/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Twitch/bundle.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/master/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
+  "items": [
+    {
+      "uri": "https://id.twitch.tv/oauth2/token",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "secret-access-token",
+        "token_type": "access",
+        "refresh_token": "secret-refresh-token",
+        "expires_in": "300"
+      }
+    },
+    {
+      "comment": "https://dev.twitch.tv/docs/api/reference/#get-users",
+      "uri": "https://api.twitch.tv/helix/users/",
+      "contentFormat": "json",
+      "contentJson": {
+        "data": [
+          {
+            "id": "44322889",
+            "login": "dallas",
+            "display_name": "Dallas",
+            "type": "staff",
+            "broadcaster_type": "Broadcaster",
+            "description": "Just a gamer playing games and chatting. :)",
+            "profile_image_url": "https://static-cdn.jtvnw.net/jtv_user_pictures/dallas-profile_image-1a2c906ee2c35f12-300x300.png",
+            "offline_image_url": "https://static-cdn.jtvnw.net/jtv_user_pictures/dallas-channel_offline_image-1a2c906ee2c35f12-1920x1080.png",
+            "view_count": 191836881,
+            "email": "login@provider.com"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Untappd/UntappdTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Untappd/UntappdTests.cs
@@ -1,0 +1,50 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AspNet.Security.OAuth.Untappd
+{
+    public class UntappdTests : OAuthTests<UntappdAuthenticationOptions>
+    {
+        public UntappdTests(ITestOutputHelper outputHelper)
+        {
+            OutputHelper = outputHelper;
+        }
+
+        public override string DefaultScheme => UntappdAuthenticationDefaults.AuthenticationScheme;
+
+        protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
+        {
+            builder.AddUntappd(options => ConfigureDefaults(builder, options));
+        }
+
+        [Theory]
+        [InlineData(ClaimTypes.NameIdentifier, "my-id")]
+        [InlineData(ClaimTypes.Name, "John Smith")]
+        [InlineData(ClaimTypes.GivenName, "John")]
+        [InlineData(ClaimTypes.Surname, "Smith")]
+        [InlineData(ClaimTypes.Webpage, "https://untappd.local/JohnSmith")]
+        [InlineData("urn:untappd:link", "https://untappd.local/john-smith.png")]
+        public async Task Can_Sign_In_Using_Untappd(string claimType, string claimValue)
+        {
+            // Arrange
+            using (var server = CreateTestServer())
+            {
+                // Act
+                var claims = await AuthenticateUserAsync(server);
+
+                // Assert
+                AssertClaim(claims, claimType, claimValue);
+            }
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Untappd/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Untappd/bundle.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/master/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
+  "items": [
+    {
+      "uri": "https://untappd.com/oauth/authorize",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "secret-access-token",
+        "token_type": "access",
+        "refresh_token": "secret-refresh-token",
+        "expires_in": "300"
+      }
+    },
+    {
+      "uri": "https://api.untappd.com/v4/user/info",
+      "contentFormat": "json",
+      "contentJson": {
+        "user": {
+          "id": "my-id",
+          "first_name": "John",
+          "last_name": "Smith",
+          "user_name": "John Smith",
+          "email": "john@john-smith.local",
+          "url": "https://untappd.local/JohnSmith",
+          "user_avatar": "https://untappd.local/john-smith.png"
+        }
+      }
+    }
+  ]
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Vimeo/VimeoTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Vimeo/VimeoTests.cs
@@ -1,0 +1,47 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AspNet.Security.OAuth.Vimeo
+{
+    public class VimeoTests : OAuthTests<VimeoAuthenticationOptions>
+    {
+        public VimeoTests(ITestOutputHelper outputHelper)
+        {
+            OutputHelper = outputHelper;
+        }
+
+        public override string DefaultScheme => VimeoAuthenticationDefaults.AuthenticationScheme;
+
+        protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
+        {
+            builder.AddVimeo(options => ConfigureDefaults(builder, options));
+        }
+
+        [Theory]
+        [InlineData(ClaimTypes.NameIdentifier, "my-id")]
+        [InlineData("urn:vimeo:fullname", "John Smith")]
+        [InlineData("urn:vimeo:profileurl", "https://vimeo.local/JohnSmith")]
+        public async Task Can_Sign_In_Using_Vimeo(string claimType, string claimValue)
+        {
+            // Arrange
+            using (var server = CreateTestServer())
+            {
+                // Act
+                var claims = await AuthenticateUserAsync(server);
+
+                // Assert
+                AssertClaim(claims, claimType, claimValue);
+            }
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Vimeo/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Vimeo/bundle.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/master/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
+  "items": [
+    {
+      "uri": "https://api.vimeo.com/oauth/access_token",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "secret-access-token",
+        "token_type": "access",
+        "refresh_token": "secret-refresh-token",
+        "expires_in": "300"
+      }
+    },
+    {
+      "uri": "https://api.vimeo.com/me",
+      "contentFormat": "json",
+      "contentJson": {
+        "uri": "https://vimeo.local/my-id",
+        "name": "John Smith",
+        "link": "https://vimeo.local/JohnSmith"
+      }
+    }
+  ]
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/VisualStudio/VisualStudioTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/VisualStudio/VisualStudioTests.cs
@@ -1,0 +1,48 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AspNet.Security.OAuth.VisualStudio
+{
+    public class VisualStudioTests : OAuthTests<VisualStudioAuthenticationOptions>
+    {
+        public VisualStudioTests(ITestOutputHelper outputHelper)
+        {
+            OutputHelper = outputHelper;
+        }
+
+        public override string DefaultScheme => VisualStudioAuthenticationDefaults.AuthenticationScheme;
+
+        protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
+        {
+            builder.AddVisualStudio(options => ConfigureDefaults(builder, options));
+        }
+
+        [Theory]
+        [InlineData(ClaimTypes.NameIdentifier, "my-id")]
+        [InlineData(ClaimTypes.Name, "John Smith")]
+        [InlineData(ClaimTypes.Email, "john@john-smith.local")]
+        [InlineData(ClaimTypes.GivenName, "John")]
+        public async Task Can_Sign_In_Using_Visual_Studio(string claimType, string claimValue)
+        {
+            // Arrange
+            using (var server = CreateTestServer())
+            {
+                // Act
+                var claims = await AuthenticateUserAsync(server);
+
+                // Assert
+                AssertClaim(claims, claimType, claimValue);
+            }
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/VisualStudio/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/VisualStudio/bundle.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/master/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
+  "items": [
+    {
+      "uri": "https://app.vssps.visualstudio.com/oauth2/token",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "secret-access-token",
+        "token_type": "access",
+        "refresh_token": "secret-refresh-token",
+        "expires_in": "300"
+      }
+    },
+    {
+      "uri": "https://app.vssps.visualstudio.com/_apis/profile/profiles/me",
+      "contentFormat": "json",
+      "contentJson": {
+        "id": "my-id",
+        "publicAlias": "John Smith",
+        "displayName": "John",
+        "emailAddress": "john@john-smith.local"
+      }
+    }
+  ]
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Vkontakte/VkontakteTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Vkontakte/VkontakteTests.cs
@@ -1,0 +1,51 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AspNet.Security.OAuth.Vkontakte
+{
+    public class VkontakteTests : OAuthTests<VkontakteAuthenticationOptions>
+    {
+        public VkontakteTests(ITestOutputHelper outputHelper)
+        {
+            OutputHelper = outputHelper;
+        }
+
+        public override string DefaultScheme => VkontakteAuthenticationDefaults.AuthenticationScheme;
+
+        protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
+        {
+            builder.AddVkontakte(options => ConfigureDefaults(builder, options));
+        }
+
+        [Theory]
+        [InlineData(ClaimTypes.NameIdentifier, "my-id")]
+        [InlineData(ClaimTypes.Email, "john@john-smith.local")]
+        [InlineData(ClaimTypes.GivenName, "John")]
+        [InlineData(ClaimTypes.Surname, "Smith")]
+        [InlineData(ClaimTypes.Hash, "1fRE977YklVfdpwiJRZWW2+oEKo=")]
+        [InlineData("urn:vkontakte:photo:link", "https://vk.local/photo.png")]
+        [InlineData("urn:vkontakte:photo_thumb:link", "https://vk.local/thumbnail.png")]
+        public async Task Can_Sign_In_Using_Vkontakte(string claimType, string claimValue)
+        {
+            // Arrange
+            using (var server = CreateTestServer())
+            {
+                // Act
+                var claims = await AuthenticateUserAsync(server);
+
+                // Assert
+                AssertClaim(claims, claimType, claimValue);
+            }
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Vkontakte/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Vkontakte/bundle.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/master/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
+  "items": [
+    {
+      "uri": "https://oauth.vk.com/access_token",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "secret-access-token",
+        "token_type": "access",
+        "refresh_token": "secret-refresh-token",
+        "email": "john@john-smith.local"
+      }
+    },
+    {
+      "uri": "https://api.vk.com/method/users.get.json?access_token=secret-access-token&v=5.78&fields=id,first_name,last_name,photo_rec,photo,hash",
+      "contentFormat": "json",
+      "contentJson": {
+        "response": [
+          {
+            "id": "my-id",
+            "first_name": "John",
+            "last_name": "Smith",
+            "hash": "1fRE977YklVfdpwiJRZWW2+oEKo=",
+            "photo": "https://vk.local/photo.png",
+            "photo_rec": "https://vk.local/thumbnail.png"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Weibo/WeiboTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Weibo/WeiboTests.cs
@@ -1,0 +1,54 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AspNet.Security.OAuth.Weibo
+{
+    public class WeiboTests : OAuthTests<WeiboAuthenticationOptions>
+    {
+        public WeiboTests(ITestOutputHelper outputHelper)
+        {
+            OutputHelper = outputHelper;
+        }
+
+        public override string DefaultScheme => WeiboAuthenticationDefaults.AuthenticationScheme;
+
+        protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
+        {
+            builder.AddWeibo(options => ConfigureDefaults(builder, options));
+        }
+
+        [Theory]
+        [InlineData(ClaimTypes.NameIdentifier, "my-id")]
+        [InlineData(ClaimTypes.Name, "John Smith")]
+        [InlineData(ClaimTypes.Email, "john@john-smith.local")]
+        [InlineData(ClaimTypes.Gender, "male")]
+        [InlineData("urn:weibo:avatar_hd", "Avatar HD")]
+        [InlineData("urn:weibo:avatar_large", "Avatar Large")]
+        [InlineData("urn:weibo:cover_image_phone", "Nokia 3310")]
+        [InlineData("urn:weibo:location", "The Cloud")]
+        [InlineData("urn:weibo:profile_image_url", "https://weibo.local/profile.png")]
+        [InlineData("urn:weibo:screen_name", "JohnSmith")]
+        public async Task Can_Sign_In_Using_Weibo(string claimType, string claimValue)
+        {
+            // Arrange
+            using (var server = CreateTestServer())
+            {
+                // Act
+                var claims = await AuthenticateUserAsync(server);
+
+                // Assert
+                AssertClaim(claims, claimType, claimValue);
+            }
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Weibo/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Weibo/bundle.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/master/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
+  "items": [
+    {
+      "uri": "https://api.weibo.com/oauth2/access_token",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "secret-access-token",
+        "token_type": "access",
+        "refresh_token": "secret-refresh-token",
+        "expires_in": "300",
+        "uid": "67f4fbf2-c5a5-4ba5-8694-6838b9603d9e"
+      }
+    },
+    {
+      "uri": "https://api.weibo.com/2/users/show.json?access_token=secret-access-token&uid=67f4fbf2-c5a5-4ba5-8694-6838b9603d9e",
+      "contentFormat": "json",
+      "contentJson": {
+        "id": "my-id",
+        "name": "John Smith",
+        "gender": "male",
+        "screen_name": "JohnSmith",
+        "profile_image_url": "https://weibo.local/profile.png",
+        "avatar_large": "Avatar Large",
+        "avatar_hd": "Avatar HD",
+        "cover_image_phone": "Nokia 3310",
+        "location": "The Cloud"
+      }
+    },
+    {
+      "uri": "https://api.weibo.com/2/account/profile/email.json?access_token=secret-access-token",
+      "contentFormat": "json",
+      "contentJson": [
+        {
+          "email": "john@john-smith.local"
+        }
+      ]
+    }
+  ]
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Weixin/WeixinTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Weixin/WeixinTests.cs
@@ -1,0 +1,53 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AspNet.Security.OAuth.Weixin
+{
+    public class WeixinTests : OAuthTests<WeixinAuthenticationOptions>
+    {
+        public WeixinTests(ITestOutputHelper outputHelper)
+        {
+            OutputHelper = outputHelper;
+        }
+
+        public override string DefaultScheme => WeixinAuthenticationDefaults.AuthenticationScheme;
+
+        protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
+        {
+            builder.AddWeixin(options => ConfigureDefaults(builder, options));
+        }
+
+        [Theory]
+        [InlineData(ClaimTypes.NameIdentifier, "my-id")]
+        [InlineData(ClaimTypes.Name, "John Smith")]
+        [InlineData(ClaimTypes.Gender, "Male")]
+        [InlineData(ClaimTypes.Country, "CN")]
+        [InlineData("urn:weixin:city", "Beijing")]
+        [InlineData("urn:weixin:headimgurl", "https://weixin.qq.local/image.png")]
+        [InlineData("urn:weixin:openid", "my-open-id")]
+        [InlineData("urn:weixin:privilege", "a,b,c")]
+        [InlineData("urn:weixin:province", "Hebei")]
+        public async Task Can_Sign_In_Using_Weixin(string claimType, string claimValue)
+        {
+            // Arrange
+            using (var server = CreateTestServer())
+            {
+                // Act
+                var claims = await AuthenticateUserAsync(server);
+
+                // Assert
+                AssertClaim(claims, claimType, claimValue);
+            }
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Weixin/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Weixin/bundle.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/master/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
+  "items": [
+    {
+      "uri": "https://api.weixin.qq.com/sns/oauth2/access_token?appid=my-client-id&secret=my-client-secret&code=a6ed8e7f-471f-44f1-903b-65946475f351&grant_type=authorization_code",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "secret-access-token",
+        "token_type": "access",
+        "refresh_token": "secret-refresh-token",
+        "expires_in": "300",
+        "openid": "my-open-id"
+      }
+    },
+    {
+      "uri": "https://api.weixin.qq.com/sns/userinfo?access_token=secret-access-token&openid=my-open-id",
+      "contentFormat": "json",
+      "contentJson": {
+        "unionid": "my-id",
+        "nickname": "John Smith",
+        "sex": "Male",
+        "country": "CN",
+        "openid": "my-open-id",
+        "province": "Hebei",
+        "city": "Beijing",
+        "headimgurl": "https://weixin.qq.local/image.png",
+        "privilege": [
+          "a",
+          "b",
+          "c"
+        ]
+      }
+    }
+  ]
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/WordPress/WordPressTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/WordPress/WordPressTests.cs
@@ -1,0 +1,51 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AspNet.Security.OAuth.WordPress
+{
+    public class WordPressTests : OAuthTests<WordPressAuthenticationOptions>
+    {
+        public WordPressTests(ITestOutputHelper outputHelper)
+        {
+            OutputHelper = outputHelper;
+        }
+
+        public override string DefaultScheme => WordPressAuthenticationDefaults.AuthenticationScheme;
+
+        protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
+        {
+            builder.AddWordPress(options => ConfigureDefaults(builder, options));
+        }
+
+        [Theory]
+        [InlineData(ClaimTypes.NameIdentifier, "my-id")]
+        [InlineData(ClaimTypes.Name, "john-smith")]
+        [InlineData("urn:wordpress:avatarurl", "https://www.wordpress.local/john-smith/avatar.png")]
+        [InlineData("urn:wordpress:displayname", "John Smith")]
+        [InlineData("urn:wordpress:email", "john@john-smith.local")]
+        [InlineData("urn:wordpress:primaryblog", "https://john-smith.wordpress.local")]
+        [InlineData("urn:wordpress:profileurl", "https://www.wordpress.local/john-smith")]
+        public async Task Can_Sign_In_Using_WordPress(string claimType, string claimValue)
+        {
+            // Arrange
+            using (var server = CreateTestServer())
+            {
+                // Act
+                var claims = await AuthenticateUserAsync(server);
+
+                // Assert
+                AssertClaim(claims, claimType, claimValue);
+            }
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/WordPress/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/WordPress/bundle.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/master/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
+  "items": [
+    {
+      "uri": "https://public-api.wordpress.com/oauth2/token",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "secret-access-token",
+        "token_type": "access",
+        "refresh_token": "secret-refresh-token",
+        "expires_in": "300"
+      }
+    },
+    {
+      "uri": "https://public-api.wordpress.com/rest/v1.1/me",
+      "contentFormat": "json",
+      "contentJson": {
+        "ID": "my-id",
+        "username": "john-smith",
+        "email": "john@john-smith.local",
+        "display_name": "John Smith",
+        "profile_URL": "https://www.wordpress.local/john-smith",
+        "avatar_URL": "https://www.wordpress.local/john-smith/avatar.png",
+        "primary_blog": "https://john-smith.wordpress.local"
+      }
+    }
+  ]
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Yahoo/YahooTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Yahoo/YahooTests.cs
@@ -1,0 +1,50 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AspNet.Security.OAuth.Yahoo
+{
+    public class YahooTests : OAuthTests<YahooAuthenticationOptions>
+    {
+        public YahooTests(ITestOutputHelper outputHelper)
+        {
+            OutputHelper = outputHelper;
+        }
+
+        public override string DefaultScheme => YahooAuthenticationDefaults.AuthenticationScheme;
+
+        protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
+        {
+            builder.AddYahoo(options => ConfigureDefaults(builder, options));
+        }
+
+        [Theory]
+        [InlineData(ClaimTypes.NameIdentifier, "my-id")]
+        [InlineData(ClaimTypes.Name, "John Smith")]
+        [InlineData("urn:yahoo:familyname", "Smith")]
+        [InlineData("urn:yahoo:givenname", "John")]
+        [InlineData("urn:yahoo:profile", "https://www.yahoo.local/JohnSmith")]
+        [InlineData("urn:yahoo:profileimage", "https://www.yahoo.local/JohnSmith/image.png")]
+        public async Task Can_Sign_In_Using_Yahoo(string claimType, string claimValue)
+        {
+            // Arrange
+            using (var server = CreateTestServer())
+            {
+                // Act
+                var claims = await AuthenticateUserAsync(server);
+
+                // Assert
+                AssertClaim(claims, claimType, claimValue);
+            }
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Yahoo/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Yahoo/bundle.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/master/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
+  "items": [
+    {
+      "uri": "https://api.login.yahoo.com/oauth2/get_token",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "secret-access-token",
+        "token_type": "access",
+        "refresh_token": "secret-refresh-token",
+        "expires_in": "300"
+      }
+    },
+    {
+      "uri": "https://social.yahooapis.com/v1/user/me/profile",
+      "contentFormat": "json",
+      "contentJson": {
+        "profile": {
+          "guid": "my-id",
+          "nickname": "John Smith",
+          "familyName": "Smith",
+          "givenName": "John",
+          "profileUrl": "https://www.yahoo.local/JohnSmith",
+          "imageUrl": "https://www.yahoo.local/JohnSmith/image.png"
+        }
+      }
+    }
+  ]
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Yammer/YammerTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Yammer/YammerTests.cs
@@ -1,0 +1,51 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AspNet.Security.OAuth.Yammer
+{
+    public class YammerTests : OAuthTests<YammerAuthenticationOptions>
+    {
+        public YammerTests(ITestOutputHelper outputHelper)
+        {
+            OutputHelper = outputHelper;
+        }
+
+        public override string DefaultScheme => YammerAuthenticationDefaults.AuthenticationScheme;
+
+        protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
+        {
+            builder.AddYammer(options => ConfigureDefaults(builder, options));
+        }
+
+        [Theory]
+        [InlineData(ClaimTypes.NameIdentifier, "my-id")]
+        [InlineData(ClaimTypes.Name, "John Smith")]
+        [InlineData(ClaimTypes.Email, "john@john-smith.local")]
+        [InlineData(ClaimTypes.GivenName, "John")]
+        [InlineData(ClaimTypes.Surname, "Smith")]
+        [InlineData("urn:yammer:link", "https://www.yammer.com")]
+        [InlineData("urn:yammer:job_title", "Developer")]
+        public async Task Can_Sign_In_Using_Yammer(string claimType, string claimValue)
+        {
+            // Arrange
+            using (var server = CreateTestServer())
+            {
+                // Act
+                var claims = await AuthenticateUserAsync(server);
+
+                // Assert
+                AssertClaim(claims, claimType, claimValue);
+            }
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Yammer/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Yammer/bundle.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/master/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
+  "items": [
+    {
+      "comment": "https://developer.yammer.com/docs/oauth-2",
+      "uri": "https://www.yammer.com/oauth2/access_token",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": {
+          "view_subscriptions": true,
+          "expires_at": null,
+          "authorized_at": "2011/04/06 16:25:46 +0000",
+          "modify_subscriptions": true,
+          "modify_messages": true,
+          "network_permalink": "yammer-inc.com",
+          "view_members": true,
+          "view_tags": true,
+          "network_id": 155465488,
+          "user_id": 1014216,
+          "view_groups": true,
+          "token": "ajsdfiasd7f6asdf8o",
+          "network_name": "Yammer",
+          "view_messages": true,
+          "created_at": "2011/04/06 16:25:46 +0000"
+        }
+      }
+    },
+    {
+      "comment": "https://developer.yammer.com/docs/userscurrentjson",
+      "uri": "https://www.yammer.com/api/v1/users/current.json",
+      "contentFormat": "json",
+      "contentJson": {
+        "id": "my-id",
+        "name": "John Smith",
+        "email": "john@john-smith.local",
+        "first_name": "John",
+        "last_name": "Smith",
+        "web_url": "https://www.yammer.com",
+        "job_title": "Developer"
+      }
+    }
+  ]
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Yandex/YandexTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Yandex/YandexTests.cs
@@ -1,0 +1,49 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AspNet.Security.OAuth.Yandex
+{
+    public class YandexTests : OAuthTests<YandexAuthenticationOptions>
+    {
+        public YandexTests(ITestOutputHelper outputHelper)
+        {
+            OutputHelper = outputHelper;
+        }
+
+        public override string DefaultScheme => YandexAuthenticationDefaults.AuthenticationScheme;
+
+        protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
+        {
+            builder.AddYandex(options => ConfigureDefaults(builder, options));
+        }
+
+        [Theory]
+        [InlineData(ClaimTypes.NameIdentifier, "my-id")]
+        [InlineData(ClaimTypes.Name, "John Smith")]
+        [InlineData(ClaimTypes.Email, "john@john-smith.local")]
+        [InlineData(ClaimTypes.GivenName, "John")]
+        [InlineData(ClaimTypes.Surname, "Smith")]
+        public async Task Can_Sign_In_Using_Yandex(string claimType, string claimValue)
+        {
+            // Arrange
+            using (var server = CreateTestServer())
+            {
+                // Act
+                var claims = await AuthenticateUserAsync(server);
+
+                // Assert
+                AssertClaim(claims, claimType, claimValue);
+            }
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Yandex/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Yandex/bundle.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/master/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
+  "items": [
+    {
+      "uri": "https://oauth.yandex.ru/token",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "secret-access-token",
+        "token_type": "access",
+        "refresh_token": "secret-refresh-token",
+        "expires_in": "300"
+      }
+    },
+    {
+      "uri": "https://login.yandex.ru/info",
+      "contentFormat": "json",
+      "contentJson": {
+        "id": "my-id",
+        "login": "John Smith",
+        "first_name": "John",
+        "last_name": "Smith",
+        "emails": [
+          "john@john-smith.local"
+        ]
+      }
+    }
+  ]
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/xunit.runner.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/xunit.runner.json
@@ -1,0 +1,3 @@
+{
+  "methodDisplay": "method"
+}


### PR DESCRIPTION
  * Add integration tests for all of the OAuth providers.
  * Update JetBrains annotations package.

Replaces #282 by targeting 2.2 so we can get the benefits of the tests into the dev branch before 3.0 ships in September and #280 is merged.
