### PR TITLE
Package and version fixes

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -46,6 +46,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <IsPackable>true</IsPackable>
     <IsShipping>true</IsShipping>
+    <Serviceable>false</Serviceable>
   </PropertyGroup>
   <ItemGroup Condition=" '$(IsPackable)' == 'true' ">
     <None Include="$(MSBuildThisFileDirectory)package-icon.png" Pack="True" PackagePath="" />

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -8,6 +8,7 @@
   -->
 
   <PropertyGroup>
+    <Company>$(Authors)</Company>
     <Copyright>$(_ProjectCopyright)</Copyright>
   </PropertyGroup>
 

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,7 +1,12 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <MajorVersion>3</MajorVersion>
+    <MinorVersion>0</MinorVersion>
+    <PatchVersion>0</PatchVersion>
+    <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <PreReleaseVersionLabel>release</PreReleaseVersionLabel>
+    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
+    <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
   </PropertyGroup>
   <PropertyGroup>
     <AspNetCoreVersion>3.0.0</AspNetCoreVersion>


### PR DESCRIPTION
  * Fixes to generate stable package versions for shipping.
  * Fix incorrect `[AssemblyCompany]`.
  * Disable package servicing.
