### PR TITLE
3.1.0 preparation

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 3.0.0.{build}
+version: 3.1.0.{build}
 
 build_script:
   - eng\common\CIBuild.cmd -configuration Release -prepareMachine

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -14,7 +14,7 @@
     <JetBrainsVersion>2019.1.3</JetBrainsVersion>
     <JustEatHttpClientInterceptionVersion>3.0.0</JustEatHttpClientInterceptionVersion>
     <MartinCostelloLoggingXUnitVersion>0.1.0</MartinCostelloLoggingXUnitVersion>
-    <MicrosoftNETTestSdkVersion>16.3.0</MicrosoftNETTestSdkVersion>
+    <MicrosoftNETTestSdkVersion>16.4.0</MicrosoftNETTestSdkVersion>
     <ShouldlyVersion>3.0.2</ShouldlyVersion>
     <SystemIdentityModelTokensJwtVersion>5.3.0</SystemIdentityModelTokensJwtVersion>
     <TwitterProviderVersion>3.0.0</TwitterProviderVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,10 +1,10 @@
 <Project>
   <PropertyGroup>
     <MajorVersion>3</MajorVersion>
-    <MinorVersion>0</MinorVersion>
+    <MinorVersion>1</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
-    <PreReleaseVersionLabel>release</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
   </PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -12,7 +12,7 @@
     <AspNetCoreVersion>3.0.0</AspNetCoreVersion>
     <GoogleProviderVersion>3.0.0</GoogleProviderVersion>
     <JetBrainsVersion>2019.1.3</JetBrainsVersion>
-    <JustEatHttpClientInterceptionVersion>2.0.2</JustEatHttpClientInterceptionVersion>
+    <JustEatHttpClientInterceptionVersion>3.0.0</JustEatHttpClientInterceptionVersion>
     <MartinCostelloLoggingXUnitVersion>0.1.0</MartinCostelloLoggingXUnitVersion>
     <MicrosoftNETTestSdkVersion>16.3.0</MicrosoftNETTestSdkVersion>
     <ShouldlyVersion>3.0.2</ShouldlyVersion>

--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "dotnet": "3.0.100"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19405.1",
+    "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19502.2",
     "Microsoft.DotNet.Helix.Sdk": "2.0.0-beta.19405.1"
   }
 }


### PR DESCRIPTION
  * Bump version to `3.1.0`
  * Reset prelease label to `preview`
  * Update to the latest release of `JustEat.HttpClientInterception`
