### PR TITLE
Update Paypal provider to use OAuth user endpoint

### DIFF
--- a/src/AspNet.Security.OAuth.Paypal/PaypalAuthenticationDefaults.cs
+++ b/src/AspNet.Security.OAuth.Paypal/PaypalAuthenticationDefaults.cs
@@ -47,6 +47,6 @@ namespace AspNet.Security.OAuth.Paypal
         /// <summary>
         /// Default value for <see cref="OAuthOptions.UserInformationEndpoint"/>.
         /// </summary>
-        public const string UserInformationEndpoint = "https://api.paypal.com/v1/identity/openidconnect/userinfo?schema=openid";
+        public const string UserInformationEndpoint = "https://api.paypal.com/v1/identity/oauth2/userinfo";
     }
 }

--- a/src/AspNet.Security.OAuth.Paypal/PaypalAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Paypal/PaypalAuthenticationOptions.cs
@@ -8,7 +8,7 @@ using System.Linq;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
-using Microsoft.AspNetCore.Http;
+using Newtonsoft.Json.Linq;
 
 namespace AspNet.Security.OAuth.Paypal
 {
@@ -20,8 +20,7 @@ namespace AspNet.Security.OAuth.Paypal
         public PaypalAuthenticationOptions()
         {
             ClaimsIssuer = PaypalAuthenticationDefaults.Issuer;
-
-            CallbackPath = new PathString(PaypalAuthenticationDefaults.CallbackPath);
+            CallbackPath = PaypalAuthenticationDefaults.CallbackPath;
 
             AuthorizationEndpoint = PaypalAuthenticationDefaults.AuthorizationEndpoint;
             TokenEndpoint = PaypalAuthenticationDefaults.TokenEndpoint;
@@ -34,8 +33,8 @@ namespace AspNet.Security.OAuth.Paypal
             ClaimActions.MapJsonKey(ClaimTypes.Name, "name");
             ClaimActions.MapJsonKey(ClaimTypes.GivenName, "given_name");
             ClaimActions.MapJsonKey(ClaimTypes.Surname, "family_name");
-            ClaimActions.MapJsonKey(ClaimTypes.Email, "email");
             ClaimActions.MapCustomJson(ClaimTypes.NameIdentifier, user => user.Value<string>("user_id")?.Split('/')?.LastOrDefault());
+            ClaimActions.MapCustomJson(ClaimTypes.Email, user => user.Value<JArray>("emails")?.FirstOrDefault(email => email.Value<bool>("primary"))?.Value<string>("value"));
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Paypal/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Paypal/bundle.json
@@ -14,7 +14,7 @@
     },
     {
       "comment": "https://developer.paypal.com/docs/api/identity/v1/#userinfo",
-      "uri": "https://api.paypal.com/v1/identity/openidconnect/userinfo?schema=openid",
+      "uri": "https://api.paypal.com/v1/identity/oauth2/userinfo",
       "contentFormat": "json",
       "contentJson": {
         "user_id": "https://www.paypal.com/webapps/auth/identity/user/mWq6_1sU85v5EG9yHdPxJRrhGHrnMJ-1PQKtX6pcsmA",
@@ -30,7 +30,16 @@
           "country": "US"
         },
         "verified_account": "true",
-        "email": "user1@example.com"
+        "emails": [
+          {
+            "value": "user1@example.com",
+            "primary": true
+          },
+          {
+            "value": "user2@example.com",
+            "primary": false
+          }
+        ]
       }
     }
   ]


### PR DESCRIPTION
Update the provider for Paypal to use the OAuth endpoint to get the user information, rather than the OpenID Connect endpoint.

As this involves changing the value of a constant, I think it's technically a breaking change so maybe should wait for the 3.0 release (see #280). Otherwise, if someone were using the constant in their code and updated the NuGet package without recompiling, the shape of the data in the response would no longer match the mapped claims actions, so the email would no longer be returned.

Relates to #283.
