### PR TITLE
Improve error handling

### DIFF
--- a/src/AspNet.Security.OAuth.Foursquare/FoursquareAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Foursquare/FoursquareAuthenticationHandler.cs
@@ -38,7 +38,7 @@ namespace AspNet.Security.OAuth.Foursquare
             var address = QueryHelpers.AddQueryString(Options.UserInformationEndpoint, new Dictionary<string, string>
             {
                 ["m"] = "foursquare",
-                ["v"] = Options.ApiVersion,
+                ["v"] = !string.IsNullOrEmpty(Options.ApiVersion) ? Options.ApiVersion : FoursquareAuthenticationDefaults.ApiVersion,
                 ["oauth_token"] = tokens.AccessToken,
             });
 

--- a/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationHandler.cs
@@ -35,6 +35,12 @@ namespace AspNet.Security.OAuth.StackExchange
         protected override async Task<AuthenticationTicket> CreateTicketAsync([NotNull] ClaimsIdentity identity,
             [NotNull] AuthenticationProperties properties, [NotNull] OAuthTokenResponse tokens)
         {
+            if (string.IsNullOrEmpty(Options.Site))
+            {
+                throw new InvalidOperationException(
+                    $"No site was specified for the {nameof(StackExchangeAuthenticationOptions.Site)} property of {nameof(StackExchangeAuthenticationOptions)}.");
+            }
+
             var queryArguments = new Dictionary<string, string>
             {
                 ["access_token"] = tokens.AccessToken,


### PR DESCRIPTION
  * Validate that a value is set for the `Site` property of `StackExchangeAuthenticationOptions` to fix #289.
  * If the `ApiVersion` is not set on the options for the Foursquare provider, send the default version as the version is a required property for Foursquare. This replicates the behaviour of `VkontakteAuthenticationHandler`.
