### PR TITLE
Simplify AddQueryString() calls

### DIFF
--- a/src/AspNet.Security.OAuth.Baidu/BaiduAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Baidu/BaiduAuthenticationHandler.cs
@@ -4,7 +4,6 @@
  * for more information concerning the license and the contributors participating to this project.
  */
 
-using System.Collections.Generic;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Security.Claims;
@@ -31,13 +30,12 @@ namespace AspNet.Security.OAuth.Baidu
         {
         }
 
-        protected override async Task<AuthenticationTicket> CreateTicketAsync([NotNull] ClaimsIdentity identity,
-            [NotNull] AuthenticationProperties properties, [NotNull] OAuthTokenResponse tokens)
+        protected override async Task<AuthenticationTicket> CreateTicketAsync(
+            [NotNull] ClaimsIdentity identity,
+            [NotNull] AuthenticationProperties properties,
+            [NotNull] OAuthTokenResponse tokens)
         {
-            var address = QueryHelpers.AddQueryString(Options.UserInformationEndpoint, new Dictionary<string, string>
-            {
-                ["access_token"] = tokens.AccessToken
-            });
+            string address = QueryHelpers.AddQueryString(Options.UserInformationEndpoint, "access_token", tokens.AccessToken);
 
             var request = new HttpRequestMessage(HttpMethod.Get, address);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));

--- a/src/AspNet.Security.OAuth.LinkedIn/LinkedInAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.LinkedIn/LinkedInAuthenticationHandler.cs
@@ -5,7 +5,6 @@
  */
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -33,22 +32,20 @@ namespace AspNet.Security.OAuth.LinkedIn
         {
         }
 
-        protected override async Task<AuthenticationTicket> CreateTicketAsync([NotNull] ClaimsIdentity identity,
-            [NotNull] AuthenticationProperties properties, [NotNull] OAuthTokenResponse tokens)
+        protected override async Task<AuthenticationTicket> CreateTicketAsync(
+            [NotNull] ClaimsIdentity identity,
+            [NotNull] AuthenticationProperties properties,
+            [NotNull] OAuthTokenResponse tokens)
         {
             string address = Options.UserInformationEndpoint;
             var fields = Options.Fields
                 .Where(f => !string.Equals(f, LinkedInAuthenticationConstants.EmailAddressField, StringComparison.OrdinalIgnoreCase))
                 .ToList();
 
-            // If at least one field is specified,
-            // append the fields to the endpoint URL.
-            if (fields.Count != 0)
+            // If at least one field is specified, append the fields to the endpoint URL.
+            if (fields.Count > 0)
             {
-                address = QueryHelpers.AddQueryString(address, new Dictionary<string, string>
-                {
-                    ["projection"] = $"({string.Join(",", fields)})",
-                });
+                address = QueryHelpers.AddQueryString(address, "projection", $"({string.Join(",", fields)})");
             }
 
             var request = new HttpRequestMessage(HttpMethod.Get, address);

--- a/src/AspNet.Security.OAuth.Weibo/WeiboAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Weibo/WeiboAuthenticationHandler.cs
@@ -83,10 +83,7 @@ namespace AspNet.Security.OAuth.Weibo
         protected virtual async Task<string> GetEmailAsync([NotNull] OAuthTokenResponse tokens)
         {
             // See http://open.weibo.com/wiki/2/account/profile/email for more information about the /account/profile/email.json endpoint.
-            var address = QueryHelpers.AddQueryString(Options.UserEmailsEndpoint, new Dictionary<string, string>
-            {
-                ["access_token"] = tokens.AccessToken
-            });
+            string address = QueryHelpers.AddQueryString(Options.UserEmailsEndpoint, "access_token", tokens.AccessToken);
 
             var request = new HttpRequestMessage(HttpMethod.Get, address);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));


### PR DESCRIPTION
Use simplified overload of `AddQueryString()` when adding one query string parameter to a URI.

Resolves #307.
