### PR TITLE
GitHub community documentation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+﻿# Contributing
+
+## Feature requests and bugs
+
+Please submit any feature requests or bugs as an [issue](https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers) in GitHub.
+
+## New OAuth Providers
+
+New OAuth providers are added by the community, not the maintainers.
+
+If you wish to add a new provider that is not already part of this repository, fork the repository and try and implement it yourself.
+
+Then you can submit it back as a Pull Request for inclusion here.
+
+New providers are likely to be merged if they are based on OAuth 2.0
+
+## Pull requests
+
+If you wish to contribute code, please consider the guidelines below:
+
+  1. Create an issue detailing the motivation for the change.
+  1. Fork the repository to your GitHub account.
+  1. Create a branch to work on your changes.
+  1. Please follow the existing code style and [EditorConfig](http://editorconfig.org/) formatting settings.
+  1. If fixing a bug or adding new functionality, add or update any tests you deem appropriate.
+  1. Ensure ```build.cmd```/```build.sh``` runs with no errors or warnings and all the tests pass.
+  1. Open a pull request against the ```dev``` branch, referencing your issue, if appropriate.
+
+Once your pull request is opened, the project maintainers will review it as soon as they are able.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,19 @@
+### Provider name
+
+_State which provider(s) you are experiencing an issue with._
+
+### Expected behavior
+
+_Explain what you expected to happen._
+
+### Actual behavior
+
+_Explain what actually happened. If an exception occurred, please include a stack trace if available._
+
+### Steps to reproduce
+
+_A concise and repeatable example of how to illustrate the issue._
+
+### Additional information
+
+_Any additional information that may be useful, such as the version of the package you are using or the version of .NET Core._

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,25 @@
+---
+name: Bug report
+about: Create a bug report to help us improve AspNet.Security.OAuth.Providers
+
+---
+
+**Describe the bug**
+_A clear and concise description of what the bug is. State which provider(s) the bug relates to._
+
+**Steps To reproduce**
+_A concise and repeatable example of how to illustrate the issue._
+
+**Expected behaviour**
+_A clear and concise description of what you expected to happen._
+
+**Actual behaviour**
+_A clear and concise description of what actually happened. If an exception occurred, please include a stack trace if available._
+
+**System information:**
+ - OS: [e.g. Windows 10]
+ - Library Version [e.g. 2.0.1]
+ - .NET version (e.g. output from `dotnet --info`)
+
+**Additional context**
+_Add any other context about the problem here._

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for a new feature for AspNet.Security.OAuth.Providers
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. For example: _I'm always frustrated when [...]_
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+_Summarize the changes this Pull Request makes._
+
+_If adding a new provider, please ensure you have included appropiate test(s)._
+
+_Please include a reference to a GitHub issue if appropriate._

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team [through a GitHub issue](https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/issues). All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/


### PR DESCRIPTION
This Pull Request adds all the GitHub recommended community documentation, including:

  1. A contributing guide
  1. A Code of Conduct
  1. A Pull Request template
  1. Issue templates
