### PR TITLE
Code Analyzers + Fixes and Nullable Annotations

### DIFF
--- a/AspNet.Security.OAuth.Providers.ruleset
+++ b/AspNet.Security.OAuth.Providers.ruleset
@@ -16,4 +16,24 @@
     <Rule Id="CA2208" Action="None" />
     <Rule Id="CA2234" Action="None" />
   </Rules>
+  <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="AD0001" Action="None" />
+    <Rule Id="SA0001" Action="None" />
+    <Rule Id="SA1100" Action="None" />
+    <Rule Id="SA1101" Action="None" />
+    <Rule Id="SA1116" Action="None" />
+    <Rule Id="SA1129" Action="None" />
+    <Rule Id="SA1201" Action="None" />
+    <Rule Id="SA1202" Action="None" />
+    <Rule Id="SA1203" Action="None" />
+    <Rule Id="SA1204" Action="None" />
+    <Rule Id="SA1309" Action="None" />
+    <Rule Id="SA1413" Action="None" />
+    <Rule Id="SA1600" Action="None" />
+    <Rule Id="SA1609" Action="None" />
+    <Rule Id="SA1623" Action="None" />
+    <Rule Id="SA1629" Action="None" />
+    <Rule Id="SA1642" Action="None" />
+    <Rule Id="SA1652" Action="None" />
+  </Rules>
 </RuleSet>

--- a/AspNet.Security.OAuth.Providers.ruleset
+++ b/AspNet.Security.OAuth.Providers.ruleset
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="AspNet.Security.OAuth.Providers Rules" Description="This rule set contains rules for the AspNet.Security.OAuth.Providers solution." ToolsVersion="16.0">
+  <IncludeAll Action="Warning" />
+  <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
+    <Rule Id="CA1031" Action="None" />
+    <Rule Id="CA1034" Action="None" />
+    <Rule Id="CA1044" Action="None" />
+    <Rule Id="CA1052" Action="None" />
+    <Rule Id="CA1056" Action="None" />
+    <Rule Id="CA1062" Action="None" />
+    <Rule Id="CA1303" Action="None" />
+    <Rule Id="CA1308" Action="None" />
+    <Rule Id="CA1724" Action="None" />
+    <Rule Id="CA1812" Action="None" />
+    <Rule Id="CA2007" Action="None" />
+    <Rule Id="CA2208" Action="None" />
+    <Rule Id="CA2234" Action="None" />
+  </Rules>
+</RuleSet>

--- a/AspNet.Security.OAuth.Providers.sln
+++ b/AspNet.Security.OAuth.Providers.sln
@@ -126,6 +126,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		NuGet.config = NuGet.config
 		package-icon.png = package-icon.png
 		README.md = README.md
+		stylecop.json = stylecop.json
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{3FA3F7B5-5373-4E43-8F45-8EC18249E526}"

--- a/AspNet.Security.OAuth.Providers.sln
+++ b/AspNet.Security.OAuth.Providers.sln
@@ -114,6 +114,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.gitignore = .gitignore
 		.travis.yml = .travis.yml
 		appveyor.yml = appveyor.yml
+		AspNet.Security.OAuth.Providers.ruleset = AspNet.Security.OAuth.Providers.ruleset
 		build.cmd = build.cmd
 		build.ps1 = build.ps1
 		build.sh = build.sh
@@ -172,7 +173,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".vscode", ".vscode", "{ED90
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNet.Security.OAuth.Apple", "src\AspNet.Security.OAuth.Apple\AspNet.Security.OAuth.Apple.csproj", "{DC80AFEC-EFB4-4B21-BF79-44DEA6E1FE26}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AspNet.Security.OAuth.Gitee", "src\AspNet.Security.OAuth.Gitee\AspNet.Security.OAuth.Gitee.csproj", "{82AA3C52-9B98-4203-9D26-1FA6E5BAEEBD}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNet.Security.OAuth.Gitee", "src\AspNet.Security.OAuth.Gitee\AspNet.Security.OAuth.Gitee.csproj", "{82AA3C52-9B98-4203-9D26-1FA6E5BAEEBD}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNet.Security.OAuth.Deezer", "src\AspNet.Security.OAuth.Deezer\AspNet.Security.OAuth.Deezer.csproj", "{0D9EB03D-99AF-4A80-B7CE-2302A8D3747B}"
 EndProject

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -72,8 +72,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="$(RoslynAnalyzersVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NetCore.Analyzers" Version="$(RoslynAnalyzersVersion)" PrivateAssets="All" />
-    <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" Link="stylecop.json" />
-    <PackageReference Include="StyleCop.Analyzers" Version="$(StyleCopAnalyzersVersion)" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,6 +7,7 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DebugSymbols>true</DebugSymbols>
+    <DefineConstants Condition=" '$(Configuration)' == 'Debug' ">$(DefineConstants);JETBRAINS_ANNOTATIONS</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,6 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DebugSymbols>true</DebugSymbols>
     <DefineConstants Condition=" '$(Configuration)' == 'Debug' ">$(DefineConstants);JETBRAINS_ANNOTATIONS</DefineConstants>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -63,6 +63,15 @@
     <Serviceable>false</Serviceable>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)AspNet.Security.OAuth.Providers.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="$(RoslynAnalyzersVersion)" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NetCore.Analyzers" Version="$(RoslynAnalyzersVersion)" PrivateAssets="All" />
+  </ItemGroup>
+
   <ItemGroup Condition=" '$(OS)' != 'Windows_NT' ">
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0-preview.2" />
   </ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -70,6 +70,13 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="$(RoslynAnalyzersVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NetCore.Analyzers" Version="$(RoslynAnalyzersVersion)" PrivateAssets="All" />
+    <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" Link="stylecop.json" />
+    <PackageReference Include="StyleCop.Analyzers" Version="$(StyleCopAnalyzersVersion)" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" Link="stylecop.json" />
+    <PackageReference Include="StyleCop.Analyzers" Version="$(StyleCopAnalyzersVersion)" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(OS)' != 'Windows_NT' ">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -18,6 +18,7 @@
     <MicrosoftNETTestSdkVersion>16.5.0</MicrosoftNETTestSdkVersion>
     <RoslynAnalyzersVersion>2.9.8</RoslynAnalyzersVersion>
     <ShouldlyVersion>3.0.2</ShouldlyVersion>
+    <StyleCopAnalyzersVersion>1.1.118</StyleCopAnalyzersVersion>
     <!--
       Cannot use later versions (5.5.0+) due to https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/1302.
     -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -16,6 +16,7 @@
     <MicrosoftAspNetCoreMvcTestingVersion>3.1.1</MicrosoftAspNetCoreMvcTestingVersion>
     <MicrosoftAspNetCoreTestHostVersion>3.1.1</MicrosoftAspNetCoreTestHostVersion>
     <MicrosoftNETTestSdkVersion>16.5.0</MicrosoftNETTestSdkVersion>
+    <RoslynAnalyzersVersion>2.9.8</RoslynAnalyzersVersion>
     <ShouldlyVersion>3.0.2</ShouldlyVersion>
     <!--
       Cannot use later versions (5.5.0+) due to https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/1302.

--- a/samples/Mvc.Client/Controllers/AuthenticationController.cs
+++ b/samples/Mvc.Client/Controllers/AuthenticationController.cs
@@ -38,7 +38,8 @@ namespace Mvc.Client.Controllers
             return Challenge(new AuthenticationProperties { RedirectUri = "/" }, provider);
         }
 
-        [HttpGet("~/signout"), HttpPost("~/signout")]
+        [HttpGet("~/signout")]
+        [HttpPost("~/signout")]
         public IActionResult SignOut()
         {
             // Instruct the cookies middleware to delete the local cookie created

--- a/samples/Mvc.Client/Program.cs
+++ b/samples/Mvc.Client/Program.cs
@@ -1,4 +1,10 @@
-﻿using Microsoft.AspNetCore.Hosting;
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
 
 namespace Mvc.Client

--- a/samples/Mvc.Client/Startup.cs
+++ b/samples/Mvc.Client/Startup.cs
@@ -77,7 +77,7 @@ namespace Mvc.Client
                 options.ClientSecret = Configuration["Dropbox:ClientSecret"];
             });
 
-            services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_3_0);
+            services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Latest);
         }
 
         public void Configure(IApplicationBuilder app)

--- a/samples/Mvc.Client/Startup.cs
+++ b/samples/Mvc.Client/Startup.cs
@@ -43,29 +43,29 @@ namespace Mvc.Client
 
             .AddGoogle(options =>
             {
-                options.ClientId = "560027070069-37ldt4kfuohhu3m495hk2j4pjp92d382.apps.googleusercontent.com";
-                options.ClientSecret = "n2Q-GEw9RQjzcRbU3qhfTj8f";
+                options.ClientId = Configuration["Google:ClientId"];
+                options.ClientSecret = Configuration["Google:ClientSecret"];
             })
 
             .AddTwitter(options =>
             {
-                options.ConsumerKey = "6XaCTaLbMqfj6ww3zvZ5g";
-                options.ConsumerSecret = "Il2eFzGIrYhz6BWjYhVXBPQSfZuS4xoHpSSyD9PI";
+                options.ConsumerKey = Configuration["Twitter:ConsumerKey"];
+                options.ConsumerSecret = Configuration["Twitter:ConsumerSecret"];
             })
 
             .AddGitHub(options =>
             {
-                options.ClientId = "49e302895d8b09ea5656";
-                options.ClientSecret = "98f1bf028608901e9df91d64ee61536fe562064b";
+                options.ClientId = Configuration["GitHub:ClientId"];
+                options.ClientSecret = Configuration["GitHub:ClientSecret"];
                 options.Scope.Add("user:email");
             })
 
             /*
             .AddApple(options =>
             {
-                options.ClientId = Configuration["AppleClientId"];
-                options.KeyId = Configuration["AppleKeyId"];
-                options.TeamId = Configuration["AppleTeamId"];
+                options.ClientId = Configuration["Apple:ClientId"];
+                options.KeyId = Configuration["Apple:KeyId"];
+                options.TeamId = Configuration["Apple:TeamId"];
                 options.UsePrivateKey(
                     (keyId) => HostingEnvironment.ContentRootFileProvider.GetFileInfo($"AuthKey_{keyId}.p8"));
             })
@@ -73,8 +73,8 @@ namespace Mvc.Client
 
             .AddDropbox(options =>
             {
-                options.ClientId = "jpk24g2uxfxe939";
-                options.ClientSecret = "qbxvkjk5la7mjp6";
+                options.ClientId = Configuration["Dropbox:ClientId"];
+                options.ClientSecret = Configuration["Dropbox:ClientSecret"];
             });
 
             services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_3_0);

--- a/samples/Mvc.Client/appsettings.json
+++ b/samples/Mvc.Client/appsettings.json
@@ -1,0 +1,18 @@
+﻿{
+  "Dropbox": {
+    "ClientId": "jpk24g2uxfxe939",
+    "ClientSecret": "qbxvkjk5la7mjp6"
+  },
+  "GitHub": {
+    "ClientId": "49e302895d8b09ea5656",
+    "ClientSecret": "98f1bf028608901e9df91d64ee61536fe562064b"
+  },
+  "Google": {
+    "ClientId": "560027070069-37ldt4kfuohhu3m495hk2j4pjp92d382.apps.googleusercontent.com",
+    "ClientSecret": "n2Q-GEw9RQjzcRbU3qhfTj8f"
+  },
+  "Twitter": {
+    "ConsumerKey": "6XaCTaLbMqfj6ww3zvZ5g",
+    "ConsumerSecret": "Il2eFzGIrYhz6BWjYhVXBPQSfZuS4xoHpSSyD9PI"
+  }
+}

--- a/samples/Mvc.Client/web.config
+++ b/samples/Mvc.Client/web.config
@@ -1,10 +1,7 @@
-﻿<?xml version="1.0"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <system.webServer>
-    <handlers>
-      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModuleV2" resourceType="Unspecified"/>
-    </handlers>
-    <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false"/>
+    <aspNetCore />
     <security>
       <requestFiltering>
         <requestLimits maxQueryString="4096" />

--- a/src/AspNet.Security.OAuth.Amazon/AmazonAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.Amazon/AmazonAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the Amazon options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddAmazon(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<AmazonAuthenticationOptions> configuration)
         {
             return builder.AddAmazon(scheme, AmazonAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddAmazon(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<AmazonAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<AmazonAuthenticationOptions, AmazonAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.Amazon/AmazonAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Amazon/AmazonAuthenticationHandler.cs
@@ -46,7 +46,7 @@ namespace AspNet.Security.OAuth.Amazon
             [NotNull] AuthenticationProperties properties,
             [NotNull] OAuthTokenResponse tokens)
         {
-            var endpoint = Options.UserInformationEndpoint;
+            string endpoint = Options.UserInformationEndpoint;
 
             if (Options.Fields.Count > 0)
             {

--- a/src/AspNet.Security.OAuth.Apple/AppleAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Apple/AppleAuthenticationHandler.cs
@@ -122,7 +122,7 @@ namespace AspNet.Security.OAuth.Apple
         }
 
         /// <inheritdoc />
-        protected override async Task<OAuthTokenResponse> ExchangeCodeAsync(OAuthCodeExchangeContext context)
+        protected override async Task<OAuthTokenResponse> ExchangeCodeAsync([NotNull] OAuthCodeExchangeContext context)
         {
             if (Options.GenerateClientSecret)
             {

--- a/src/AspNet.Security.OAuth.Apple/AppleAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Apple/AppleAuthenticationOptions.cs
@@ -58,7 +58,7 @@ namespace AspNet.Security.OAuth.Apple
         /// <summary>
         /// Gets or sets the optional ID for your Sign in with Apple private key.
         /// </summary>
-        public string KeyId { get; set; }
+        public string? KeyId { get; set; }
 
         /// <summary>
         /// Gets or sets the default period of time to cache the Apple public key(s)
@@ -82,12 +82,12 @@ namespace AspNet.Security.OAuth.Apple
         /// <remarks>
         /// The private key should be in PKCS #8 (<c>.p8</c>) format.
         /// </remarks>
-        public Func<string, Task<byte[]>> PrivateKeyBytes { get; set; }
+        public Func<string, Task<byte[]>>? PrivateKeyBytes { get; set; }
 
         /// <summary>
         /// Gets or sets the Team ID for your Apple Developer account.
         /// </summary>
-        public string TeamId { get; set; }
+        public string TeamId { get; set; } = string.Empty;
 
         /// <summary>
         /// Gets or sets the audience used for tokens.

--- a/src/AspNet.Security.OAuth.Apple/Internal/DefaultAppleClientSecretGenerator.cs
+++ b/src/AspNet.Security.OAuth.Apple/Internal/DefaultAppleClientSecretGenerator.cs
@@ -91,7 +91,7 @@ namespace AspNet.Security.OAuth.Apple.Internal
             return (clientSecret, expiresAt);
         }
 
-        private ECDsa CreateAlgorithm(byte[] keyBlob)
+        private static ECDsa CreateAlgorithm(byte[] keyBlob)
         {
             var algorithm = ECDsa.Create();
 
@@ -107,7 +107,7 @@ namespace AspNet.Security.OAuth.Apple.Internal
             }
         }
 
-        private SigningCredentials CreateSigningCredentials(string keyId, ECDsa algorithm)
+        private static SigningCredentials CreateSigningCredentials(string keyId, ECDsa algorithm)
         {
             var key = new ECDsaSecurityKey(algorithm) { KeyId = keyId };
             return new SigningCredentials(key, SecurityAlgorithms.EcdsaSha256Signature);

--- a/src/AspNet.Security.OAuth.Apple/Internal/DefaultAppleClientSecretGenerator.cs
+++ b/src/AspNet.Security.OAuth.Apple/Internal/DefaultAppleClientSecretGenerator.cs
@@ -23,7 +23,7 @@ namespace AspNet.Security.OAuth.Apple.Internal
         private readonly AppleKeyStore _keyStore;
         private readonly JwtSecurityTokenHandler _tokenHandler;
 
-        private string _clientSecret;
+        private string? _clientSecret;
         private DateTimeOffset _expiresAt;
 
         public DefaultAppleClientSecretGenerator(
@@ -81,7 +81,7 @@ namespace AspNet.Security.OAuth.Apple.Internal
 
             using (var algorithm = CreateAlgorithm(keyBlob))
             {
-                tokenDescriptor.SigningCredentials = CreateSigningCredentials(context.Options.KeyId, algorithm);
+                tokenDescriptor.SigningCredentials = CreateSigningCredentials(context.Options.KeyId!, algorithm);
 
                 clientSecret = _tokenHandler.CreateEncodedJwt(tokenDescriptor);
             }

--- a/src/AspNet.Security.OAuth.Apple/Internal/DefaultAppleKeyStore.cs
+++ b/src/AspNet.Security.OAuth.Apple/Internal/DefaultAppleKeyStore.cs
@@ -18,7 +18,7 @@ namespace AspNet.Security.OAuth.Apple.Internal
         private readonly ISystemClock _clock;
         private readonly ILogger _logger;
 
-        private byte[] _publicKey;
+        private byte[] _publicKey = null!;
         private DateTimeOffset _reloadKeysAfter;
 
         public DefaultAppleKeyStore(
@@ -39,7 +39,7 @@ namespace AspNet.Security.OAuth.Apple.Internal
                     nameof(AppleAuthenticationOptions.PrivateKeyBytes));
             }
 
-            return await context.Options.PrivateKeyBytes(context.Options.KeyId);
+            return await context.Options.PrivateKeyBytes(context.Options.KeyId!);
         }
 
         /// <inheritdoc />

--- a/src/AspNet.Security.OAuth.ArcGIS/ArcGISAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.ArcGIS/ArcGISAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the ArcGIS options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddArcGIS(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<ArcGISAuthenticationOptions> configuration)
         {
             return builder.AddArcGIS(scheme, ArcGISAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddArcGIS(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<ArcGISAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<ArcGISAuthenticationOptions, ArcGISAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.ArcGIS/ArcGISAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.ArcGIS/ArcGISAuthenticationHandler.cs
@@ -38,7 +38,7 @@ namespace AspNet.Security.OAuth.ArcGIS
             [NotNull] OAuthTokenResponse tokens)
         {
             // Note: the ArcGIS API doesn't support content negotiation via headers.
-            var address = QueryHelpers.AddQueryString(Options.UserInformationEndpoint, new Dictionary<string, string>
+            string address = QueryHelpers.AddQueryString(Options.UserInformationEndpoint, new Dictionary<string, string>
             {
                 ["f"] = "json",
                 ["token"] = tokens.AccessToken

--- a/src/AspNet.Security.OAuth.ArcGIS/ArcGISAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.ArcGIS/ArcGISAuthenticationHandler.cs
@@ -32,8 +32,10 @@ namespace AspNet.Security.OAuth.ArcGIS
         {
         }
 
-        protected override async Task<AuthenticationTicket> CreateTicketAsync([NotNull] ClaimsIdentity identity,
-            [NotNull] AuthenticationProperties properties, [NotNull] OAuthTokenResponse tokens)
+        protected override async Task<AuthenticationTicket> CreateTicketAsync(
+            [NotNull] ClaimsIdentity identity,
+            [NotNull] AuthenticationProperties properties,
+            [NotNull] OAuthTokenResponse tokens)
         {
             // Note: the ArcGIS API doesn't support content negotiation via headers.
             var address = QueryHelpers.AddQueryString(Options.UserInformationEndpoint, new Dictionary<string, string>

--- a/src/AspNet.Security.OAuth.ArcGIS/ArcGISAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.ArcGIS/ArcGISAuthenticationOptions.cs
@@ -7,7 +7,6 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
-using Microsoft.AspNetCore.Http;
 
 namespace AspNet.Security.OAuth.ArcGIS
 {
@@ -19,7 +18,7 @@ namespace AspNet.Security.OAuth.ArcGIS
         public ArcGISAuthenticationOptions()
         {
             ClaimsIssuer = ArcGISAuthenticationDefaults.Issuer;
-            CallbackPath = new PathString(ArcGISAuthenticationDefaults.CallbackPath);
+            CallbackPath = ArcGISAuthenticationDefaults.CallbackPath;
 
             AuthorizationEndpoint = ArcGISAuthenticationDefaults.AuthorizationEndpoint;
             TokenEndpoint = ArcGISAuthenticationDefaults.TokenEndpoint;

--- a/src/AspNet.Security.OAuth.Asana/AsanaAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.Asana/AsanaAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the Asana options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddAsana(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<AsanaAuthenticationOptions> configuration)
         {
             return builder.AddAsana(scheme, AsanaAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddAsana(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<AsanaAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<AsanaAuthenticationOptions, AsanaAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.Asana/AsanaAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Asana/AsanaAuthenticationHandler.cs
@@ -29,8 +29,10 @@ namespace AspNet.Security.OAuth.Asana
         {
         }
 
-        protected override async Task<AuthenticationTicket> CreateTicketAsync([NotNull] ClaimsIdentity identity,
-            [NotNull] AuthenticationProperties properties, [NotNull] OAuthTokenResponse tokens)
+        protected override async Task<AuthenticationTicket> CreateTicketAsync(
+            [NotNull] ClaimsIdentity identity,
+            [NotNull] AuthenticationProperties properties,
+            [NotNull] OAuthTokenResponse tokens)
         {
             using var request = new HttpRequestMessage(HttpMethod.Get, Options.UserInformationEndpoint);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));

--- a/src/AspNet.Security.OAuth.Asana/AsanaAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Asana/AsanaAuthenticationOptions.cs
@@ -7,7 +7,6 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
-using Microsoft.AspNetCore.Http;
 
 namespace AspNet.Security.OAuth.Asana
 {
@@ -19,7 +18,7 @@ namespace AspNet.Security.OAuth.Asana
         public AsanaAuthenticationOptions()
         {
             ClaimsIssuer = AsanaAuthenticationDefaults.Issuer;
-            CallbackPath = new PathString(AsanaAuthenticationDefaults.CallbackPath);
+            CallbackPath = AsanaAuthenticationDefaults.CallbackPath;
 
             AuthorizationEndpoint = AsanaAuthenticationDefaults.AuthorizationEndpoint;
             TokenEndpoint = AsanaAuthenticationDefaults.TokenEndpoint;

--- a/src/AspNet.Security.OAuth.Autodesk/AutodeskAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.Autodesk/AutodeskAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the Autodesk options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddAutodesk(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<AutodeskAuthenticationOptions> configuration)
         {
             return builder.AddAutodesk(scheme, AutodeskAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddAutodesk(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<AutodeskAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<AutodeskAuthenticationOptions, AutodeskAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.Autodesk/AutodeskAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Autodesk/AutodeskAuthenticationHandler.cs
@@ -29,8 +29,10 @@ namespace AspNet.Security.OAuth.Autodesk
         {
         }
 
-        protected override async Task<AuthenticationTicket> CreateTicketAsync([NotNull] ClaimsIdentity identity,
-            [NotNull] AuthenticationProperties properties, [NotNull] OAuthTokenResponse tokens)
+        protected override async Task<AuthenticationTicket> CreateTicketAsync(
+            [NotNull] ClaimsIdentity identity,
+            [NotNull] AuthenticationProperties properties,
+            [NotNull] OAuthTokenResponse tokens)
         {
             using var request = new HttpRequestMessage(HttpMethod.Get, Options.UserInformationEndpoint);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));

--- a/src/AspNet.Security.OAuth.Autodesk/AutodeskAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Autodesk/AutodeskAuthenticationOptions.cs
@@ -7,7 +7,6 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
-using Microsoft.AspNetCore.Http;
 using static AspNet.Security.OAuth.Autodesk.AutodeskAuthenticationConstants;
 
 namespace AspNet.Security.OAuth.Autodesk
@@ -20,7 +19,7 @@ namespace AspNet.Security.OAuth.Autodesk
         public AutodeskAuthenticationOptions()
         {
             ClaimsIssuer = AutodeskAuthenticationDefaults.Issuer;
-            CallbackPath = new PathString(AutodeskAuthenticationDefaults.CallbackPath);
+            CallbackPath = AutodeskAuthenticationDefaults.CallbackPath;
 
             AuthorizationEndpoint = AutodeskAuthenticationDefaults.AuthorizationEndpoint;
             TokenEndpoint = AutodeskAuthenticationDefaults.TokenEndpoint;

--- a/src/AspNet.Security.OAuth.Automatic/AutomaticAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.Automatic/AutomaticAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the Automatic options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddAutomatic(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<AutomaticAuthenticationOptions> configuration)
         {
             return builder.AddAutomatic(scheme, AutomaticAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddAutomatic(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<AutomaticAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<AutomaticAuthenticationOptions, AutomaticAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.Automatic/AutomaticAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Automatic/AutomaticAuthenticationHandler.cs
@@ -62,7 +62,7 @@ namespace AspNet.Security.OAuth.Automatic
             return new AuthenticationTicket(context.Principal, context.Properties, Scheme.Name);
         }
 
-        protected override string BuildChallengeUrl(AuthenticationProperties properties, string redirectUri)
+        protected override string BuildChallengeUrl([NotNull] AuthenticationProperties properties, [NotNull] string redirectUri)
         {
             // Note: the redirect_uri parameter is not allowed by Automatic and MUST NOT be sent.
             return QueryHelpers.AddQueryString(Options.AuthorizationEndpoint, new Dictionary<string, string>

--- a/src/AspNet.Security.OAuth.Automatic/AutomaticAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Automatic/AutomaticAuthenticationHandler.cs
@@ -31,8 +31,10 @@ namespace AspNet.Security.OAuth.Automatic
         {
         }
 
-        protected override async Task<AuthenticationTicket> CreateTicketAsync([NotNull] ClaimsIdentity identity,
-            [NotNull] AuthenticationProperties properties, [NotNull] OAuthTokenResponse tokens)
+        protected override async Task<AuthenticationTicket> CreateTicketAsync(
+            [NotNull] ClaimsIdentity identity,
+            [NotNull] AuthenticationProperties properties,
+            [NotNull] OAuthTokenResponse tokens)
         {
             using var request = new HttpRequestMessage(HttpMethod.Get, Options.UserInformationEndpoint);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));

--- a/src/AspNet.Security.OAuth.Automatic/AutomaticAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Automatic/AutomaticAuthenticationOptions.cs
@@ -7,7 +7,6 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
-using Microsoft.AspNetCore.Http;
 
 namespace AspNet.Security.OAuth.Automatic
 {
@@ -19,7 +18,7 @@ namespace AspNet.Security.OAuth.Automatic
         public AutomaticAuthenticationOptions()
         {
             ClaimsIssuer = AutomaticAuthenticationDefaults.Issuer;
-            CallbackPath = new PathString(AutomaticAuthenticationDefaults.CallbackPath);
+            CallbackPath = AutomaticAuthenticationDefaults.CallbackPath;
 
             AuthorizationEndpoint = AutomaticAuthenticationDefaults.AuthorizationEndpoint;
             TokenEndpoint = AutomaticAuthenticationDefaults.TokenEndpoint;

--- a/src/AspNet.Security.OAuth.Baidu/BaiduAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.Baidu/BaiduAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the Baidu options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddBaidu(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<BaiduAuthenticationOptions> configuration)
         {
             return builder.AddBaidu(scheme, BaiduAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddBaidu(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<BaiduAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<BaiduAuthenticationOptions, BaiduAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.Baidu/BaiduAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Baidu/BaiduAuthenticationOptions.cs
@@ -31,7 +31,7 @@ namespace AspNet.Security.OAuth.Baidu
             ClaimActions.MapCustomJson(BaiduAuthenticationConstants.Claims.Portrait,
                 user =>
                 {
-                    var portrait = user.GetString("portrait");
+                    string portrait = user.GetString("portrait");
                     return string.IsNullOrWhiteSpace(portrait) ?
                         null :
                         $"https://tb.himg.baidu.com/sys/portrait/item/{WebUtility.UrlEncode(portrait)}";

--- a/src/AspNet.Security.OAuth.BattleNet/BattleNetAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.BattleNet/BattleNetAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the Battle.net options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddBattleNet(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<BattleNetAuthenticationOptions> configuration)
         {
             return builder.AddBattleNet(scheme, BattleNetAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddBattleNet(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<BattleNetAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<BattleNetAuthenticationOptions, BattleNetAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.BattleNet/BattleNetAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.BattleNet/BattleNetAuthenticationHandler.cs
@@ -35,7 +35,7 @@ namespace AspNet.Security.OAuth.BattleNet
             [NotNull] AuthenticationProperties properties,
             [NotNull] OAuthTokenResponse tokens)
         {
-            var address = QueryHelpers.AddQueryString(Options.UserInformationEndpoint, "access_token", tokens.AccessToken);
+            string address = QueryHelpers.AddQueryString(Options.UserInformationEndpoint, "access_token", tokens.AccessToken);
 
             using var request = new HttpRequestMessage(HttpMethod.Get, address);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));

--- a/src/AspNet.Security.OAuth.BattleNet/BattleNetAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.BattleNet/BattleNetAuthenticationHandler.cs
@@ -30,8 +30,10 @@ namespace AspNet.Security.OAuth.BattleNet
         {
         }
 
-        protected override async Task<AuthenticationTicket> CreateTicketAsync([NotNull] ClaimsIdentity identity,
-            [NotNull] AuthenticationProperties properties, [NotNull] OAuthTokenResponse tokens)
+        protected override async Task<AuthenticationTicket> CreateTicketAsync(
+            [NotNull] ClaimsIdentity identity,
+            [NotNull] AuthenticationProperties properties,
+            [NotNull] OAuthTokenResponse tokens)
         {
             var address = QueryHelpers.AddQueryString(Options.UserInformationEndpoint, "access_token", tokens.AccessToken);
 

--- a/src/AspNet.Security.OAuth.BattleNet/BattleNetAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.BattleNet/BattleNetAuthenticationOptions.cs
@@ -8,7 +8,6 @@ using System;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
-using Microsoft.AspNetCore.Http;
 
 namespace AspNet.Security.OAuth.BattleNet
 {
@@ -21,7 +20,7 @@ namespace AspNet.Security.OAuth.BattleNet
         {
             ClaimsIssuer = BattleNetAuthenticationDefaults.Issuer;
 
-            CallbackPath = new PathString(BattleNetAuthenticationDefaults.CallbackPath);
+            CallbackPath = BattleNetAuthenticationDefaults.CallbackPath;
 
             Region = BattleNetAuthenticationRegion.America;
 

--- a/src/AspNet.Security.OAuth.BattleNet/BattleNetAuthenticationRegion.cs
+++ b/src/AspNet.Security.OAuth.BattleNet/BattleNetAuthenticationRegion.cs
@@ -1,4 +1,10 @@
-﻿namespace AspNet.Security.OAuth.BattleNet
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+namespace AspNet.Security.OAuth.BattleNet
 {
     /// <summary>
     /// Defines a list of regions used to determine the appropriate

--- a/src/AspNet.Security.OAuth.Beam/BeamAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.Beam/BeamAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the Beam options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddBeam(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<BeamAuthenticationOptions> configuration)
         {
             return builder.AddBeam(scheme, BeamAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddBeam(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<BeamAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<BeamAuthenticationOptions, BeamAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.Beam/BeamAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Beam/BeamAuthenticationHandler.cs
@@ -29,8 +29,10 @@ namespace AspNet.Security.OAuth.Beam
         {
         }
 
-        protected override async Task<AuthenticationTicket> CreateTicketAsync([NotNull] ClaimsIdentity identity,
-            [NotNull] AuthenticationProperties properties, [NotNull] OAuthTokenResponse tokens)
+        protected override async Task<AuthenticationTicket> CreateTicketAsync(
+            [NotNull] ClaimsIdentity identity,
+            [NotNull] AuthenticationProperties properties,
+            [NotNull] OAuthTokenResponse tokens)
         {
             using var request = new HttpRequestMessage(HttpMethod.Get, Options.UserInformationEndpoint);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));

--- a/src/AspNet.Security.OAuth.Beam/BeamAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Beam/BeamAuthenticationOptions.cs
@@ -7,7 +7,6 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
-using Microsoft.AspNetCore.Http;
 
 namespace AspNet.Security.OAuth.Beam
 {
@@ -19,7 +18,7 @@ namespace AspNet.Security.OAuth.Beam
         public BeamAuthenticationOptions()
         {
             ClaimsIssuer = BeamAuthenticationDefaults.Issuer;
-            CallbackPath = new PathString(BeamAuthenticationDefaults.CallbackPath);
+            CallbackPath = BeamAuthenticationDefaults.CallbackPath;
 
             AuthorizationEndpoint = BeamAuthenticationDefaults.AuthorizationEndpoint;
             TokenEndpoint = BeamAuthenticationDefaults.TokenEndpoint;

--- a/src/AspNet.Security.OAuth.Bitbucket/BitbucketAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.Bitbucket/BitbucketAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the Bitbucket options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddBitbucket(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<BitbucketAuthenticationOptions> configuration)
         {
             return builder.AddBitbucket(scheme, BitbucketAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddBitbucket(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<BitbucketAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<BitbucketAuthenticationOptions, BitbucketAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.Bitbucket/BitbucketAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Bitbucket/BitbucketAuthenticationHandler.cs
@@ -30,8 +30,10 @@ namespace AspNet.Security.OAuth.Bitbucket
         {
         }
 
-        protected override async Task<AuthenticationTicket> CreateTicketAsync([NotNull] ClaimsIdentity identity,
-            [NotNull] AuthenticationProperties properties, [NotNull] OAuthTokenResponse tokens)
+        protected override async Task<AuthenticationTicket> CreateTicketAsync(
+            [NotNull] ClaimsIdentity identity,
+            [NotNull] AuthenticationProperties properties,
+            [NotNull] OAuthTokenResponse tokens)
         {
             using var request = new HttpRequestMessage(HttpMethod.Get, Options.UserInformationEndpoint);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));

--- a/src/AspNet.Security.OAuth.Bitbucket/BitbucketAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Bitbucket/BitbucketAuthenticationHandler.cs
@@ -60,9 +60,11 @@ namespace AspNet.Security.OAuth.Bitbucket
             // When the email address is not public, retrieve it from
             // the emails endpoint if the user:email scope is specified.
             if (!string.IsNullOrEmpty(Options.UserEmailsEndpoint) &&
-                !identity.HasClaim(claim => claim.Type == ClaimTypes.Email) && Options.Scope.Contains("email"))
+                !identity.HasClaim(claim => claim.Type == ClaimTypes.Email) &&
+                Options.Scope.Contains("email"))
             {
-                var address = await GetEmailAsync(tokens);
+                string address = await GetEmailAsync(tokens);
+
                 if (!string.IsNullOrEmpty(address))
                 {
                     identity.AddClaim(new Claim(ClaimTypes.Email, address, ClaimValueTypes.String, Options.ClaimsIssuer));

--- a/src/AspNet.Security.OAuth.Bitbucket/BitbucketAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Bitbucket/BitbucketAuthenticationOptions.cs
@@ -7,7 +7,6 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
-using Microsoft.AspNetCore.Http;
 using static AspNet.Security.OAuth.Bitbucket.BitbucketAuthenticationConstants;
 
 namespace AspNet.Security.OAuth.Bitbucket
@@ -20,7 +19,7 @@ namespace AspNet.Security.OAuth.Bitbucket
         public BitbucketAuthenticationOptions()
         {
             ClaimsIssuer = BitbucketAuthenticationDefaults.Issuer;
-            CallbackPath = new PathString(BitbucketAuthenticationDefaults.CallbackPath);
+            CallbackPath = BitbucketAuthenticationDefaults.CallbackPath;
 
             AuthorizationEndpoint = BitbucketAuthenticationDefaults.AuthorizationEndpoint;
             TokenEndpoint = BitbucketAuthenticationDefaults.TokenEndpoint;

--- a/src/AspNet.Security.OAuth.Buffer/BufferAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.Buffer/BufferAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the Buffer options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddBuffer(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<BufferAuthenticationOptions> configuration)
         {
             return builder.AddBuffer(scheme, BufferAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddBuffer(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<BufferAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<BufferAuthenticationOptions, BufferAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.Buffer/BufferAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Buffer/BufferAuthenticationHandler.cs
@@ -29,8 +29,10 @@ namespace AspNet.Security.OAuth.Buffer
         {
         }
 
-        protected override async Task<AuthenticationTicket> CreateTicketAsync([NotNull] ClaimsIdentity identity,
-            [NotNull] AuthenticationProperties properties, [NotNull] OAuthTokenResponse tokens)
+        protected override async Task<AuthenticationTicket> CreateTicketAsync(
+            [NotNull] ClaimsIdentity identity,
+            [NotNull] AuthenticationProperties properties,
+            [NotNull] OAuthTokenResponse tokens)
         {
             using var request = new HttpRequestMessage(HttpMethod.Get, Options.UserInformationEndpoint);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));

--- a/src/AspNet.Security.OAuth.Buffer/BufferAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Buffer/BufferAuthenticationOptions.cs
@@ -7,7 +7,6 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
-using Microsoft.AspNetCore.Http;
 
 namespace AspNet.Security.OAuth.Buffer
 {
@@ -19,7 +18,7 @@ namespace AspNet.Security.OAuth.Buffer
         public BufferAuthenticationOptions()
         {
             ClaimsIssuer = BufferAuthenticationDefaults.Issuer;
-            CallbackPath = new PathString(BufferAuthenticationDefaults.CallbackPath);
+            CallbackPath = BufferAuthenticationDefaults.CallbackPath;
 
             AuthorizationEndpoint = BufferAuthenticationDefaults.AuthorizationEndpoint;
             TokenEndpoint = BufferAuthenticationDefaults.TokenEndpoint;

--- a/src/AspNet.Security.OAuth.CiscoSpark/CiscoSparkAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.CiscoSpark/CiscoSparkAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the CiscoSpark options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddCiscoSpark(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<CiscoSparkAuthenticationOptions> configuration)
         {
             return builder.AddCiscoSpark(scheme, CiscoSparkAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddCiscoSpark(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<CiscoSparkAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<CiscoSparkAuthenticationOptions, CiscoSparkAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.CiscoSpark/CiscoSparkAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.CiscoSpark/CiscoSparkAuthenticationHandler.cs
@@ -29,8 +29,10 @@ namespace AspNet.Security.OAuth.CiscoSpark
         {
         }
 
-        protected override async Task<AuthenticationTicket> CreateTicketAsync([NotNull] ClaimsIdentity identity,
-            [NotNull] AuthenticationProperties properties, [NotNull] OAuthTokenResponse tokens)
+        protected override async Task<AuthenticationTicket> CreateTicketAsync(
+            [NotNull] ClaimsIdentity identity,
+            [NotNull] AuthenticationProperties properties,
+            [NotNull] OAuthTokenResponse tokens)
         {
 
             using var request = new HttpRequestMessage(HttpMethod.Get, Options.UserInformationEndpoint);

--- a/src/AspNet.Security.OAuth.CiscoSpark/CiscoSparkAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.CiscoSpark/CiscoSparkAuthenticationHandler.cs
@@ -34,7 +34,6 @@ namespace AspNet.Security.OAuth.CiscoSpark
             [NotNull] AuthenticationProperties properties,
             [NotNull] OAuthTokenResponse tokens)
         {
-
             using var request = new HttpRequestMessage(HttpMethod.Get, Options.UserInformationEndpoint);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", tokens.AccessToken);

--- a/src/AspNet.Security.OAuth.CiscoSpark/CiscoSparkAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.CiscoSpark/CiscoSparkAuthenticationOptions.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
-using Microsoft.AspNetCore.Http;
 
 namespace AspNet.Security.OAuth.CiscoSpark
 {
@@ -20,7 +19,7 @@ namespace AspNet.Security.OAuth.CiscoSpark
         public CiscoSparkAuthenticationOptions()
         {
             ClaimsIssuer = CiscoSparkAuthenticationDefaults.Issuer;
-            CallbackPath = new PathString(CiscoSparkAuthenticationDefaults.CallbackPath);
+            CallbackPath = CiscoSparkAuthenticationDefaults.CallbackPath;
 
             AuthorizationEndpoint = CiscoSparkAuthenticationDefaults.AuthorizationEndpoint;
             TokenEndpoint = CiscoSparkAuthenticationDefaults.TokenEndpoint;

--- a/src/AspNet.Security.OAuth.Deezer/DeezerAuthenticationConstants.cs
+++ b/src/AspNet.Security.OAuth.Deezer/DeezerAuthenticationConstants.cs
@@ -11,8 +11,6 @@ namespace AspNet.Security.OAuth.Deezer
     /// </summary>
     public static class DeezerAuthenticationConstants
     {
-#pragma warning disable CA1034 // Nested types should not be visible
-
         public static class Claims
         {
             public const string Username = "urn:deezer:username";
@@ -53,32 +51,30 @@ namespace AspNet.Security.OAuth.Deezer
             /// Access user data any time
             /// <para>Application may access user data at any time.</para>
             /// </summary>
-            public const string Offline_Access = "offline_access";
+            public const string OfflineAccess = "offline_access";
 
             /// <summary>
             /// Manage users' library
             /// <para>Add/rename a playlist. Add/order songs in the playlist.</para>
             /// </summary>
-            public const string Manage_Library = "manage_library";
+            public const string ManageLibrary = "manage_library";
 
             /// <summary>
             /// Manage users' friends
             /// <para>Add/remove a following/follower.</para>
             /// </summary>
-            public const string Manage_Community = "manage_community";
+            public const string ManageCommunity = "manage_community";
 
             /// <summary>
             /// Delete library items
             /// <para>Allow the application to delete items in the user's library.</para>
             /// </summary>
-            public const string Delete_Library = "delete_library";
+            public const string DeleteLibrary = "delete_library";
 
             /// <summary>
             /// Allow the application to access the user's listening history
             /// </summary>
-            public const string Listening_History = "listening_history";
+            public const string ListeningHistory = "listening_history";
         }
-
-#pragma warning restore CA1034 // Nested types should not be visible
     }
 }

--- a/src/AspNet.Security.OAuth.Deezer/DeezerAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.Deezer/DeezerAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the Deezer options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddDeezer(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<DeezerAuthenticationOptions> configuration)
         {
             return builder.AddDeezer(scheme, DeezerAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddDeezer(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<DeezerAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<DeezerAuthenticationOptions, DeezerAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.Deezer/DeezerAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Deezer/DeezerAuthenticationHandler.cs
@@ -75,8 +75,10 @@ namespace AspNet.Security.OAuth.Deezer
             return OAuthTokenResponse.Success(payload);
         }
 
-        protected override async Task<AuthenticationTicket> CreateTicketAsync([NotNull] ClaimsIdentity identity,
-            [NotNull] AuthenticationProperties properties, [NotNull] OAuthTokenResponse tokens)
+        protected override async Task<AuthenticationTicket> CreateTicketAsync(
+            [NotNull] ClaimsIdentity identity,
+            [NotNull] AuthenticationProperties properties,
+            [NotNull] OAuthTokenResponse tokens)
         {
             string address = QueryHelpers.AddQueryString(Options.UserInformationEndpoint, "access_token", tokens.AccessToken);
 

--- a/src/AspNet.Security.OAuth.Deezer/DeezerAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Deezer/DeezerAuthenticationHandler.cs
@@ -35,7 +35,7 @@ namespace AspNet.Security.OAuth.Deezer
         {
         }
 
-        protected override async Task<OAuthTokenResponse> ExchangeCodeAsync(OAuthCodeExchangeContext context)
+        protected override async Task<OAuthTokenResponse> ExchangeCodeAsync([NotNull] OAuthCodeExchangeContext context)
         {
             var tokenRequestParameters = new Dictionary<string, string>()
             {
@@ -107,7 +107,7 @@ namespace AspNet.Security.OAuth.Deezer
             return new AuthenticationTicket(context.Principal, context.Properties, Scheme.Name);
         }
 
-        protected override string BuildChallengeUrl(AuthenticationProperties properties, string redirectUri)
+        protected override string BuildChallengeUrl([NotNull] AuthenticationProperties properties, [NotNull] string redirectUri)
         {
             var scopeParameter = properties.GetParameter<ICollection<string>>(OAuthChallengeProperties.ScopeKey);
             string scopes = scopeParameter != null ? FormatScope(scopeParameter) : FormatScope();
@@ -140,7 +140,7 @@ namespace AspNet.Security.OAuth.Deezer
         }
 
         /// <inheritdoc/>
-        protected override string FormatScope(IEnumerable<string> scopes)
+        protected override string FormatScope([NotNull] IEnumerable<string> scopes)
             => string.Join(",", scopes);
     }
 }

--- a/src/AspNet.Security.OAuth.Deezer/DeezerAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Deezer/DeezerAuthenticationHandler.cs
@@ -46,7 +46,7 @@ namespace AspNet.Security.OAuth.Deezer
             };
 
             // PKCE https://tools.ietf.org/html/rfc7636#section-4.5, see BuildChallengeUrl
-            if (context.Properties.Items.TryGetValue(OAuthConstants.CodeVerifierKey, out string codeVerifier))
+            if (context.Properties.Items.TryGetValue(OAuthConstants.CodeVerifierKey, out string? codeVerifier))
             {
                 tokenRequestParameters.Add(OAuthConstants.CodeVerifierKey, codeVerifier);
                 context.Properties.Items.Remove(OAuthConstants.CodeVerifierKey);

--- a/src/AspNet.Security.OAuth.Deezer/DeezerAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Deezer/DeezerAuthenticationHandler.cs
@@ -39,10 +39,10 @@ namespace AspNet.Security.OAuth.Deezer
         {
             var tokenRequestParameters = new Dictionary<string, string>()
             {
-                { "app_id", Options.ClientId },
-                { "secret", Options.ClientSecret },
-                { "code", context.Code },
-                { "output", "json" }
+                ["app_id"] = Options.ClientId,
+                ["secret"] = Options.ClientSecret,
+                ["code"] = context.Code,
+                ["output"] = "json",
             };
 
             // PKCE https://tools.ietf.org/html/rfc7636#section-4.5, see BuildChallengeUrl
@@ -114,9 +114,9 @@ namespace AspNet.Security.OAuth.Deezer
 
             var parameters = new Dictionary<string, string>
             {
-                { "app_id", Options.ClientId },
-                { "redirect_uri", redirectUri },
-                { "perms", scopes }
+                ["app_id"] = Options.ClientId,
+                ["redirect_uri"] = redirectUri,
+                ["perms"] = scopes,
             };
 
             if (Options.UsePkce)

--- a/src/AspNet.Security.OAuth.DeviantArt/DeviantArtAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.DeviantArt/DeviantArtAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the DeviantArt options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddDeviantArt(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<DeviantArtAuthenticationOptions> configuration)
         {
             return builder.AddDeviantArt(scheme, DeviantArtAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddDeviantArt(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<DeviantArtAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<DeviantArtAuthenticationOptions, DeviantArtAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.DeviantArt/DeviantArtAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.DeviantArt/DeviantArtAuthenticationHandler.cs
@@ -29,8 +29,10 @@ namespace AspNet.Security.OAuth.DeviantArt
         {
         }
 
-        protected override async Task<AuthenticationTicket> CreateTicketAsync([NotNull] ClaimsIdentity identity,
-            [NotNull] AuthenticationProperties properties, [NotNull] OAuthTokenResponse tokens)
+        protected override async Task<AuthenticationTicket> CreateTicketAsync(
+            [NotNull] ClaimsIdentity identity,
+            [NotNull] AuthenticationProperties properties,
+            [NotNull] OAuthTokenResponse tokens)
         {
             using var request = new HttpRequestMessage(HttpMethod.Get, Options.UserInformationEndpoint);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));

--- a/src/AspNet.Security.OAuth.DeviantArt/DeviantArtAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.DeviantArt/DeviantArtAuthenticationOptions.cs
@@ -7,7 +7,6 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
-using Microsoft.AspNetCore.Http;
 using static AspNet.Security.OAuth.DeviantArt.DeviantArtAuthenticationConstants;
 
 namespace AspNet.Security.OAuth.DeviantArt
@@ -20,7 +19,7 @@ namespace AspNet.Security.OAuth.DeviantArt
         public DeviantArtAuthenticationOptions()
         {
             ClaimsIssuer = DeviantArtAuthenticationDefaults.Issuer;
-            CallbackPath = new PathString(DeviantArtAuthenticationDefaults.CallbackPath);
+            CallbackPath = DeviantArtAuthenticationDefaults.CallbackPath;
 
             AuthorizationEndpoint = DeviantArtAuthenticationDefaults.AuthorizationEndpoint;
             TokenEndpoint = DeviantArtAuthenticationDefaults.TokenEndpoint;

--- a/src/AspNet.Security.OAuth.Discord/DiscordAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.Discord/DiscordAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the Discord options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddDiscord(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<DiscordAuthenticationOptions> configuration)
         {
             return builder.AddDiscord(scheme, DiscordAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddDiscord(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<DiscordAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<DiscordAuthenticationOptions, DiscordAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.Discord/DiscordAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Discord/DiscordAuthenticationHandler.cs
@@ -1,4 +1,5 @@
 /*
+﻿/*
  * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
  * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
  * for more information concerning the license and the contributors participating to this project.
@@ -29,8 +30,10 @@ namespace AspNet.Security.OAuth.Discord
         {
         }
 
-        protected override async Task<AuthenticationTicket> CreateTicketAsync([NotNull] ClaimsIdentity identity,
-            [NotNull] AuthenticationProperties properties, [NotNull] OAuthTokenResponse tokens)
+        protected override async Task<AuthenticationTicket> CreateTicketAsync(
+            [NotNull] ClaimsIdentity identity,
+            [NotNull] AuthenticationProperties properties,
+            [NotNull] OAuthTokenResponse tokens)
         {
             using var request = new HttpRequestMessage(HttpMethod.Get, Options.UserInformationEndpoint);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));

--- a/src/AspNet.Security.OAuth.Discord/DiscordAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Discord/DiscordAuthenticationHandler.cs
@@ -1,4 +1,3 @@
-/*
 ﻿/*
  * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
  * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers

--- a/src/AspNet.Security.OAuth.Discord/DiscordAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Discord/DiscordAuthenticationOptions.cs
@@ -4,6 +4,7 @@
  * for more information concerning the license and the contributors participating to this project.
  */
 
+using System.Globalization;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
@@ -39,10 +40,14 @@ namespace AspNet.Security.OAuth.Discord
             ClaimActions.MapJsonKey(ClaimTypes.Name, "username");
             ClaimActions.MapJsonKey(ClaimTypes.Email, "email");
             ClaimActions.MapJsonKey(Claims.AvatarHash, "avatar");
-            ClaimActions.MapCustomJson(Claims.AvatarUrl, user => {
-                return string.Format(DiscordAvatarFormat, DiscordCdn.TrimEnd('/'), user.GetString("id"), user.GetString("avatar"));
-            });
             ClaimActions.MapJsonKey(Claims.Discriminator, "discriminator");
+            ClaimActions.MapCustomJson(Claims.AvatarUrl, user =>
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    DiscordAvatarFormat,
+                    DiscordCdn.TrimEnd('/'),
+                    user.GetString("id"),
+                    user.GetString("avatar")));
 
             Scope.Add("identify");
         }

--- a/src/AspNet.Security.OAuth.Discord/DiscordAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Discord/DiscordAuthenticationOptions.cs
@@ -31,7 +31,7 @@ namespace AspNet.Security.OAuth.Discord
         public DiscordAuthenticationOptions()
         {
             ClaimsIssuer = DiscordAuthenticationDefaults.Issuer;
-            CallbackPath = new PathString(DiscordAuthenticationDefaults.CallbackPath);
+            CallbackPath = DiscordAuthenticationDefaults.CallbackPath;
             AuthorizationEndpoint = DiscordAuthenticationDefaults.AuthorizationEndpoint;
             TokenEndpoint = DiscordAuthenticationDefaults.TokenEndpoint;
             UserInformationEndpoint = DiscordAuthenticationDefaults.UserInformationEndpoint;

--- a/src/AspNet.Security.OAuth.Dropbox/DropboxAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.Dropbox/DropboxAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the Dropbox options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddDropbox(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<DropboxAuthenticationOptions> configuration)
         {
             return builder.AddDropbox(scheme, DropboxAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddDropbox(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<DropboxAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<DropboxAuthenticationOptions, DropboxAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.Dropbox/DropboxAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Dropbox/DropboxAuthenticationHandler.cs
@@ -29,8 +29,10 @@ namespace AspNet.Security.OAuth.Dropbox
         {
         }
 
-        protected override async Task<AuthenticationTicket> CreateTicketAsync([NotNull] ClaimsIdentity identity,
-            [NotNull] AuthenticationProperties properties, [NotNull] OAuthTokenResponse tokens)
+        protected override async Task<AuthenticationTicket> CreateTicketAsync(
+            [NotNull] ClaimsIdentity identity,
+            [NotNull] AuthenticationProperties properties,
+            [NotNull] OAuthTokenResponse tokens)
         {
             using var request = new HttpRequestMessage(HttpMethod.Post, Options.UserInformationEndpoint);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));

--- a/src/AspNet.Security.OAuth.Dropbox/DropboxAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Dropbox/DropboxAuthenticationOptions.cs
@@ -7,7 +7,6 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
-using Microsoft.AspNetCore.Http;
 
 namespace AspNet.Security.OAuth.Dropbox
 {
@@ -20,7 +19,7 @@ namespace AspNet.Security.OAuth.Dropbox
         {
             ClaimsIssuer = DropboxAuthenticationDefaults.Issuer;
 
-            CallbackPath = new PathString(DropboxAuthenticationDefaults.CallbackPath);
+            CallbackPath = DropboxAuthenticationDefaults.CallbackPath;
 
             AuthorizationEndpoint = DropboxAuthenticationDefaults.AuthorizationEndpoint;
             TokenEndpoint = DropboxAuthenticationDefaults.TokenEndpoint;

--- a/src/AspNet.Security.OAuth.EVEOnline/EVEOnlineAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.EVEOnline/EVEOnlineAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the EVEOnline options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddEVEOnline(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<EVEOnlineAuthenticationOptions> configuration)
         {
             return builder.AddEVEOnline(scheme, EVEOnlineAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddEVEOnline(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<EVEOnlineAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<EVEOnlineAuthenticationOptions, EVEOnlineAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.EVEOnline/EVEOnlineAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.EVEOnline/EVEOnlineAuthenticationHandler.cs
@@ -29,8 +29,10 @@ namespace AspNet.Security.OAuth.EVEOnline
         {
         }
 
-        protected override async Task<AuthenticationTicket> CreateTicketAsync([NotNull] ClaimsIdentity identity,
-            [NotNull] AuthenticationProperties properties, [NotNull] OAuthTokenResponse tokens)
+        protected override async Task<AuthenticationTicket> CreateTicketAsync(
+            [NotNull] ClaimsIdentity identity,
+            [NotNull] AuthenticationProperties properties,
+            [NotNull] OAuthTokenResponse tokens)
         {
             using var request = new HttpRequestMessage(HttpMethod.Get, Options.UserInformationEndpoint);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));

--- a/src/AspNet.Security.OAuth.EVEOnline/EVEOnlineAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.EVEOnline/EVEOnlineAuthenticationOptions.cs
@@ -8,7 +8,6 @@ using System;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
-using Microsoft.AspNetCore.Http;
 using static AspNet.Security.OAuth.EVEOnline.EVEOnlineAuthenticationConstants;
 
 namespace AspNet.Security.OAuth.EVEOnline
@@ -21,7 +20,7 @@ namespace AspNet.Security.OAuth.EVEOnline
         public EVEOnlineAuthenticationOptions()
         {
             ClaimsIssuer = EVEOnlineAuthenticationDefaults.Issuer;
-            CallbackPath = new PathString(EVEOnlineAuthenticationDefaults.CallbackPath);
+            CallbackPath = EVEOnlineAuthenticationDefaults.CallbackPath;
 
             Server = EVEOnlineAuthenticationServer.Tranquility;
 

--- a/src/AspNet.Security.OAuth.Fitbit/FitbitAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.Fitbit/FitbitAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the Fitbit options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddFitbit(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<FitbitAuthenticationOptions> configuration)
         {
             return builder.AddFitbit(scheme, FitbitAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddFitbit(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<FitbitAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<FitbitAuthenticationOptions, FitbitAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.Fitbit/FitbitAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Fitbit/FitbitAuthenticationHandler.cs
@@ -107,7 +107,8 @@ namespace AspNet.Security.OAuth.Fitbit
 
             string credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes(
                 string.Concat(
-                    EscapeDataString(Options.ClientId), ":",
+                    EscapeDataString(Options.ClientId),
+                    ":",
                     EscapeDataString(Options.ClientSecret))));
 
             return new AuthenticationHeaderValue("Basic", credentials);

--- a/src/AspNet.Security.OAuth.Fitbit/FitbitAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Fitbit/FitbitAuthenticationHandler.cs
@@ -95,7 +95,7 @@ namespace AspNet.Security.OAuth.Fitbit
 
         private AuthenticationHeaderValue CreateAuthorizationHeader()
         {
-            static string EscapeDataString(string value)
+            static string? EscapeDataString(string value)
             {
                 if (string.IsNullOrEmpty(value))
                 {

--- a/src/AspNet.Security.OAuth.Fitbit/FitbitAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Fitbit/FitbitAuthenticationHandler.cs
@@ -102,7 +102,7 @@ namespace AspNet.Security.OAuth.Fitbit
                     return null;
                 }
 
-                return Uri.EscapeDataString(value).Replace("%20", "+");
+                return Uri.EscapeDataString(value).Replace("%20", "+", StringComparison.Ordinal);
             }
 
             string credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes(

--- a/src/AspNet.Security.OAuth.Fitbit/FitbitAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Fitbit/FitbitAuthenticationOptions.cs
@@ -7,7 +7,6 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
-using Microsoft.AspNetCore.Http;
 using static AspNet.Security.OAuth.Fitbit.FitbitAuthenticationConstants;
 
 namespace AspNet.Security.OAuth.Fitbit
@@ -20,7 +19,7 @@ namespace AspNet.Security.OAuth.Fitbit
         public FitbitAuthenticationOptions()
         {
             ClaimsIssuer = FitbitAuthenticationDefaults.Issuer;
-            CallbackPath = new PathString(FitbitAuthenticationDefaults.CallbackPath);
+            CallbackPath = FitbitAuthenticationDefaults.CallbackPath;
 
             AuthorizationEndpoint = FitbitAuthenticationDefaults.AuthorizationEndpoint;
             TokenEndpoint = FitbitAuthenticationDefaults.TokenEndpoint;

--- a/src/AspNet.Security.OAuth.Foursquare/FoursquareAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.Foursquare/FoursquareAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the Foursquare options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddFoursquare(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<FoursquareAuthenticationOptions> configuration)
         {
             return builder.AddFoursquare(scheme, FoursquareAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddFoursquare(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<FoursquareAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<FoursquareAuthenticationOptions, FoursquareAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.Foursquare/FoursquareAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Foursquare/FoursquareAuthenticationHandler.cs
@@ -37,7 +37,7 @@ namespace AspNet.Security.OAuth.Foursquare
         {
             // See https://developer.foursquare.com/overview/versioning
             // for more information about the mandatory "v" and "m" parameters.
-            var address = QueryHelpers.AddQueryString(Options.UserInformationEndpoint, new Dictionary<string, string>
+            string address = QueryHelpers.AddQueryString(Options.UserInformationEndpoint, new Dictionary<string, string>
             {
                 ["m"] = "foursquare",
                 ["v"] = !string.IsNullOrEmpty(Options.ApiVersion) ? Options.ApiVersion : FoursquareAuthenticationDefaults.ApiVersion,

--- a/src/AspNet.Security.OAuth.Foursquare/FoursquareAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Foursquare/FoursquareAuthenticationHandler.cs
@@ -30,8 +30,10 @@ namespace AspNet.Security.OAuth.Foursquare
         {
         }
 
-        protected override async Task<AuthenticationTicket> CreateTicketAsync([NotNull] ClaimsIdentity identity,
-            [NotNull] AuthenticationProperties properties, [NotNull] OAuthTokenResponse tokens)
+        protected override async Task<AuthenticationTicket> CreateTicketAsync(
+            [NotNull] ClaimsIdentity identity,
+            [NotNull] AuthenticationProperties properties,
+            [NotNull] OAuthTokenResponse tokens)
         {
             // See https://developer.foursquare.com/overview/versioning
             // for more information about the mandatory "v" and "m" parameters.

--- a/src/AspNet.Security.OAuth.Foursquare/FoursquareAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Foursquare/FoursquareAuthenticationOptions.cs
@@ -19,7 +19,7 @@ namespace AspNet.Security.OAuth.Foursquare
         public FoursquareAuthenticationOptions()
         {
             ClaimsIssuer = FoursquareAuthenticationDefaults.Issuer;
-            CallbackPath = new PathString(FoursquareAuthenticationDefaults.CallbackPath);
+            CallbackPath = FoursquareAuthenticationDefaults.CallbackPath;
 
             AuthorizationEndpoint = FoursquareAuthenticationDefaults.AuthorizationEndpoint;
             TokenEndpoint = FoursquareAuthenticationDefaults.TokenEndpoint;

--- a/src/AspNet.Security.OAuth.GitHub/GitHubAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.GitHub/GitHubAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the GitHub options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddGitHub(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<GitHubAuthenticationOptions> configuration)
         {
             return builder.AddGitHub(scheme, GitHubAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddGitHub(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<GitHubAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<GitHubAuthenticationOptions, GitHubAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.GitHub/GitHubAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.GitHub/GitHubAuthenticationHandler.cs
@@ -30,8 +30,10 @@ namespace AspNet.Security.OAuth.GitHub
         {
         }
 
-        protected override async Task<AuthenticationTicket> CreateTicketAsync([NotNull] ClaimsIdentity identity,
-            [NotNull] AuthenticationProperties properties, [NotNull] OAuthTokenResponse tokens)
+        protected override async Task<AuthenticationTicket> CreateTicketAsync(
+            [NotNull] ClaimsIdentity identity,
+            [NotNull] AuthenticationProperties properties,
+            [NotNull] OAuthTokenResponse tokens)
         {
             using var request = new HttpRequestMessage(HttpMethod.Get, Options.UserInformationEndpoint);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));

--- a/src/AspNet.Security.OAuth.GitHub/GitHubAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.GitHub/GitHubAuthenticationHandler.cs
@@ -60,9 +60,11 @@ namespace AspNet.Security.OAuth.GitHub
             // When the email address is not public, retrieve it from
             // the emails endpoint if the user:email scope is specified.
             if (!string.IsNullOrEmpty(Options.UserEmailsEndpoint) &&
-                !identity.HasClaim(claim => claim.Type == ClaimTypes.Email) && Options.Scope.Contains("user:email"))
+                !identity.HasClaim(claim => claim.Type == ClaimTypes.Email) &&
+                Options.Scope.Contains("user:email"))
             {
-                var address = await GetEmailAsync(tokens);
+                string address = await GetEmailAsync(tokens);
+
                 if (!string.IsNullOrEmpty(address))
                 {
                     identity.AddClaim(new Claim(ClaimTypes.Email, address, ClaimValueTypes.String, Options.ClaimsIssuer));

--- a/src/AspNet.Security.OAuth.GitHub/GitHubAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.GitHub/GitHubAuthenticationOptions.cs
@@ -7,7 +7,6 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
-using Microsoft.AspNetCore.Http;
 using static AspNet.Security.OAuth.GitHub.GitHubAuthenticationConstants;
 
 namespace AspNet.Security.OAuth.GitHub
@@ -21,7 +20,7 @@ namespace AspNet.Security.OAuth.GitHub
         {
             ClaimsIssuer = GitHubAuthenticationDefaults.Issuer;
 
-            CallbackPath = new PathString(GitHubAuthenticationDefaults.CallbackPath);
+            CallbackPath = GitHubAuthenticationDefaults.CallbackPath;
 
             AuthorizationEndpoint = GitHubAuthenticationDefaults.AuthorizationEndpoint;
             TokenEndpoint = GitHubAuthenticationDefaults.TokenEndpoint;

--- a/src/AspNet.Security.OAuth.GitLab/GitLabAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.GitLab/GitLabAuthenticationHandler.cs
@@ -30,9 +30,9 @@ namespace AspNet.Security.OAuth.GitLab
         }
 
         protected override async Task<AuthenticationTicket> CreateTicketAsync(
-            ClaimsIdentity identity,
-            AuthenticationProperties properties,
-            OAuthTokenResponse tokens)
+            [NotNull] ClaimsIdentity identity,
+            [NotNull] AuthenticationProperties properties,
+            [NotNull] OAuthTokenResponse tokens)
         {
             // Get the GitLab user
             using var request = new HttpRequestMessage(HttpMethod.Get, Options.UserInformationEndpoint);

--- a/src/AspNet.Security.OAuth.Gitee/GiteeAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.Gitee/GiteeAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the Gitee options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddGitee(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<GiteeAuthenticationOptions> configuration)
         {
             return builder.AddGitee(scheme, GiteeAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddGitee(
             [NotNull]this AuthenticationBuilder builder,
-            [NotNull] string scheme,[CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<GiteeAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<GiteeAuthenticationOptions, GiteeAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.Gitee/GiteeAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Gitee/GiteeAuthenticationHandler.cs
@@ -9,13 +9,13 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
+using System.Text.Json;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using System.Text.Json;
 
 namespace AspNet.Security.OAuth.Gitee
 {

--- a/src/AspNet.Security.OAuth.Gitee/GiteeAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Gitee/GiteeAuthenticationHandler.cs
@@ -60,9 +60,11 @@ namespace AspNet.Security.OAuth.Gitee
             // When the email address is not public, retrieve it from
             // the emails endpoint if the user:email scope is specified.
             if (!string.IsNullOrEmpty(Options.UserEmailsEndpoint) &&
-                !identity.HasClaim(claim => claim.Type == ClaimTypes.Email) && Options.Scope.Contains("emails"))
+                !identity.HasClaim(claim => claim.Type == ClaimTypes.Email) &&
+                Options.Scope.Contains("emails"))
             {
-                var address = await GetEmailAsync(tokens);
+                string address = await GetEmailAsync(tokens);
+
                 if (!string.IsNullOrEmpty(address))
                 {
                     identity.AddClaim(new Claim(ClaimTypes.Email, address, ClaimValueTypes.String, Options.ClaimsIssuer));

--- a/src/AspNet.Security.OAuth.Gitee/GiteeAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Gitee/GiteeAuthenticationHandler.cs
@@ -30,7 +30,10 @@ namespace AspNet.Security.OAuth.Gitee
             {
             }
 
-        protected override async Task<AuthenticationTicket> CreateTicketAsync(ClaimsIdentity identity, AuthenticationProperties properties, OAuthTokenResponse tokens)
+        protected override async Task<AuthenticationTicket> CreateTicketAsync(
+            [NotNull] ClaimsIdentity identity,
+            [NotNull] AuthenticationProperties properties,
+            [NotNull] OAuthTokenResponse tokens)
         {
             using var request = new HttpRequestMessage(HttpMethod.Get, Options.UserInformationEndpoint);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));

--- a/src/AspNet.Security.OAuth.Gitee/GiteeAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Gitee/GiteeAuthenticationOptions.cs
@@ -7,14 +7,13 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
-using Microsoft.AspNetCore.Http;
 using static AspNet.Security.OAuth.Gitee.GiteeAuthenticationConstants;
 
 namespace AspNet.Security.OAuth.Gitee
 {
     /// <summary>
-     /// Defines a set of options used by <see cref="GiteeAuthenticationHandler"/>.
-     /// </summary>
+    /// Defines a set of options used by <see cref="GiteeAuthenticationHandler"/>.
+    /// </summary>
     public class GiteeAuthenticationOptions : OAuthOptions
     {
         public GiteeAuthenticationOptions()

--- a/src/AspNet.Security.OAuth.Gitee/GiteeAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Gitee/GiteeAuthenticationOptions.cs
@@ -41,6 +41,6 @@ namespace AspNet.Security.OAuth.Gitee
         /// Gets or sets the address of the endpoint exposing
         /// the email addresses associated with the logged in user.
         /// </summary>
-        public string UserEmailsEndpoint { get; set; } 
+        public string UserEmailsEndpoint { get; set; }
     }
 }

--- a/src/AspNet.Security.OAuth.Gitter/GitterAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.Gitter/GitterAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the Gitter options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddGitter(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<GitterAuthenticationOptions> configuration)
         {
             return builder.AddGitter(scheme, GitterAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddGitter(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<GitterAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<GitterAuthenticationOptions, GitterAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.Gitter/GitterAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Gitter/GitterAuthenticationHandler.cs
@@ -29,8 +29,10 @@ namespace AspNet.Security.OAuth.Gitter
         {
         }
 
-        protected override async Task<AuthenticationTicket> CreateTicketAsync([NotNull] ClaimsIdentity identity,
-            [NotNull] AuthenticationProperties properties, [NotNull] OAuthTokenResponse tokens)
+        protected override async Task<AuthenticationTicket> CreateTicketAsync(
+            [NotNull] ClaimsIdentity identity,
+            [NotNull] AuthenticationProperties properties,
+            [NotNull] OAuthTokenResponse tokens)
         {
             using var request = new HttpRequestMessage(HttpMethod.Get, Options.UserInformationEndpoint);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));

--- a/src/AspNet.Security.OAuth.Gitter/GitterAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Gitter/GitterAuthenticationOptions.cs
@@ -7,7 +7,6 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
-using Microsoft.AspNetCore.Http;
 
 namespace AspNet.Security.OAuth.Gitter
 {
@@ -17,7 +16,7 @@ namespace AspNet.Security.OAuth.Gitter
         {
             ClaimsIssuer = GitterAuthenticationDefaults.Issuer;
 
-            CallbackPath = new PathString(GitterAuthenticationDefaults.CallbackPath);
+            CallbackPath = GitterAuthenticationDefaults.CallbackPath;
 
             AuthorizationEndpoint = GitterAuthenticationDefaults.AuthorizationEndpoint;
             TokenEndpoint = GitterAuthenticationDefaults.TokenEndpoint;

--- a/src/AspNet.Security.OAuth.Harvest/HarvestAuthenticationDefaults.cs
+++ b/src/AspNet.Security.OAuth.Harvest/HarvestAuthenticationDefaults.cs
@@ -6,7 +6,6 @@
 
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
-using Microsoft.AspNetCore.Builder;
 
 namespace AspNet.Security.OAuth.Harvest
 {

--- a/src/AspNet.Security.OAuth.Harvest/HarvestAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.Harvest/HarvestAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the Harvest options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddHarvest(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<HarvestAuthenticationOptions> configuration)
         {
             return builder.AddHarvest(scheme, HarvestAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddHarvest(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<HarvestAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<HarvestAuthenticationOptions, HarvestAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.Harvest/HarvestAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Harvest/HarvestAuthenticationHandler.cs
@@ -29,8 +29,10 @@ namespace AspNet.Security.OAuth.Harvest
         {
         }
 
-        protected override async Task<AuthenticationTicket> CreateTicketAsync([NotNull] ClaimsIdentity identity,
-            [NotNull] AuthenticationProperties properties, [NotNull] OAuthTokenResponse tokens)
+        protected override async Task<AuthenticationTicket> CreateTicketAsync(
+            [NotNull] ClaimsIdentity identity,
+            [NotNull] AuthenticationProperties properties,
+            [NotNull] OAuthTokenResponse tokens)
         {
             using var request = new HttpRequestMessage(HttpMethod.Get, Options.UserInformationEndpoint);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));

--- a/src/AspNet.Security.OAuth.Harvest/HarvestAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Harvest/HarvestAuthenticationOptions.cs
@@ -4,11 +4,10 @@
  * for more information concerning the license and the contributors participating to this project.
  */
 
+using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
 using Microsoft.AspNetCore.Http;
-using System.Linq;
-using System.Security.Claims;
 
 namespace AspNet.Security.OAuth.Harvest
 {

--- a/src/AspNet.Security.OAuth.HealthGraph/HealthGraphAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.HealthGraph/HealthGraphAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the HealthGraph options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddHealthGraph(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<HealthGraphAuthenticationOptions> configuration)
         {
             return builder.AddHealthGraph(scheme, HealthGraphAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddHealthGraph(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<HealthGraphAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<HealthGraphAuthenticationOptions, HealthGraphAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.HealthGraph/HealthGraphAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.HealthGraph/HealthGraphAuthenticationHandler.cs
@@ -29,8 +29,10 @@ namespace AspNet.Security.OAuth.HealthGraph
         {
         }
 
-        protected override async Task<AuthenticationTicket> CreateTicketAsync([NotNull] ClaimsIdentity identity,
-            [NotNull] AuthenticationProperties properties, [NotNull] OAuthTokenResponse tokens)
+        protected override async Task<AuthenticationTicket> CreateTicketAsync(
+            [NotNull] ClaimsIdentity identity,
+            [NotNull] AuthenticationProperties properties,
+            [NotNull] OAuthTokenResponse tokens)
         {
             using var request = new HttpRequestMessage(HttpMethod.Get, Options.UserInformationEndpoint);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.com.runkeeper.User+json"));

--- a/src/AspNet.Security.OAuth.HealthGraph/HealthGraphAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.HealthGraph/HealthGraphAuthenticationOptions.cs
@@ -4,7 +4,6 @@
  * for more information concerning the license and the contributors participating to this project.
  */
 
-
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;

--- a/src/AspNet.Security.OAuth.HealthGraph/HealthGraphAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.HealthGraph/HealthGraphAuthenticationOptions.cs
@@ -8,7 +8,6 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
-using Microsoft.AspNetCore.Http;
 
 namespace AspNet.Security.OAuth.HealthGraph
 {
@@ -21,7 +20,7 @@ namespace AspNet.Security.OAuth.HealthGraph
         {
             ClaimsIssuer = HealthGraphAuthenticationDefaults.Issuer;
 
-            CallbackPath = new PathString(HealthGraphAuthenticationDefaults.CallbackPath);
+            CallbackPath = HealthGraphAuthenticationDefaults.CallbackPath;
 
             AuthorizationEndpoint = HealthGraphAuthenticationDefaults.AuthorizationEndpoint;
             TokenEndpoint = HealthGraphAuthenticationDefaults.TokenEndpoint;

--- a/src/AspNet.Security.OAuth.Imgur/ImgurAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.Imgur/ImgurAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the Imgur options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddImgur(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<ImgurAuthenticationOptions> configuration)
         {
             return builder.AddImgur(scheme, ImgurAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddImgur(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<ImgurAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<ImgurAuthenticationOptions, ImgurAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.Imgur/ImgurAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Imgur/ImgurAuthenticationHandler.cs
@@ -29,8 +29,10 @@ namespace AspNet.Security.OAuth.Imgur
         {
         }
 
-        protected override async Task<AuthenticationTicket> CreateTicketAsync([NotNull] ClaimsIdentity identity,
-            [NotNull] AuthenticationProperties properties, [NotNull] OAuthTokenResponse tokens)
+        protected override async Task<AuthenticationTicket> CreateTicketAsync(
+            [NotNull] ClaimsIdentity identity,
+            [NotNull] AuthenticationProperties properties,
+            [NotNull] OAuthTokenResponse tokens)
         {
             using var request = new HttpRequestMessage(HttpMethod.Get, Options.UserInformationEndpoint);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));

--- a/src/AspNet.Security.OAuth.Imgur/ImgurAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Imgur/ImgurAuthenticationOptions.cs
@@ -7,7 +7,6 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
-using Microsoft.AspNetCore.Http;
 using static AspNet.Security.OAuth.Imgur.ImgurAuthenticationConstants;
 
 namespace AspNet.Security.OAuth.Imgur
@@ -20,7 +19,7 @@ namespace AspNet.Security.OAuth.Imgur
         public ImgurAuthenticationOptions()
         {
             ClaimsIssuer = ImgurAuthenticationDefaults.Issuer;
-            CallbackPath = new PathString(ImgurAuthenticationDefaults.CallbackPath);
+            CallbackPath = ImgurAuthenticationDefaults.CallbackPath;
 
             AuthorizationEndpoint = ImgurAuthenticationDefaults.AuthorizationEndpoint;
             TokenEndpoint = ImgurAuthenticationDefaults.TokenEndpoint;

--- a/src/AspNet.Security.OAuth.Instagram/InstagramAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.Instagram/InstagramAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the Instagram options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddInstagram(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<InstagramAuthenticationOptions> configuration)
         {
             return builder.AddInstagram(scheme, InstagramAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddInstagram(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<InstagramAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<InstagramAuthenticationOptions, InstagramAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.Instagram/InstagramAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Instagram/InstagramAuthenticationHandler.cs
@@ -35,8 +35,10 @@ namespace AspNet.Security.OAuth.Instagram
         {
         }
 
-        protected override async Task<AuthenticationTicket> CreateTicketAsync([NotNull] ClaimsIdentity identity,
-            [NotNull] AuthenticationProperties properties, [NotNull] OAuthTokenResponse tokens)
+        protected override async Task<AuthenticationTicket> CreateTicketAsync(
+            [NotNull] ClaimsIdentity identity,
+            [NotNull] AuthenticationProperties properties,
+            [NotNull] OAuthTokenResponse tokens)
         {
             var address = QueryHelpers.AddQueryString(Options.UserInformationEndpoint, "access_token", tokens.AccessToken);
 

--- a/src/AspNet.Security.OAuth.Instagram/InstagramAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Instagram/InstagramAuthenticationHandler.cs
@@ -40,12 +40,12 @@ namespace AspNet.Security.OAuth.Instagram
             [NotNull] AuthenticationProperties properties,
             [NotNull] OAuthTokenResponse tokens)
         {
-            var address = QueryHelpers.AddQueryString(Options.UserInformationEndpoint, "access_token", tokens.AccessToken);
+            string address = QueryHelpers.AddQueryString(Options.UserInformationEndpoint, "access_token", tokens.AccessToken);
 
             if (Options.UseSignedRequests)
             {
                 // Compute the HMAC256 signature.
-                var signature = ComputeSignature(address);
+                string signature = ComputeSignature(address);
 
                 // Add the signature to the query string.
                 address = QueryHelpers.AddQueryString(address, "sig", signature);

--- a/src/AspNet.Security.OAuth.Instagram/InstagramAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Instagram/InstagramAuthenticationHandler.cs
@@ -76,7 +76,7 @@ namespace AspNet.Security.OAuth.Instagram
             return new AuthenticationTicket(context.Principal, context.Properties, Scheme.Name);
         }
 
-        protected virtual string ComputeSignature(string address)
+        protected virtual string ComputeSignature([NotNull] string address)
         {
             string query = new UriBuilder(address).Query;
 

--- a/src/AspNet.Security.OAuth.Instagram/InstagramAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Instagram/InstagramAuthenticationOptions.cs
@@ -7,7 +7,6 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
-using Microsoft.AspNetCore.Http;
 
 namespace AspNet.Security.OAuth.Instagram
 {
@@ -20,7 +19,7 @@ namespace AspNet.Security.OAuth.Instagram
         {
             ClaimsIssuer = InstagramAuthenticationDefaults.Issuer;
 
-            CallbackPath = new PathString(InstagramAuthenticationDefaults.CallbackPath);
+            CallbackPath = InstagramAuthenticationDefaults.CallbackPath;
 
             AuthorizationEndpoint = InstagramAuthenticationDefaults.AuthorizationEndpoint;
             TokenEndpoint = InstagramAuthenticationDefaults.TokenEndpoint;

--- a/src/AspNet.Security.OAuth.LinkedIn/LinkedInAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.LinkedIn/LinkedInAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the LinkedIn options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddLinkedIn(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<LinkedInAuthenticationOptions> configuration)
         {
             return builder.AddLinkedIn(scheme, LinkedInAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddLinkedIn(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<LinkedInAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<LinkedInAuthenticationOptions, LinkedInAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.LinkedIn/LinkedInAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.LinkedIn/LinkedInAuthenticationHandler.cs
@@ -73,7 +73,7 @@ namespace AspNet.Security.OAuth.LinkedIn
             if (!string.IsNullOrEmpty(Options.EmailAddressEndpoint) &&
                 Options.Fields.Contains(LinkedInAuthenticationConstants.EmailAddressField))
             {
-                string email = await GetEmailAsync(tokens);
+                string? email = await GetEmailAsync(tokens);
                 if (!string.IsNullOrEmpty(email))
                 {
                     identity.AddClaim(new Claim(ClaimTypes.Email, email, ClaimValueTypes.String, Options.ClaimsIssuer));
@@ -84,7 +84,7 @@ namespace AspNet.Security.OAuth.LinkedIn
             return new AuthenticationTicket(context.Principal, context.Properties, Scheme.Name);
         }
 
-        protected virtual async Task<string> GetEmailAsync([NotNull] OAuthTokenResponse tokens)
+        protected virtual async Task<string?> GetEmailAsync([NotNull] OAuthTokenResponse tokens)
         {
             using var request = new HttpRequestMessage(HttpMethod.Get, Options.EmailAddressEndpoint);
             request.Headers.Add("x-li-format", "json");

--- a/src/AspNet.Security.OAuth.LinkedIn/LinkedInAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.LinkedIn/LinkedInAuthenticationOptions.cs
@@ -71,8 +71,8 @@ namespace AspNet.Security.OAuth.LinkedIn
         /// 2. Returns the value corresponding to the <see cref="Thread.CurrentUICulture"/> if it exists.
         /// 3. Returns the first value.
         /// </summary>
-        /// <see cref="DefaultMultiLocaleStringResolver(IReadOnlyDictionary{string, string}, string)"/>
-        public Func<IReadOnlyDictionary<string, string>, string, string> MultiLocaleStringResolver { get; set; } = DefaultMultiLocaleStringResolver;
+        /// <see cref="DefaultMultiLocaleStringResolver(IReadOnlyDictionary{string, string}, string?)"/>
+        public Func<IReadOnlyDictionary<string, string>, string?, string> MultiLocaleStringResolver { get; set; } = DefaultMultiLocaleStringResolver;
 
         /// <summary>
         /// Gets the <c>MultiLocaleString</c> value using the configured resolver.
@@ -81,7 +81,7 @@ namespace AspNet.Security.OAuth.LinkedIn
         /// <param name="user">The payload returned by the user info endpoint.</param>
         /// <param name="propertyName">The name of the <c>MultiLocaleString</c> property.</param>
         /// <returns>The property value.</returns>
-        private string GetMultiLocaleString(JsonElement user, string propertyName)
+        private string? GetMultiLocaleString(JsonElement user, string propertyName)
         {
             if (!user.TryGetProperty(propertyName, out var property))
             {
@@ -93,7 +93,7 @@ namespace AspNet.Security.OAuth.LinkedIn
                 return null;
             }
 
-            string preferredLocaleKey = null;
+            string? preferredLocaleKey = null;
 
             if (property.TryGetProperty("preferredLocale", out var preferredLocale))
             {
@@ -112,7 +112,7 @@ namespace AspNet.Security.OAuth.LinkedIn
 
         private string GetFullName(JsonElement user)
         {
-            string[] nameParts = new string[]
+            string?[] nameParts = new string?[]
             {
                 GetMultiLocaleString(user, ProfileFields.FirstName),
                 GetMultiLocaleString(user, ProfileFields.LastName),
@@ -164,16 +164,16 @@ namespace AspNet.Security.OAuth.LinkedIn
         /// <param name="localizedValues">The localized values with culture keys.</param>
         /// <param name="preferredLocale">The preferred locale, if provided by LinkedIn.</param>
         /// <returns>The localized value.</returns>
-        private static string DefaultMultiLocaleStringResolver(IReadOnlyDictionary<string, string> localizedValues, string preferredLocale)
+        private static string DefaultMultiLocaleStringResolver(IReadOnlyDictionary<string, string> localizedValues, string? preferredLocale)
         {
             if (!string.IsNullOrEmpty(preferredLocale) &&
-                localizedValues.TryGetValue(preferredLocale, out string preferredLocaleValue))
+                localizedValues.TryGetValue(preferredLocale, out string? preferredLocaleValue))
             {
                 return preferredLocaleValue;
             }
 
             string currentUIKey = Thread.CurrentThread.CurrentUICulture.ToString().Replace('-', '_');
-            if (localizedValues.TryGetValue(currentUIKey, out string currentUIValue))
+            if (localizedValues.TryGetValue(currentUIKey, out string? currentUIValue))
             {
                 return currentUIValue;
             }

--- a/src/AspNet.Security.OAuth.MailChimp/MailChimpAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.MailChimp/MailChimpAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the MailChimp options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddMailChimp(
-            [NotNull] this AuthenticationBuilder builder, string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<MailChimpAuthenticationOptions> configuration)
         {
             return builder.AddMailChimp(scheme, MailChimpAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddMailChimp(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<MailChimpAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<MailChimpAuthenticationOptions, MailChimpAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.MailChimp/MailChimpAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.MailChimp/MailChimpAuthenticationHandler.cs
@@ -29,8 +29,10 @@ namespace AspNet.Security.OAuth.MailChimp
         {
         }
 
-        protected override async Task<AuthenticationTicket> CreateTicketAsync([NotNull] ClaimsIdentity identity,
-            [NotNull] AuthenticationProperties properties, [NotNull] OAuthTokenResponse tokens)
+        protected override async Task<AuthenticationTicket> CreateTicketAsync(
+            [NotNull] ClaimsIdentity identity,
+            [NotNull] AuthenticationProperties properties,
+            [NotNull] OAuthTokenResponse tokens)
         {
             using var request = new HttpRequestMessage(HttpMethod.Get, Options.UserInformationEndpoint);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));

--- a/src/AspNet.Security.OAuth.MailChimp/MailChimpAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.MailChimp/MailChimpAuthenticationOptions.cs
@@ -7,7 +7,6 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
-using Microsoft.AspNetCore.Http;
 
 namespace AspNet.Security.OAuth.MailChimp
 {
@@ -20,7 +19,7 @@ namespace AspNet.Security.OAuth.MailChimp
         {
             ClaimsIssuer = MailChimpAuthenticationDefaults.Issuer;
 
-            CallbackPath = new PathString(MailChimpAuthenticationDefaults.CallbackPath);
+            CallbackPath = MailChimpAuthenticationDefaults.CallbackPath;
 
             AuthorizationEndpoint = MailChimpAuthenticationDefaults.AuthorizationEndpoint;
             TokenEndpoint = MailChimpAuthenticationDefaults.TokenEndpoint;

--- a/src/AspNet.Security.OAuth.MailRu/MailRuAuthenticationDefaults.cs
+++ b/src/AspNet.Security.OAuth.MailRu/MailRuAuthenticationDefaults.cs
@@ -48,6 +48,5 @@ namespace AspNet.Security.OAuth.MailRu
         /// Default value for <see cref="OAuthOptions.UserInformationEndpoint"/>.
         /// </summary>
         public const string UserInformationEndpoint = "https://oauth.mail.ru/userinfo";
-
     }
 }

--- a/src/AspNet.Security.OAuth.MailRu/MailRuAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.MailRu/MailRuAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the MailRu options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddMailRu(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<MailRuAuthenticationOptions> configuration)
         {
             return builder.AddMailRu(scheme, MailRuAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddMailRu(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<MailRuAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<MailRuAuthenticationOptions, MailRuAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.Myob/MyobAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.Myob/MyobAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the Myob options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddMyob(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<MyobAuthenticationOptions> configuration)
         {
             return builder.AddMyob(scheme, MyobAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddMyob(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<MyobAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<MyobAuthenticationOptions, MyobAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.Myob/MyobAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Myob/MyobAuthenticationHandler.cs
@@ -26,8 +26,10 @@ namespace AspNet.Security.OAuth.Myob
         {
         }
 
-        protected override async Task<AuthenticationTicket> CreateTicketAsync([NotNull] ClaimsIdentity identity,
-            [NotNull] AuthenticationProperties properties, [NotNull] OAuthTokenResponse tokens)
+        protected override async Task<AuthenticationTicket> CreateTicketAsync(
+            [NotNull] ClaimsIdentity identity,
+            [NotNull] AuthenticationProperties properties,
+            [NotNull] OAuthTokenResponse tokens)
         {
             // Note: MYOB doesn't provide a user information endpoint,
             // so we rely on the details sent back in the token request.

--- a/src/AspNet.Security.OAuth.Myob/MyobAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Myob/MyobAuthenticationOptions.cs
@@ -4,7 +4,6 @@
  * for more information concerning the license and the contributors participating to this project.
  */
 
-
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;

--- a/src/AspNet.Security.OAuth.Myob/MyobAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Myob/MyobAuthenticationOptions.cs
@@ -8,7 +8,6 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
-using Microsoft.AspNetCore.Http;
 
 namespace AspNet.Security.OAuth.Myob
 {
@@ -20,7 +19,7 @@ namespace AspNet.Security.OAuth.Myob
         public MyobAuthenticationOptions()
         {
             ClaimsIssuer = MyobAuthenticationDefaults.Issuer;
-            CallbackPath = new PathString(MyobAuthenticationDefaults.CallbackPath);
+            CallbackPath = MyobAuthenticationDefaults.CallbackPath;
 
             AuthorizationEndpoint = MyobAuthenticationDefaults.AuthorizationEndpoint;
             TokenEndpoint = MyobAuthenticationDefaults.TokenEndpoint;

--- a/src/AspNet.Security.OAuth.Nextcloud/NextcloudAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.Nextcloud/NextcloudAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the Nextcloud options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddNextcloud(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<NextcloudAuthenticationOptions> configuration)
         {
             return builder.AddNextcloud(scheme, NextcloudAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddNextcloud(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<NextcloudAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<NextcloudAuthenticationOptions, NextcloudAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.Nextcloud/NextcloudAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Nextcloud/NextcloudAuthenticationOptions.cs
@@ -54,7 +54,7 @@ namespace AspNet.Security.OAuth.Nextcloud
             return false;
         }
 
-        private static string GetDataString(JsonElement user, string key)
+        private static string? GetDataString(JsonElement user, string key)
         {
             if (TryGetData(user, out var data))
             {

--- a/src/AspNet.Security.OAuth.Odnoklassniki/OdnoklassnikiAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.Odnoklassniki/OdnoklassnikiAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the Odnoklassniki options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddOdnoklassniki(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<OdnoklassnikiAuthenticationOptions> configuration)
         {
             return builder.AddOdnoklassniki(scheme, OdnoklassnikiAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddOdnoklassniki(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<OdnoklassnikiAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<OdnoklassnikiAuthenticationOptions, OdnoklassnikiAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.Odnoklassniki/OdnoklassnikiAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Odnoklassniki/OdnoklassnikiAuthenticationHandler.cs
@@ -39,7 +39,7 @@ namespace AspNet.Security.OAuth.Odnoklassniki
             [NotNull] AuthenticationProperties properties,
             [NotNull] OAuthTokenResponse tokens)
         {
-            using var algorithm = MD5.Create();
+            using var algorithm = HashAlgorithm.Create("MD5");
             string accessSecret = GetHash(algorithm, tokens.AccessToken + Options.ClientSecret);
             string sign = GetHash(algorithm, $"application_key={Options.PublicSecret}format=jsonmethod=users.getCurrentUser{accessSecret}");
 

--- a/src/AspNet.Security.OAuth.Odnoklassniki/OdnoklassnikiAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Odnoklassniki/OdnoklassnikiAuthenticationHandler.cs
@@ -45,7 +45,7 @@ namespace AspNet.Security.OAuth.Odnoklassniki
 
             string address = QueryHelpers.AddQueryString(Options.UserInformationEndpoint, new Dictionary<string, string>
             {
-                ["application_key"] = Options.PublicSecret,
+                ["application_key"] = Options.PublicSecret ?? string.Empty,
                 ["format"] = "json",
                 ["method"] = "users.getCurrentUser",
                 ["sig"] = sign,

--- a/src/AspNet.Security.OAuth.Odnoklassniki/OdnoklassnikiAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Odnoklassniki/OdnoklassnikiAuthenticationHandler.cs
@@ -81,7 +81,7 @@ namespace AspNet.Security.OAuth.Odnoklassniki
         {
             var builder = new StringBuilder();
 
-            foreach (var b in algorithm.ComputeHash(Encoding.UTF8.GetBytes(input)))
+            foreach (byte b in algorithm.ComputeHash(Encoding.UTF8.GetBytes(input)))
             {
                 builder.Append(b.ToString("x2", CultureInfo.InvariantCulture));
             }

--- a/src/AspNet.Security.OAuth.Odnoklassniki/OdnoklassnikiAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Odnoklassniki/OdnoklassnikiAuthenticationOptions.cs
@@ -50,6 +50,6 @@ namespace AspNet.Security.OAuth.Odnoklassniki
         /// <summary>
         /// Public App Key from application registration email.
         /// </summary>
-        public string PublicSecret { get; set; }
+        public string? PublicSecret { get; set; }
     }
 }

--- a/src/AspNet.Security.OAuth.Onshape/OnshapeAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.Onshape/OnshapeAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the Onshape options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddOnshape(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<OnshapeAuthenticationOptions> configuration)
         {
             return builder.AddOnshape(scheme, OnshapeAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddOnshape(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<OnshapeAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<OnshapeAuthenticationOptions, OnshapeAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.Onshape/OnshapeAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Onshape/OnshapeAuthenticationHandler.cs
@@ -29,8 +29,10 @@ namespace AspNet.Security.OAuth.Onshape
         {
         }
 
-        protected override async Task<AuthenticationTicket> CreateTicketAsync([NotNull] ClaimsIdentity identity,
-            [NotNull] AuthenticationProperties properties, [NotNull] OAuthTokenResponse tokens)
+        protected override async Task<AuthenticationTicket> CreateTicketAsync(
+            [NotNull] ClaimsIdentity identity,
+            [NotNull] AuthenticationProperties properties,
+            [NotNull] OAuthTokenResponse tokens)
         {
             using var request = new HttpRequestMessage(HttpMethod.Get, Options.UserInformationEndpoint);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));

--- a/src/AspNet.Security.OAuth.Onshape/OnshapeAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Onshape/OnshapeAuthenticationOptions.cs
@@ -7,7 +7,6 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
-using Microsoft.AspNetCore.Http;
 
 namespace AspNet.Security.OAuth.Onshape
 {
@@ -20,7 +19,7 @@ namespace AspNet.Security.OAuth.Onshape
         {
             ClaimsIssuer = OnshapeAuthenticationDefaults.Issuer;
 
-            CallbackPath = new PathString(OnshapeAuthenticationDefaults.CallbackPath);
+            CallbackPath = OnshapeAuthenticationDefaults.CallbackPath;
 
             AuthorizationEndpoint = OnshapeAuthenticationDefaults.AuthorizationEndpoint;
             TokenEndpoint = OnshapeAuthenticationDefaults.TokenEndpoint;

--- a/src/AspNet.Security.OAuth.Patreon/PatreonAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.Patreon/PatreonAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the Patreon options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddPatreon(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<PatreonAuthenticationOptions> configuration)
         {
             return builder.AddPatreon(scheme, PatreonAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddPatreon(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<PatreonAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<PatreonAuthenticationOptions, PatreonAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.Patreon/PatreonAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Patreon/PatreonAuthenticationHandler.cs
@@ -29,8 +29,10 @@ namespace AspNet.Security.OAuth.Patreon
         {
         }
 
-        protected override async Task<AuthenticationTicket> CreateTicketAsync([NotNull] ClaimsIdentity identity,
-            [NotNull] AuthenticationProperties properties, [NotNull] OAuthTokenResponse tokens)
+        protected override async Task<AuthenticationTicket> CreateTicketAsync(
+            [NotNull] ClaimsIdentity identity,
+            [NotNull] AuthenticationProperties properties,
+            [NotNull] OAuthTokenResponse tokens)
         {
             using var request = new HttpRequestMessage(HttpMethod.Get, Options.UserInformationEndpoint);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));

--- a/src/AspNet.Security.OAuth.Patreon/PatreonAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Patreon/PatreonAuthenticationOptions.cs
@@ -7,7 +7,6 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
-using Microsoft.AspNetCore.Http;
 using static AspNet.Security.OAuth.Patreon.PatreonAuthenticationConstants;
 
 namespace AspNet.Security.OAuth.Patreon
@@ -21,7 +20,7 @@ namespace AspNet.Security.OAuth.Patreon
         {
             ClaimsIssuer = PatreonAuthenticationDefaults.Issuer;
 
-            CallbackPath = new PathString(PatreonAuthenticationDefaults.CallbackPath);
+            CallbackPath = PatreonAuthenticationDefaults.CallbackPath;
 
             AuthorizationEndpoint = PatreonAuthenticationDefaults.AuthorizationEndpoint;
             TokenEndpoint = PatreonAuthenticationDefaults.TokenEndpoint;

--- a/src/AspNet.Security.OAuth.Paypal/PaypalAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.Paypal/PaypalAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the Paypal options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddPaypal(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<PaypalAuthenticationOptions> configuration)
         {
             return builder.AddPaypal(scheme, PaypalAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddPaypal(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<PaypalAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<PaypalAuthenticationOptions, PaypalAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.Paypal/PaypalAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Paypal/PaypalAuthenticationHandler.cs
@@ -29,8 +29,10 @@ namespace AspNet.Security.OAuth.Paypal
         {
         }
 
-        protected override async Task<AuthenticationTicket> CreateTicketAsync([NotNull] ClaimsIdentity identity,
-            [NotNull] AuthenticationProperties properties, [NotNull] OAuthTokenResponse tokens)
+        protected override async Task<AuthenticationTicket> CreateTicketAsync(
+            [NotNull] ClaimsIdentity identity,
+            [NotNull] AuthenticationProperties properties,
+            [NotNull] OAuthTokenResponse tokens)
         {
             using var request = new HttpRequestMessage(HttpMethod.Get, Options.UserInformationEndpoint);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));

--- a/src/AspNet.Security.OAuth.QQ/QQAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.QQ/QQAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the QQ options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddQQ(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<QQAuthenticationOptions> configuration)
         {
             return builder.AddQQ(scheme, QQAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddQQ(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<QQAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<QQAuthenticationOptions, QQAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.QQ/QQAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.QQ/QQAuthenticationHandler.cs
@@ -136,10 +136,10 @@ namespace AspNet.Security.OAuth.QQ
 
             string body = await response.Content.ReadAsStringAsync();
 
-            int index = body.IndexOf("{");
+            int index = body.IndexOf("{", StringComparison.Ordinal);
             if (index > 0)
             {
-                body = body.Substring(index, body.LastIndexOf("}") - index + 1);
+                body = body.Substring(index, body.LastIndexOf("}", StringComparison.Ordinal) - index + 1);
             }
 
             using var payload = JsonDocument.Parse(body);
@@ -153,18 +153,17 @@ namespace AspNet.Security.OAuth.QQ
         {
             var bufferWriter = new ArrayBufferWriter<byte>();
 
-            await using (var writer = new Utf8JsonWriter(bufferWriter))
+            using var writer = new Utf8JsonWriter(bufferWriter);
+
+            writer.WriteStartObject();
+
+            foreach (var item in content)
             {
-                writer.WriteStartObject();
-
-                foreach (var item in content)
-                {
-                    writer.WriteString(item.Key, item.Value);
-                }
-
-                writer.WriteEndObject();
-                await writer.FlushAsync();
+                writer.WriteString(item.Key, item.Value);
             }
+
+            writer.WriteEndObject();
+            await writer.FlushAsync();
 
             return JsonDocument.Parse(bufferWriter.WrittenMemory);
         }

--- a/src/AspNet.Security.OAuth.QQ/QQAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.QQ/QQAuthenticationOptions.cs
@@ -7,7 +7,6 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
-using Microsoft.AspNetCore.Http;
 using static AspNet.Security.OAuth.QQ.QQAuthenticationConstants;
 
 namespace AspNet.Security.OAuth.QQ
@@ -20,7 +19,7 @@ namespace AspNet.Security.OAuth.QQ
         public QQAuthenticationOptions()
         {
             ClaimsIssuer = QQAuthenticationDefaults.Issuer;
-            CallbackPath = new PathString(QQAuthenticationDefaults.CallbackPath);
+            CallbackPath = QQAuthenticationDefaults.CallbackPath;
 
             AuthorizationEndpoint = QQAuthenticationDefaults.AuthorizationEndpoint;
             TokenEndpoint = QQAuthenticationDefaults.TokenEndpoint;

--- a/src/AspNet.Security.OAuth.Reddit/RedditAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.Reddit/RedditAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the Reddit options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddReddit(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<RedditAuthenticationOptions> configuration)
         {
             return builder.AddReddit(scheme, RedditAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddReddit(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<RedditAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<RedditAuthenticationOptions, RedditAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.Reddit/RedditAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Reddit/RedditAuthenticationHandler.cs
@@ -127,7 +127,7 @@ namespace AspNet.Security.OAuth.Reddit
 
         private AuthenticationHeaderValue CreateAuthorizationHeader()
         {
-            static string EscapeDataString(string value)
+            static string? EscapeDataString(string value)
             {
                 if (string.IsNullOrEmpty(value))
                 {

--- a/src/AspNet.Security.OAuth.Reddit/RedditAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Reddit/RedditAuthenticationHandler.cs
@@ -71,7 +71,7 @@ namespace AspNet.Security.OAuth.Reddit
             return new AuthenticationTicket(context.Principal, context.Properties, Scheme.Name);
         }
 
-        protected override string BuildChallengeUrl(AuthenticationProperties properties, string redirectUri)
+        protected override string BuildChallengeUrl([NotNull] AuthenticationProperties properties, [NotNull] string redirectUri)
         {
             string address = base.BuildChallengeUrl(properties, redirectUri);
 

--- a/src/AspNet.Security.OAuth.Reddit/RedditAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Reddit/RedditAuthenticationHandler.cs
@@ -139,7 +139,8 @@ namespace AspNet.Security.OAuth.Reddit
 
             string credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes(
                 string.Concat(
-                    EscapeDataString(Options.ClientId), ":",
+                    EscapeDataString(Options.ClientId),
+                    ":",
                     EscapeDataString(Options.ClientSecret))));
 
             return new AuthenticationHeaderValue("Basic", credentials);

--- a/src/AspNet.Security.OAuth.Reddit/RedditAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Reddit/RedditAuthenticationHandler.cs
@@ -134,7 +134,7 @@ namespace AspNet.Security.OAuth.Reddit
                     return null;
                 }
 
-                return Uri.EscapeDataString(value).Replace("%20", "+");
+                return Uri.EscapeDataString(value).Replace("%20", "+", StringComparison.Ordinal);
             }
 
             string credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes(

--- a/src/AspNet.Security.OAuth.Reddit/RedditAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Reddit/RedditAuthenticationOptions.cs
@@ -38,6 +38,6 @@ namespace AspNet.Security.OAuth.Reddit
         /// Setting this option is strongly recommended to prevent request throttling.
         /// For more information, visit https://github.com/reddit/reddit/wiki/API.
         /// </summary>
-        public string UserAgent { get; set; }
+        public string? UserAgent { get; set; }
     }
 }

--- a/src/AspNet.Security.OAuth.Reddit/RedditAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Reddit/RedditAuthenticationOptions.cs
@@ -7,7 +7,6 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
-using Microsoft.AspNetCore.Http;
 using static AspNet.Security.OAuth.Reddit.RedditAuthenticationConstants;
 
 namespace AspNet.Security.OAuth.Reddit
@@ -21,7 +20,7 @@ namespace AspNet.Security.OAuth.Reddit
         {
             ClaimsIssuer = RedditAuthenticationDefaults.Issuer;
 
-            CallbackPath = new PathString(RedditAuthenticationDefaults.CallbackPath);
+            CallbackPath = RedditAuthenticationDefaults.CallbackPath;
 
             AuthorizationEndpoint = RedditAuthenticationDefaults.AuthorizationEndpoint;
             TokenEndpoint = RedditAuthenticationDefaults.TokenEndpoint;

--- a/src/AspNet.Security.OAuth.Salesforce/SalesforceAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.Salesforce/SalesforceAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the Salesforce options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddSalesforce(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<SalesforceAuthenticationOptions> configuration)
         {
             return builder.AddSalesforce(scheme, SalesforceAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddSalesforce(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<SalesforceAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<SalesforceAuthenticationOptions, SalesforceAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.Salesforce/SalesforceAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Salesforce/SalesforceAuthenticationHandler.cs
@@ -29,8 +29,10 @@ namespace AspNet.Security.OAuth.Salesforce
         {
         }
 
-        protected override async Task<AuthenticationTicket> CreateTicketAsync([NotNull] ClaimsIdentity identity,
-            [NotNull] AuthenticationProperties properties, [NotNull] OAuthTokenResponse tokens)
+        protected override async Task<AuthenticationTicket> CreateTicketAsync(
+            [NotNull] ClaimsIdentity identity,
+            [NotNull] AuthenticationProperties properties,
+            [NotNull] OAuthTokenResponse tokens)
         {
             // Note: unlike the other social providers, the userinfo endpoint is user-specific and can't be set globally.
             // For more information, see https://developer.salesforce.com/page/Digging_Deeper_into_OAuth_2.0_on_Force.com

--- a/src/AspNet.Security.OAuth.Salesforce/SalesforceAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Salesforce/SalesforceAuthenticationOptions.cs
@@ -8,7 +8,6 @@ using System;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
-using Microsoft.AspNetCore.Http;
 using static AspNet.Security.OAuth.Salesforce.SalesforceAuthenticationConstants;
 
 namespace AspNet.Security.OAuth.Salesforce
@@ -22,7 +21,7 @@ namespace AspNet.Security.OAuth.Salesforce
         {
             ClaimsIssuer = SalesforceAuthenticationDefaults.Issuer;
 
-            CallbackPath = new PathString(SalesforceAuthenticationDefaults.CallbackPath);
+            CallbackPath = SalesforceAuthenticationDefaults.CallbackPath;
 
             Environment = SalesforceAuthenticationDefaults.Environment;
 

--- a/src/AspNet.Security.OAuth.Shopify/ShopifyAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.Shopify/ShopifyAuthenticationExtensions.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the Shopify options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddShopify(
-            [NotNull] this AuthenticationBuilder builder, 
+            [NotNull] this AuthenticationBuilder builder,
             [NotNull] string scheme,
             [NotNull] Action<ShopifyAuthenticationOptions> configuration)
         {
@@ -68,7 +68,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddShopify(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, 
+            [NotNull] string scheme,
             [CanBeNull] string caption,
             [NotNull] Action<ShopifyAuthenticationOptions> configuration)
         {

--- a/src/AspNet.Security.OAuth.Shopify/ShopifyAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Shopify/ShopifyAuthenticationHandler.cs
@@ -101,7 +101,7 @@ namespace AspNet.Security.OAuth.Shopify
         /// <inheritdoc />
         protected override string BuildChallengeUrl([NotNull] AuthenticationProperties properties, [NotNull] string redirectUri)
         {
-            if (!properties.Items.TryGetValue(ShopifyAuthenticationDefaults.ShopNameAuthenticationProperty, out string shopName))
+            if (!properties.Items.TryGetValue(ShopifyAuthenticationDefaults.ShopNameAuthenticationProperty, out string? shopName))
             {
                 string message =
                     $"Shopify provider AuthenticationProperties must contain {ShopifyAuthenticationDefaults.ShopNameAuthenticationProperty}.";
@@ -113,7 +113,7 @@ namespace AspNet.Security.OAuth.Shopify
             string uri = string.Format(CultureInfo.InvariantCulture, Options.AuthorizationEndpoint, shopName);
 
             // Get the permission scope, which can either be set in options or overridden in AuthenticationProperties.
-            if (!properties.Items.TryGetValue(ShopifyAuthenticationDefaults.ShopScopeAuthenticationProperty, out string scope))
+            if (!properties.Items.TryGetValue(ShopifyAuthenticationDefaults.ShopScopeAuthenticationProperty, out string? scope))
             {
                 scope = FormatScope();
             }
@@ -127,7 +127,7 @@ namespace AspNet.Security.OAuth.Shopify
             });
 
             // If we're requesting a per-user, online only, token, add the grant_options query param.
-            if (properties.Items.TryGetValue(ShopifyAuthenticationDefaults.GrantOptionsAuthenticationProperty, out string grantOptions) &&
+            if (properties.Items.TryGetValue(ShopifyAuthenticationDefaults.GrantOptionsAuthenticationProperty, out string? grantOptions) &&
                 grantOptions == ShopifyAuthenticationDefaults.PerUserAuthenticationPropertyValue)
             {
                 url = QueryHelpers.AddQueryString(url, "grant_options[]", ShopifyAuthenticationDefaults.PerUserAuthenticationPropertyValue);

--- a/src/AspNet.Security.OAuth.Shopify/ShopifyAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Shopify/ShopifyAuthenticationHandler.cs
@@ -62,7 +62,7 @@ namespace AspNet.Security.OAuth.Shopify
 
             // In Shopify, the customer can modify the scope given to the app. Apps should verify
             // that the customer is allowing the required scope.
-            string actualScope = tokens.Response.RootElement.GetString("scope").ToString();
+            string actualScope = tokens.Response.RootElement.GetString("scope");
             bool isPersistent = true;
 
             // If the request was for a "per-user" (i.e. no offline access)
@@ -111,7 +111,7 @@ namespace AspNet.Security.OAuth.Shopify
                 throw new InvalidOperationException(message);
             }
 
-            string uri = string.Format(Options.AuthorizationEndpoint, shopName);
+            string uri = string.Format(CultureInfo.InvariantCulture, Options.AuthorizationEndpoint, shopName);
 
             // Get the permission scope, which can either be set in options or overridden in AuthenticationProperties.
             if (!properties.Items.TryGetValue(ShopifyAuthenticationDefaults.ShopScopeAuthenticationProperty, out string scope))

--- a/src/AspNet.Security.OAuth.Shopify/ShopifyAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Shopify/ShopifyAuthenticationHandler.cs
@@ -99,7 +99,7 @@ namespace AspNet.Security.OAuth.Shopify
         }
 
         /// <inheritdoc />
-        protected override string BuildChallengeUrl(AuthenticationProperties properties, string redirectUri)
+        protected override string BuildChallengeUrl([NotNull] AuthenticationProperties properties, [NotNull] string redirectUri)
         {
             if (!properties.Items.TryGetValue(ShopifyAuthenticationDefaults.ShopNameAuthenticationProperty, out string shopName))
             {

--- a/src/AspNet.Security.OAuth.Shopify/ShopifyAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Shopify/ShopifyAuthenticationHandler.cs
@@ -24,7 +24,6 @@ namespace AspNet.Security.OAuth.Shopify
 {
     public class ShopifyAuthenticationHandler : OAuthHandler<ShopifyAuthenticationOptions>
     {
-        /// <inheritdoc />
         public ShopifyAuthenticationHandler(
             [NotNull] IOptionsMonitor<ShopifyAuthenticationOptions> options,
             [NotNull] ILoggerFactory logger,

--- a/src/AspNet.Security.OAuth.Shopify/ShopifyAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Shopify/ShopifyAuthenticationOptions.cs
@@ -7,7 +7,6 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
-using Microsoft.AspNetCore.Http;
 
 namespace AspNet.Security.OAuth.Shopify
 {

--- a/src/AspNet.Security.OAuth.Shopify/ShopifyAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Shopify/ShopifyAuthenticationOptions.cs
@@ -25,7 +25,7 @@ namespace AspNet.Security.OAuth.Shopify
             AuthorizationEndpoint = ShopifyAuthenticationDefaults.AuthorizationEndpointFormat;
             TokenEndpoint = ShopifyAuthenticationDefaults.TokenEndpointFormat;
             UserInformationEndpoint = ShopifyAuthenticationDefaults.UserInformationEndpointFormat;
-            
+
             ClaimActions.MapJsonSubKey(ClaimTypes.NameIdentifier, "shop", "myshopify_domain");
             ClaimActions.MapJsonSubKey(ClaimTypes.Name, "shop", "name");
             ClaimActions.MapJsonSubKey(ClaimTypes.Webpage, "shop", "domain");

--- a/src/AspNet.Security.OAuth.Shopify/ShopifyAuthenticationProperties.cs
+++ b/src/AspNet.Security.OAuth.Shopify/ShopifyAuthenticationProperties.cs
@@ -38,7 +38,7 @@ namespace AspNet.Security.OAuth.Shopify
         /// installation.
         /// </param>
         /// <param name="items">Set Items values.</param>
-        public ShopifyAuthenticationProperties(string shopName, IDictionary<string, string> items)
+        public ShopifyAuthenticationProperties(string shopName, IDictionary<string, string>? items)
             : base(items)
         {
             SetShopName(shopName);
@@ -47,7 +47,7 @@ namespace AspNet.Security.OAuth.Shopify
         /// <summary>
         /// The scope requested. Must be fully formatted. <see cref="OAuthOptions.Scope"/>
         /// </summary>
-        public string Scope
+        public string? Scope
         {
             get => GetProperty(ShopifyAuthenticationDefaults.ShopScopeAuthenticationProperty);
             set => SetProperty(ShopifyAuthenticationDefaults.ShopScopeAuthenticationProperty, value);
@@ -60,7 +60,7 @@ namespace AspNet.Security.OAuth.Shopify
         {
             get
             {
-                string prop = GetProperty(ShopifyAuthenticationDefaults.GrantOptionsAuthenticationProperty);
+                string? prop = GetProperty(ShopifyAuthenticationDefaults.GrantOptionsAuthenticationProperty);
                 return string.Equals(prop, ShopifyAuthenticationDefaults.PerUserAuthenticationPropertyValue, StringComparison.OrdinalIgnoreCase);
             }
 
@@ -77,12 +77,12 @@ namespace AspNet.Security.OAuth.Shopify
         private void SetShopName(string shopName)
             => SetProperty(ShopifyAuthenticationDefaults.ShopNameAuthenticationProperty, shopName);
 
-        private void SetProperty(string propName, string value)
+        private void SetProperty(string propName, string? value)
             => Items[propName] = value;
 
-        private string GetProperty(string propName)
+        private string? GetProperty(string propName)
         {
-            return Items.TryGetValue(propName, out string val) ? val : null;
+            return Items.TryGetValue(propName, out string? val) ? val : null;
         }
     }
 }

--- a/src/AspNet.Security.OAuth.Shopify/ShopifyAuthenticationProperties.cs
+++ b/src/AspNet.Security.OAuth.Shopify/ShopifyAuthenticationProperties.cs
@@ -25,7 +25,8 @@ namespace AspNet.Security.OAuth.Shopify
         /// to authorize. This must either be gotten from the user or sent from Shopify during App store
         /// installation.
         /// </param>
-        public ShopifyAuthenticationProperties(string shopName) : this(shopName, null)
+        public ShopifyAuthenticationProperties(string shopName)
+            : this(shopName, null)
         {
         }
 
@@ -37,7 +38,8 @@ namespace AspNet.Security.OAuth.Shopify
         /// installation.
         /// </param>
         /// <param name="items">Set Items values.</param>
-        public ShopifyAuthenticationProperties(string shopName, IDictionary<string, string> items) : base(items)
+        public ShopifyAuthenticationProperties(string shopName, IDictionary<string, string> items)
+            : base(items)
         {
             SetShopName(shopName);
         }
@@ -62,10 +64,9 @@ namespace AspNet.Security.OAuth.Shopify
                 return string.Equals(prop, ShopifyAuthenticationDefaults.PerUserAuthenticationPropertyValue, StringComparison.OrdinalIgnoreCase);
             }
 
-            set => SetProperty(ShopifyAuthenticationDefaults.GrantOptionsAuthenticationProperty,
-                value ?
-                    ShopifyAuthenticationDefaults.PerUserAuthenticationPropertyValue :
-                    null);
+            set => SetProperty(
+                ShopifyAuthenticationDefaults.GrantOptionsAuthenticationProperty,
+                value ? ShopifyAuthenticationDefaults.PerUserAuthenticationPropertyValue : null);
         }
 
         /// <summary>
@@ -75,7 +76,7 @@ namespace AspNet.Security.OAuth.Shopify
         /// </summary>
         private void SetShopName(string shopName)
             => SetProperty(ShopifyAuthenticationDefaults.ShopNameAuthenticationProperty, shopName);
-    
+
         private void SetProperty(string propName, string value)
             => Items[propName] = value;
 

--- a/src/AspNet.Security.OAuth.Shopify/ShopifyAuthenticationProperties.cs
+++ b/src/AspNet.Security.OAuth.Shopify/ShopifyAuthenticationProperties.cs
@@ -81,7 +81,7 @@ namespace AspNet.Security.OAuth.Shopify
 
         private string GetProperty(string propName)
         {
-            return Items.TryGetValue(propName, out var val) ? val : null;
+            return Items.TryGetValue(propName, out string val) ? val : null;
         }
     }
 }

--- a/src/AspNet.Security.OAuth.Shopify/ShopifyAuthenticationProperties.cs
+++ b/src/AspNet.Security.OAuth.Shopify/ShopifyAuthenticationProperties.cs
@@ -19,7 +19,7 @@ namespace AspNet.Security.OAuth.Shopify
     public class ShopifyAuthenticationProperties : AuthenticationProperties
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:AspNet.Security.OAuth.Shopify.ShopifyAuthenticationProperties" /> class
+        /// Initializes a new instance of the <see cref="ShopifyAuthenticationProperties" /> class
         /// </summary>
         /// <param name="shopName">The name of the shop. Unlike most OAuth providers, the Shop name needs to be known in order
         /// to authorize. This must either be gotten from the user or sent from Shopify during App store
@@ -30,7 +30,7 @@ namespace AspNet.Security.OAuth.Shopify
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:AspNet.Security.OAuth.Shopify.ShopifyAuthenticationProperties" /> class
+        /// Initializes a new instance of the <see cref="ShopifyAuthenticationProperties" /> class
         /// </summary>
         /// <param name="shopName">The name of the shop. Unlike most OAuth providers, the Shop name needs to be known in order
         /// to authorize. This must either be gotten from the user or sent from Shopify during App store

--- a/src/AspNet.Security.OAuth.Slack/SlackAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.Slack/SlackAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the Slack options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddSlack(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<SlackAuthenticationOptions> configuration)
         {
             return builder.AddSlack(scheme, SlackAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddSlack(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<SlackAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<SlackAuthenticationOptions, SlackAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.Slack/SlackAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Slack/SlackAuthenticationHandler.cs
@@ -30,8 +30,10 @@ namespace AspNet.Security.OAuth.Slack
         {
         }
 
-        protected override async Task<AuthenticationTicket> CreateTicketAsync([NotNull] ClaimsIdentity identity,
-            [NotNull] AuthenticationProperties properties, [NotNull] OAuthTokenResponse tokens)
+        protected override async Task<AuthenticationTicket> CreateTicketAsync(
+            [NotNull] ClaimsIdentity identity,
+            [NotNull] AuthenticationProperties properties,
+            [NotNull] OAuthTokenResponse tokens)
         {
             var address = QueryHelpers.AddQueryString(Options.UserInformationEndpoint, "token", tokens.AccessToken);
 

--- a/src/AspNet.Security.OAuth.Slack/SlackAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Slack/SlackAuthenticationHandler.cs
@@ -35,7 +35,7 @@ namespace AspNet.Security.OAuth.Slack
             [NotNull] AuthenticationProperties properties,
             [NotNull] OAuthTokenResponse tokens)
         {
-            var address = QueryHelpers.AddQueryString(Options.UserInformationEndpoint, "token", tokens.AccessToken);
+            string address = QueryHelpers.AddQueryString(Options.UserInformationEndpoint, "token", tokens.AccessToken);
 
             using var request = new HttpRequestMessage(HttpMethod.Get, address);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));

--- a/src/AspNet.Security.OAuth.Slack/SlackAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Slack/SlackAuthenticationOptions.cs
@@ -21,7 +21,7 @@ namespace AspNet.Security.OAuth.Slack
         {
             ClaimsIssuer = SlackAuthenticationDefaults.Issuer;
 
-            CallbackPath = new PathString(SlackAuthenticationDefaults.CallbackPath);
+            CallbackPath = SlackAuthenticationDefaults.CallbackPath;
 
             AuthorizationEndpoint = SlackAuthenticationDefaults.AuthorizationEndpoint;
             TokenEndpoint = SlackAuthenticationDefaults.TokenEndpoint;

--- a/src/AspNet.Security.OAuth.SoundCloud/SoundCloudAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.SoundCloud/SoundCloudAuthenticationExtensions.cs
@@ -1,6 +1,6 @@
 /*
  * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
- * See https://SoundCloud.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
  * for more information concerning the license and the contributors participating to this project.
  */
 

--- a/src/AspNet.Security.OAuth.SoundCloud/SoundCloudAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.SoundCloud/SoundCloudAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the SoundCloud options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddSoundCloud(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<SoundCloudAuthenticationOptions> configuration)
         {
             return builder.AddSoundCloud(scheme, SoundCloudAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddSoundCloud(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<SoundCloudAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<SoundCloudAuthenticationOptions, SoundCloudAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.SoundCloud/SoundCloudAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.SoundCloud/SoundCloudAuthenticationHandler.cs
@@ -30,8 +30,10 @@ namespace AspNet.Security.OAuth.SoundCloud
         {
         }
 
-        protected override async Task<AuthenticationTicket> CreateTicketAsync([NotNull] ClaimsIdentity identity,
-            [NotNull] AuthenticationProperties properties, [NotNull] OAuthTokenResponse tokens)
+        protected override async Task<AuthenticationTicket> CreateTicketAsync(
+            [NotNull] ClaimsIdentity identity,
+            [NotNull] AuthenticationProperties properties,
+            [NotNull] OAuthTokenResponse tokens)
         {
             var address = QueryHelpers.AddQueryString(Options.UserInformationEndpoint, "oauth_token", tokens.AccessToken);
 

--- a/src/AspNet.Security.OAuth.SoundCloud/SoundCloudAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.SoundCloud/SoundCloudAuthenticationHandler.cs
@@ -35,7 +35,7 @@ namespace AspNet.Security.OAuth.SoundCloud
             [NotNull] AuthenticationProperties properties,
             [NotNull] OAuthTokenResponse tokens)
         {
-            var address = QueryHelpers.AddQueryString(Options.UserInformationEndpoint, "oauth_token", tokens.AccessToken);
+            string address = QueryHelpers.AddQueryString(Options.UserInformationEndpoint, "oauth_token", tokens.AccessToken);
 
             using var request = new HttpRequestMessage(HttpMethod.Get, address);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));

--- a/src/AspNet.Security.OAuth.SoundCloud/SoundCloudAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.SoundCloud/SoundCloudAuthenticationOptions.cs
@@ -7,7 +7,6 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
-using Microsoft.AspNetCore.Http;
 using static AspNet.Security.OAuth.SoundCloud.SoundCloudAuthenticationConstants;
 
 namespace AspNet.Security.OAuth.SoundCloud
@@ -21,7 +20,7 @@ namespace AspNet.Security.OAuth.SoundCloud
         {
             ClaimsIssuer = SoundCloudAuthenticationDefaults.Issuer;
 
-            CallbackPath = new PathString(SoundCloudAuthenticationDefaults.CallbackPath);
+            CallbackPath = SoundCloudAuthenticationDefaults.CallbackPath;
 
             AuthorizationEndpoint = SoundCloudAuthenticationDefaults.AuthorizationEndpoint;
             TokenEndpoint = SoundCloudAuthenticationDefaults.TokenEndpoint;

--- a/src/AspNet.Security.OAuth.Spotify/SpotifyAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.Spotify/SpotifyAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the Spotify options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddSpotify(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<SpotifyAuthenticationOptions> configuration)
         {
             return builder.AddSpotify(scheme, SpotifyAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddSpotify(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<SpotifyAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<SpotifyAuthenticationOptions, SpotifyAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.Spotify/SpotifyAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Spotify/SpotifyAuthenticationHandler.cs
@@ -29,8 +29,10 @@ namespace AspNet.Security.OAuth.Spotify
         {
         }
 
-        protected override async Task<AuthenticationTicket> CreateTicketAsync([NotNull] ClaimsIdentity identity,
-            [NotNull] AuthenticationProperties properties, [NotNull] OAuthTokenResponse tokens)
+        protected override async Task<AuthenticationTicket> CreateTicketAsync(
+            [NotNull] ClaimsIdentity identity,
+            [NotNull] AuthenticationProperties properties,
+            [NotNull] OAuthTokenResponse tokens)
         {
             using var request = new HttpRequestMessage(HttpMethod.Get, Options.UserInformationEndpoint);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));

--- a/src/AspNet.Security.OAuth.Spotify/SpotifyAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Spotify/SpotifyAuthenticationOptions.cs
@@ -22,7 +22,7 @@ namespace AspNet.Security.OAuth.Spotify
         {
             ClaimsIssuer = SpotifyAuthenticationDefaults.Issuer;
 
-            CallbackPath = new PathString(SpotifyAuthenticationDefaults.CallbackPath);
+            CallbackPath = SpotifyAuthenticationDefaults.CallbackPath;
 
             AuthorizationEndpoint = SpotifyAuthenticationDefaults.AuthorizationEndpoint;
             TokenEndpoint = SpotifyAuthenticationDefaults.TokenEndpoint;

--- a/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the StackExchange options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddStackExchange(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<StackExchangeAuthenticationOptions> configuration)
         {
             return builder.AddStackExchange(scheme, StackExchangeAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddStackExchange(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<StackExchangeAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<StackExchangeAuthenticationOptions, StackExchangeAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationHandler.cs
@@ -121,18 +121,17 @@ namespace AspNet.Security.OAuth.StackExchange
         {
             var bufferWriter = new ArrayBufferWriter<byte>();
 
-            await using (var writer = new Utf8JsonWriter(bufferWriter))
+            using var writer = new Utf8JsonWriter(bufferWriter);
+
+            writer.WriteStartObject();
+
+            foreach (var item in content)
             {
-                writer.WriteStartObject();
-
-                foreach (var item in content)
-                {
-                    writer.WriteString(item.Key, item.Value);
-                }
-
-                writer.WriteEndObject();
-                await writer.FlushAsync();
+                writer.WriteString(item.Key, item.Value);
             }
+
+            writer.WriteEndObject();
+            await writer.FlushAsync();
 
             return JsonDocument.Parse(bufferWriter.WrittenMemory);
         }

--- a/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationOptions.cs
@@ -9,7 +9,6 @@ using System.Net.Http;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
-using Microsoft.AspNetCore.Http;
 using static AspNet.Security.OAuth.StackExchange.StackExchangeAuthenticationConstants;
 
 namespace AspNet.Security.OAuth.StackExchange
@@ -23,7 +22,7 @@ namespace AspNet.Security.OAuth.StackExchange
         {
             ClaimsIssuer = StackExchangeAuthenticationDefaults.Issuer;
 
-            CallbackPath = new PathString(StackExchangeAuthenticationDefaults.CallbackPath);
+            CallbackPath = StackExchangeAuthenticationDefaults.CallbackPath;
 
             AuthorizationEndpoint = StackExchangeAuthenticationDefaults.AuthorizationEndpoint;
             TokenEndpoint = StackExchangeAuthenticationDefaults.TokenEndpoint;

--- a/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationOptions.cs
@@ -39,7 +39,7 @@ namespace AspNet.Security.OAuth.StackExchange
         /// Gets or sets the application request key, obtained
         /// when registering your application with StackApps.
         /// </summary>
-        public string RequestKey { get; set; }
+        public string RequestKey { get; set; } = string.Empty;
 
         /// <summary>
         /// Gets or sets the site on which the user is registered.

--- a/src/AspNet.Security.OAuth.Strava/StravaAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.Strava/StravaAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the Strava options.</param>
         /// <returns>A reference to this instance after the operation has completed.</returns>
         public static AuthenticationBuilder AddStrava(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<StravaAuthenticationOptions> configuration)
         {
             return builder.AddStrava(scheme, StravaAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>A reference to this instance after the operation has completed.</returns>
         public static AuthenticationBuilder AddStrava(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<StravaAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<StravaAuthenticationOptions, StravaAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.Strava/StravaAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Strava/StravaAuthenticationHandler.cs
@@ -32,8 +32,10 @@ namespace AspNet.Security.OAuth.Strava
         {
         }
 
-        protected override async Task<AuthenticationTicket> CreateTicketAsync([NotNull] ClaimsIdentity identity,
-            [NotNull] AuthenticationProperties properties, [NotNull] OAuthTokenResponse tokens)
+        protected override async Task<AuthenticationTicket> CreateTicketAsync(
+            [NotNull] ClaimsIdentity identity,
+            [NotNull] AuthenticationProperties properties,
+            [NotNull] OAuthTokenResponse tokens)
         {
             using var request = new HttpRequestMessage(HttpMethod.Get, Options.UserInformationEndpoint);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));

--- a/src/AspNet.Security.OAuth.Strava/StravaAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Strava/StravaAuthenticationOptions.cs
@@ -6,7 +6,6 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
-using Microsoft.AspNetCore.Http;
 using static AspNet.Security.OAuth.Strava.StravaAuthenticationConstants;
 
 namespace AspNet.Security.OAuth.Strava
@@ -20,7 +19,7 @@ namespace AspNet.Security.OAuth.Strava
         {
             ClaimsIssuer = StravaAuthenticationDefaults.Issuer;
 
-            CallbackPath = new PathString(StravaAuthenticationDefaults.CallbackPath);
+            CallbackPath = StravaAuthenticationDefaults.CallbackPath;
 
             AuthorizationEndpoint = StravaAuthenticationDefaults.AuthorizationEndpoint;
             TokenEndpoint = StravaAuthenticationDefaults.TokenEndpoint;

--- a/src/AspNet.Security.OAuth.Trakt/TraktAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.Trakt/TraktAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the Trakt options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddTrakt(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<TraktAuthenticationOptions> configuration)
         {
             return builder.AddTrakt(scheme, TraktAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddTrakt(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<TraktAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<TraktAuthenticationOptions, TraktAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.Trakt/TraktAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Trakt/TraktAuthenticationOptions.cs
@@ -7,7 +7,6 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
-using Microsoft.AspNetCore.Http;
 using static AspNet.Security.OAuth.Trakt.TraktAuthenticationConstants;
 
 namespace AspNet.Security.OAuth.Trakt

--- a/src/AspNet.Security.OAuth.Trakt/TraktAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Trakt/TraktAuthenticationOptions.cs
@@ -36,7 +36,7 @@ namespace AspNet.Security.OAuth.Trakt
 
         /// <summary>
         /// Gets or sets the API version used when communicating with Trakt.
-        /// See <c>https://trakt.docs.apiary.io/#introduction/required-headers</c> for more information. 
+        /// See <c>https://trakt.docs.apiary.io/#introduction/required-headers</c> for more information.
         /// </summary>
         public string ApiVersion { get; set; } = TraktAuthenticationDefaults.ApiVersion;
     }

--- a/src/AspNet.Security.OAuth.Twitch/TwitchAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.Twitch/TwitchAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the Twitch options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddTwitch(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<TwitchAuthenticationOptions> configuration)
         {
             return builder.AddTwitch(scheme, TwitchAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddTwitch(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<TwitchAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<TwitchAuthenticationOptions, TwitchAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.Twitch/TwitchAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Twitch/TwitchAuthenticationHandler.cs
@@ -42,8 +42,10 @@ namespace AspNet.Security.OAuth.Twitch
                 ["force_verify"] = Options.ForceVerify ? "true" : "false"
             });
 
-        protected override async Task<AuthenticationTicket> CreateTicketAsync([NotNull] ClaimsIdentity identity,
-            [NotNull] AuthenticationProperties properties, [NotNull] OAuthTokenResponse tokens)
+        protected override async Task<AuthenticationTicket> CreateTicketAsync(
+            [NotNull] ClaimsIdentity identity,
+            [NotNull] AuthenticationProperties properties,
+            [NotNull] OAuthTokenResponse tokens)
         {
             using var request = new HttpRequestMessage(HttpMethod.Get, Options.UserInformationEndpoint);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));

--- a/src/AspNet.Security.OAuth.Twitch/TwitchAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Twitch/TwitchAuthenticationHandler.cs
@@ -31,7 +31,7 @@ namespace AspNet.Security.OAuth.Twitch
         {
         }
 
-        protected override string BuildChallengeUrl(AuthenticationProperties properties, string redirectUri)
+        protected override string BuildChallengeUrl([NotNull] AuthenticationProperties properties, [NotNull] string redirectUri)
             => QueryHelpers.AddQueryString(Options.AuthorizationEndpoint, new Dictionary<string, string>
             {
                 ["client_id"] = Options.ClientId,

--- a/src/AspNet.Security.OAuth.Twitch/TwitchAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Twitch/TwitchAuthenticationOptions.cs
@@ -22,7 +22,7 @@ namespace AspNet.Security.OAuth.Twitch
         public TwitchAuthenticationOptions()
         {
             ClaimsIssuer = TwitchAuthenticationDefaults.Issuer;
-            CallbackPath = new PathString(TwitchAuthenticationDefaults.CallbackPath);
+            CallbackPath = TwitchAuthenticationDefaults.CallbackPath;
 
             AuthorizationEndpoint = TwitchAuthenticationDefaults.AuthorizationEndPoint;
             TokenEndpoint = TwitchAuthenticationDefaults.TokenEndpoint;

--- a/src/AspNet.Security.OAuth.Twitch/TwitchAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Twitch/TwitchAuthenticationOptions.cs
@@ -48,7 +48,7 @@ namespace AspNet.Security.OAuth.Twitch
         /// </summary>
         public bool ForceVerify { get; set; }
 
-        private static string GetData(JsonElement user, string key)
+        private static string? GetData(JsonElement user, string key)
         {
             if (!user.TryGetProperty("data", out var data) || data.ValueKind != JsonValueKind.Array)
             {

--- a/src/AspNet.Security.OAuth.Untappd/UntappdAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.Untappd/UntappdAuthenticationExtensions.cs
@@ -1,6 +1,6 @@
 /*
  * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
- * See https://Untappd.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
  * for more information concerning the license and the contributors participating to this project.
  */
 

--- a/src/AspNet.Security.OAuth.Untappd/UntappdAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.Untappd/UntappdAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the Untappd options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddUntappd(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<UntappdAuthenticationOptions> configuration)
         {
             return builder.AddUntappd(scheme, UntappdAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddUntappd(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<UntappdAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<UntappdAuthenticationOptions, UntappdAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.Untappd/UntappdAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Untappd/UntappdAuthenticationHandler.cs
@@ -29,8 +29,10 @@ namespace AspNet.Security.OAuth.Untappd
         {
         }
 
-        protected override async Task<AuthenticationTicket> CreateTicketAsync([NotNull] ClaimsIdentity identity,
-            [NotNull] AuthenticationProperties properties, [NotNull] OAuthTokenResponse tokens)
+        protected override async Task<AuthenticationTicket> CreateTicketAsync(
+            [NotNull] ClaimsIdentity identity,
+            [NotNull] AuthenticationProperties properties,
+            [NotNull] OAuthTokenResponse tokens)
         {
             using var request = new HttpRequestMessage(HttpMethod.Get, Options.UserInformationEndpoint);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));

--- a/src/AspNet.Security.OAuth.Untappd/UntappdAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Untappd/UntappdAuthenticationOptions.cs
@@ -7,7 +7,6 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
-using Microsoft.AspNetCore.Http;
 using static AspNet.Security.OAuth.Untappd.UntappdAuthenticationConstants;
 
 namespace AspNet.Security.OAuth.Untappd
@@ -21,7 +20,7 @@ namespace AspNet.Security.OAuth.Untappd
         {
             ClaimsIssuer = UntappdAuthenticationDefaults.Issuer;
 
-            CallbackPath = new PathString(UntappdAuthenticationDefaults.CallbackPath);
+            CallbackPath = UntappdAuthenticationDefaults.CallbackPath;
 
             AuthorizationEndpoint = UntappdAuthenticationDefaults.AuthorizationEndpoint;
             TokenEndpoint = UntappdAuthenticationDefaults.TokenEndpoint;

--- a/src/AspNet.Security.OAuth.Vimeo/VimeoAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.Vimeo/VimeoAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the Vimeo options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddVimeo(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<VimeoAuthenticationOptions> configuration)
         {
             return builder.AddVimeo(scheme, VimeoAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddVimeo(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<VimeoAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<VimeoAuthenticationOptions, VimeoAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.Vimeo/VimeoAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Vimeo/VimeoAuthenticationHandler.cs
@@ -29,8 +29,10 @@ namespace AspNet.Security.OAuth.Vimeo
         {
         }
 
-        protected override async Task<AuthenticationTicket> CreateTicketAsync([NotNull] ClaimsIdentity identity,
-            [NotNull] AuthenticationProperties properties, [NotNull] OAuthTokenResponse tokens)
+        protected override async Task<AuthenticationTicket> CreateTicketAsync(
+            [NotNull] ClaimsIdentity identity,
+            [NotNull] AuthenticationProperties properties,
+            [NotNull] OAuthTokenResponse tokens)
         {
             using var request = new HttpRequestMessage(HttpMethod.Get, Options.UserInformationEndpoint);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));

--- a/src/AspNet.Security.OAuth.Vimeo/VimeoAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Vimeo/VimeoAuthenticationOptions.cs
@@ -21,7 +21,7 @@ namespace AspNet.Security.OAuth.Vimeo
         public VimeoAuthenticationOptions()
         {
             ClaimsIssuer = VimeoAuthenticationDefaults.Issuer;
-            CallbackPath = new PathString(VimeoAuthenticationDefaults.CallbackPath);
+            CallbackPath = VimeoAuthenticationDefaults.CallbackPath;
 
             AuthorizationEndpoint = VimeoAuthenticationDefaults.AuthorizationEndpoint;
             TokenEndpoint = VimeoAuthenticationDefaults.TokenEndpoint;

--- a/src/AspNet.Security.OAuth.VisualStudio/VisualStudioAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.VisualStudio/VisualStudioAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the VisualStudio options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddVisualStudio(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<VisualStudioAuthenticationOptions> configuration)
         {
             return builder.AddVisualStudio(scheme, VisualStudioAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddVisualStudio(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<VisualStudioAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<VisualStudioAuthenticationOptions, VisualStudioAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.VisualStudio/VisualStudioAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.VisualStudio/VisualStudioAuthenticationExtensions.cs
@@ -1,6 +1,6 @@
 /*
  * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
- * See https://VisualStudio.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
  * for more information concerning the license and the contributors participating to this project.
  */
 

--- a/src/AspNet.Security.OAuth.VisualStudio/VisualStudioAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.VisualStudio/VisualStudioAuthenticationHandler.cs
@@ -95,7 +95,7 @@ namespace AspNet.Security.OAuth.VisualStudio
             return OAuthTokenResponse.Success(payload);
         }
 
-        protected override string BuildChallengeUrl(AuthenticationProperties properties, string redirectUri)
+        protected override string BuildChallengeUrl([NotNull] AuthenticationProperties properties, [NotNull] string redirectUri)
         {
             return QueryHelpers.AddQueryString(Options.AuthorizationEndpoint, new Dictionary<string, string>
             {

--- a/src/AspNet.Security.OAuth.VisualStudio/VisualStudioAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.VisualStudio/VisualStudioAuthenticationOptions.cs
@@ -7,7 +7,6 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
-using Microsoft.AspNetCore.Http;
 
 namespace AspNet.Security.OAuth.VisualStudio
 {
@@ -20,7 +19,7 @@ namespace AspNet.Security.OAuth.VisualStudio
         {
             ClaimsIssuer = VisualStudioAuthenticationDefaults.Issuer;
 
-            CallbackPath = new PathString(VisualStudioAuthenticationDefaults.CallbackPath);
+            CallbackPath = VisualStudioAuthenticationDefaults.CallbackPath;
 
             AuthorizationEndpoint = VisualStudioAuthenticationDefaults.AuthorizationEndpoint;
             TokenEndpoint = VisualStudioAuthenticationDefaults.TokenEndpoint;

--- a/src/AspNet.Security.OAuth.Vkontakte/VkontakteAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.Vkontakte/VkontakteAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the Vkontakte options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddVkontakte(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<VkontakteAuthenticationOptions> configuration)
         {
             return builder.AddVkontakte(scheme, VkontakteAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddVkontakte(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<VkontakteAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<VkontakteAuthenticationOptions, VkontakteAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.Vkontakte/VkontakteAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Vkontakte/VkontakteAuthenticationHandler.cs
@@ -31,8 +31,10 @@ namespace AspNet.Security.OAuth.Vkontakte
         {
         }
 
-        protected override async Task<AuthenticationTicket> CreateTicketAsync([NotNull] ClaimsIdentity identity,
-            [NotNull] AuthenticationProperties properties, [NotNull] OAuthTokenResponse tokens)
+        protected override async Task<AuthenticationTicket> CreateTicketAsync(
+            [NotNull] ClaimsIdentity identity,
+            [NotNull] AuthenticationProperties properties,
+            [NotNull] OAuthTokenResponse tokens)
         {
             var address = QueryHelpers.AddQueryString(Options.UserInformationEndpoint, new Dictionary<string, string>
             {

--- a/src/AspNet.Security.OAuth.Vkontakte/VkontakteAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Vkontakte/VkontakteAuthenticationHandler.cs
@@ -36,7 +36,7 @@ namespace AspNet.Security.OAuth.Vkontakte
             [NotNull] AuthenticationProperties properties,
             [NotNull] OAuthTokenResponse tokens)
         {
-            var address = QueryHelpers.AddQueryString(Options.UserInformationEndpoint, new Dictionary<string, string>
+            string address = QueryHelpers.AddQueryString(Options.UserInformationEndpoint, new Dictionary<string, string>
             {
                 ["access_token"] = tokens.AccessToken,
                 ["v"] = !string.IsNullOrEmpty(Options.ApiVersion) ? Options.ApiVersion : VkontakteAuthenticationDefaults.ApiVersion

--- a/src/AspNet.Security.OAuth.Vkontakte/VkontakteAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Vkontakte/VkontakteAuthenticationOptions.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
-using Microsoft.AspNetCore.Http;
 using static AspNet.Security.OAuth.Vkontakte.VkontakteAuthenticationConstants;
 
 namespace AspNet.Security.OAuth.Vkontakte
@@ -22,7 +21,7 @@ namespace AspNet.Security.OAuth.Vkontakte
         {
             ClaimsIssuer = VkontakteAuthenticationDefaults.Issuer;
 
-            CallbackPath = new PathString(VkontakteAuthenticationDefaults.CallbackPath);
+            CallbackPath = VkontakteAuthenticationDefaults.CallbackPath;
 
             AuthorizationEndpoint = VkontakteAuthenticationDefaults.AuthorizationEndpoint;
             TokenEndpoint = VkontakteAuthenticationDefaults.TokenEndpoint;

--- a/src/AspNet.Security.OAuth.Weibo/WeiboAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.Weibo/WeiboAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the Weibo options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddWeibo(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<WeiboAuthenticationOptions> configuration)
         {
             return builder.AddWeibo(scheme, WeiboAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddWeibo(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<WeiboAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<WeiboAuthenticationOptions, WeiboAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.Weibo/WeiboAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Weibo/WeiboAuthenticationHandler.cs
@@ -37,7 +37,7 @@ namespace AspNet.Security.OAuth.Weibo
             [NotNull] AuthenticationProperties properties,
             [NotNull] OAuthTokenResponse tokens)
         {
-            var address = QueryHelpers.AddQueryString(Options.UserInformationEndpoint, new Dictionary<string, string>
+            string address = QueryHelpers.AddQueryString(Options.UserInformationEndpoint, new Dictionary<string, string>
             {
                 ["access_token"] = tokens.AccessToken,
                 ["uid"] = tokens.Response.RootElement.GetString("uid")
@@ -63,9 +63,11 @@ namespace AspNet.Security.OAuth.Weibo
             // When the email address is not public, retrieve it from
             // the emails endpoint if the user:email scope is specified.
             if (!string.IsNullOrEmpty(Options.UserEmailsEndpoint) &&
-                !identity.HasClaim(claim => claim.Type == ClaimTypes.Email) && Options.Scope.Contains("email"))
+                !identity.HasClaim(claim => claim.Type == ClaimTypes.Email) &&
+                Options.Scope.Contains("email"))
             {
-                var email = await GetEmailAsync(tokens);
+                string email = await GetEmailAsync(tokens);
+
                 if (!string.IsNullOrEmpty(address))
                 {
                     identity.AddClaim(new Claim(ClaimTypes.Email, email, ClaimValueTypes.String, Options.ClaimsIssuer));

--- a/src/AspNet.Security.OAuth.Weibo/WeiboAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Weibo/WeiboAuthenticationHandler.cs
@@ -32,8 +32,10 @@ namespace AspNet.Security.OAuth.Weibo
         {
         }
 
-        protected override async Task<AuthenticationTicket> CreateTicketAsync([NotNull] ClaimsIdentity identity,
-            [NotNull] AuthenticationProperties properties, [NotNull] OAuthTokenResponse tokens)
+        protected override async Task<AuthenticationTicket> CreateTicketAsync(
+            [NotNull] ClaimsIdentity identity,
+            [NotNull] AuthenticationProperties properties,
+            [NotNull] OAuthTokenResponse tokens)
         {
             var address = QueryHelpers.AddQueryString(Options.UserInformationEndpoint, new Dictionary<string, string>
             {

--- a/src/AspNet.Security.OAuth.Weibo/WeiboAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Weibo/WeiboAuthenticationOptions.cs
@@ -7,7 +7,6 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
-using Microsoft.AspNetCore.Http;
 using static AspNet.Security.OAuth.Weibo.WeiboAuthenticationConstants;
 
 namespace AspNet.Security.OAuth.Weibo
@@ -20,7 +19,7 @@ namespace AspNet.Security.OAuth.Weibo
         public WeiboAuthenticationOptions()
         {
             ClaimsIssuer = WeiboAuthenticationDefaults.Issuer;
-            CallbackPath = new PathString(WeiboAuthenticationDefaults.CallbackPath);
+            CallbackPath = WeiboAuthenticationDefaults.CallbackPath;
 
             AuthorizationEndpoint = WeiboAuthenticationDefaults.AuthorizationEndpoint;
             TokenEndpoint = WeiboAuthenticationDefaults.TokenEndpoint;

--- a/src/AspNet.Security.OAuth.Weixin/WeixinAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.Weixin/WeixinAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the Weixin options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddWeixin(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<WeixinAuthenticationOptions> configuration)
         {
             return builder.AddWeixin(scheme, WeixinAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddWeixin(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<WeixinAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<WeixinAuthenticationOptions, WeixinAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.Weixin/WeixinAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Weixin/WeixinAuthenticationHandler.cs
@@ -134,7 +134,7 @@ namespace AspNet.Security.OAuth.Weixin
             return OAuthTokenResponse.Success(payload);
         }
 
-        protected override string BuildChallengeUrl(AuthenticationProperties properties, string redirectUri)
+        protected override string BuildChallengeUrl([NotNull] AuthenticationProperties properties, [NotNull] string redirectUri)
         {
             string stateValue = Options.StateDataFormat.Protect(properties);
             bool addRedirectHash = false;

--- a/src/AspNet.Security.OAuth.Weixin/WeixinAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Weixin/WeixinAuthenticationHandler.cs
@@ -50,8 +50,10 @@ namespace AspNet.Security.OAuth.Weixin
                     }
                 }
             }
+
             return await base.HandleRemoteAuthenticateAsync();
         }
+
         protected override async Task<AuthenticationTicket> CreateTicketAsync(
             [NotNull] ClaimsIdentity identity,
             [NotNull] AuthenticationProperties properties,
@@ -128,6 +130,7 @@ namespace AspNet.Security.OAuth.Weixin
 
                 return OAuthTokenResponse.Failed(new Exception("An error occurred while retrieving an access token."));
             }
+
             return OAuthTokenResponse.Success(payload);
         }
 
@@ -138,7 +141,7 @@ namespace AspNet.Security.OAuth.Weixin
 
             if (!IsWeixinAuthorizationEndpointInUse())
             {
-                //Store state in redirectUri when authorizing Wechat Web pages to prevent "too long state parameters" error
+                // Store state in redirectUri when authorizing Wechat Web pages to prevent "too long state parameters" error
                 redirectUri = QueryHelpers.AddQueryString(redirectUri, OauthState, stateValue);
                 addRedirectHash = true;
             }
@@ -157,6 +160,7 @@ namespace AspNet.Security.OAuth.Weixin
                 // The parameters necessary for Web Authorization of Wechat
                 redirectUri += "#wechat_redirect";
             }
+
             return redirectUri;
         }
 

--- a/src/AspNet.Security.OAuth.Weixin/WeixinAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Weixin/WeixinAuthenticationOptions.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
-using Microsoft.AspNetCore.Http;
 using static AspNet.Security.OAuth.Weixin.WeixinAuthenticationConstants;
 
 namespace AspNet.Security.OAuth.Weixin
@@ -21,7 +20,7 @@ namespace AspNet.Security.OAuth.Weixin
         public WeixinAuthenticationOptions()
         {
             ClaimsIssuer = WeixinAuthenticationDefaults.Issuer;
-            CallbackPath = new PathString(WeixinAuthenticationDefaults.CallbackPath);
+            CallbackPath = WeixinAuthenticationDefaults.CallbackPath;
 
             AuthorizationEndpoint = WeixinAuthenticationDefaults.AuthorizationEndpoint;
             TokenEndpoint = WeixinAuthenticationDefaults.TokenEndpoint;

--- a/src/AspNet.Security.OAuth.WordPress/WordPressAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.WordPress/WordPressAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the WordPress options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddWordPress(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<WordPressAuthenticationOptions> configuration)
         {
             return builder.AddWordPress(scheme, WordPressAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddWordPress(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<WordPressAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<WordPressAuthenticationOptions, WordPressAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.WordPress/WordPressAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.WordPress/WordPressAuthenticationHandler.cs
@@ -29,8 +29,10 @@ namespace AspNet.Security.OAuth.WordPress
         {
         }
 
-        protected override async Task<AuthenticationTicket> CreateTicketAsync([NotNull] ClaimsIdentity identity,
-            [NotNull] AuthenticationProperties properties, [NotNull] OAuthTokenResponse tokens)
+        protected override async Task<AuthenticationTicket> CreateTicketAsync(
+            [NotNull] ClaimsIdentity identity,
+            [NotNull] AuthenticationProperties properties,
+            [NotNull] OAuthTokenResponse tokens)
         {
             using var request = new HttpRequestMessage(HttpMethod.Get, Options.UserInformationEndpoint);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));

--- a/src/AspNet.Security.OAuth.WordPress/WordPressAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.WordPress/WordPressAuthenticationOptions.cs
@@ -7,7 +7,6 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
-using Microsoft.AspNetCore.Http;
 using static AspNet.Security.OAuth.WordPress.WordPressAuthenticationConstants;
 
 namespace AspNet.Security.OAuth.WordPress
@@ -20,7 +19,7 @@ namespace AspNet.Security.OAuth.WordPress
         public WordPressAuthenticationOptions()
         {
             ClaimsIssuer = WordPressAuthenticationDefaults.Issuer;
-            CallbackPath = new PathString(WordPressAuthenticationDefaults.CallbackPath);
+            CallbackPath = WordPressAuthenticationDefaults.CallbackPath;
 
             AuthorizationEndpoint = WordPressAuthenticationDefaults.AuthorizationEndpoint;
             TokenEndpoint = WordPressAuthenticationDefaults.TokenEndpoint;

--- a/src/AspNet.Security.OAuth.Yahoo/YahooAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.Yahoo/YahooAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the Yahoo options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddYahoo(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<YahooAuthenticationOptions> configuration)
         {
             return builder.AddYahoo(scheme, YahooAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddYahoo(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<YahooAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<YahooAuthenticationOptions, YahooAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.Yahoo/YahooAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Yahoo/YahooAuthenticationHandler.cs
@@ -95,7 +95,7 @@ namespace AspNet.Security.OAuth.Yahoo
 
         private AuthenticationHeaderValue CreateAuthorizationHeader()
         {
-            static string EscapeDataString(string value)
+            static string? EscapeDataString(string value)
             {
                 if (string.IsNullOrEmpty(value))
                 {

--- a/src/AspNet.Security.OAuth.Yahoo/YahooAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Yahoo/YahooAuthenticationHandler.cs
@@ -102,7 +102,7 @@ namespace AspNet.Security.OAuth.Yahoo
                     return null;
                 }
 
-                return Uri.EscapeDataString(value).Replace("%20", "+");
+                return Uri.EscapeDataString(value).Replace("%20", "+", StringComparison.Ordinal);
             }
 
             string credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes(

--- a/src/AspNet.Security.OAuth.Yahoo/YahooAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Yahoo/YahooAuthenticationHandler.cs
@@ -107,7 +107,8 @@ namespace AspNet.Security.OAuth.Yahoo
 
             string credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes(
                 string.Concat(
-                    EscapeDataString(Options.ClientId), ":",
+                    EscapeDataString(Options.ClientId),
+                    ":",
                     EscapeDataString(Options.ClientSecret))));
 
             return new AuthenticationHeaderValue("Basic", credentials);

--- a/src/AspNet.Security.OAuth.Yahoo/YahooAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Yahoo/YahooAuthenticationOptions.cs
@@ -7,7 +7,6 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
-using Microsoft.AspNetCore.Http;
 using static AspNet.Security.OAuth.Yahoo.YahooAuthenticationConstants;
 
 namespace AspNet.Security.OAuth.Yahoo
@@ -20,7 +19,7 @@ namespace AspNet.Security.OAuth.Yahoo
         public YahooAuthenticationOptions()
         {
             ClaimsIssuer = YahooAuthenticationDefaults.Issuer;
-            CallbackPath = new PathString(YahooAuthenticationDefaults.CallbackPath);
+            CallbackPath = YahooAuthenticationDefaults.CallbackPath;
 
             AuthorizationEndpoint = YahooAuthenticationDefaults.AuthorizationEndpoint;
             TokenEndpoint = YahooAuthenticationDefaults.TokenEndpoint;

--- a/src/AspNet.Security.OAuth.Yammer/YammerAuthenticationDefaults.cs
+++ b/src/AspNet.Security.OAuth.Yammer/YammerAuthenticationDefaults.cs
@@ -30,6 +30,11 @@ namespace AspNet.Security.OAuth.Yammer
         public const string Issuer = "Yammer";
 
         /// <summary>
+        /// Default value for <see cref="RemoteAuthenticationOptions.CallbackPath"/>.
+        /// </summary>
+        public const string CallbackPath = "/signin-yammer";
+
+        /// <summary>
         /// Default value for <see cref="OAuthOptions.AuthorizationEndpoint"/>.
         /// </summary>
         public const string AuthorizationEndpoint = "https://www.yammer.com/oauth2/authorize";

--- a/src/AspNet.Security.OAuth.Yammer/YammerAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.Yammer/YammerAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the Yammer options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddYammer(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<YammerAuthenticationOptions> configuration)
         {
             return builder.AddYammer(scheme, YammerAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddYammer(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<YammerAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<YammerAuthenticationOptions, YammerAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.Yammer/YammerAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Yammer/YammerAuthenticationHandler.cs
@@ -103,17 +103,16 @@ namespace AspNet.Security.OAuth.Yammer
         {
             var bufferWriter = new ArrayBufferWriter<byte>();
 
-            await using (var writer = new Utf8JsonWriter(bufferWriter))
-            {
-                writer.WriteStartObject();
-                writer.WriteString("access_token", accessToken);
-                writer.WriteString("token_type", string.Empty);
-                writer.WriteString("refresh_token", string.Empty);
-                writer.WriteString("expires_in", string.Empty);
-                writer.WriteEndObject();
+            using var writer = new Utf8JsonWriter(bufferWriter);
 
-                await writer.FlushAsync();
-            }
+            writer.WriteStartObject();
+            writer.WriteString("access_token", accessToken);
+            writer.WriteString("token_type", string.Empty);
+            writer.WriteString("refresh_token", string.Empty);
+            writer.WriteString("expires_in", string.Empty);
+            writer.WriteEndObject();
+
+            await writer.FlushAsync();
 
             return JsonDocument.Parse(bufferWriter.WrittenMemory);
         }

--- a/src/AspNet.Security.OAuth.Yammer/YammerAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Yammer/YammerAuthenticationOptions.cs
@@ -7,7 +7,6 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
-using Microsoft.AspNetCore.Http;
 using static AspNet.Security.OAuth.Yammer.YammerAuthenticationConstants;
 
 namespace AspNet.Security.OAuth.Yammer
@@ -21,7 +20,7 @@ namespace AspNet.Security.OAuth.Yammer
         {
             ClaimsIssuer = YammerAuthenticationDefaults.Issuer;
 
-            CallbackPath = new PathString("/signin-yammer");
+            CallbackPath = YammerAuthenticationDefaults.CallbackPath;
 
             AuthorizationEndpoint = YammerAuthenticationDefaults.AuthorizationEndpoint;
             TokenEndpoint = YammerAuthenticationDefaults.TokenEndpoint;

--- a/src/AspNet.Security.OAuth.Yandex/YandexAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.Yandex/YandexAuthenticationExtensions.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configuration">The delegate used to configure the Yandex options.</param>
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddYandex(
-            [NotNull] this AuthenticationBuilder builder, [NotNull] string scheme,
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] string scheme,
             [NotNull] Action<YandexAuthenticationOptions> configuration)
         {
             return builder.AddYandex(scheme, YandexAuthenticationDefaults.DisplayName, configuration);
@@ -67,7 +68,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddYandex(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<YandexAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<YandexAuthenticationOptions, YandexAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.Yandex/YandexAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Yandex/YandexAuthenticationHandler.cs
@@ -107,7 +107,8 @@ namespace AspNet.Security.OAuth.Yandex
 
             string credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes(
                 string.Concat(
-                    EscapeDataString(Options.ClientId), ":",
+                    EscapeDataString(Options.ClientId),
+                    ":",
                     EscapeDataString(Options.ClientSecret))));
 
             return new AuthenticationHeaderValue("Basic", credentials);

--- a/src/AspNet.Security.OAuth.Yandex/YandexAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Yandex/YandexAuthenticationHandler.cs
@@ -95,7 +95,7 @@ namespace AspNet.Security.OAuth.Yandex
 
         private AuthenticationHeaderValue CreateAuthorizationHeader()
         {
-            static string EscapeDataString(string value)
+            static string? EscapeDataString(string value)
             {
                 if (string.IsNullOrEmpty(value))
                 {

--- a/src/AspNet.Security.OAuth.Yandex/YandexAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Yandex/YandexAuthenticationHandler.cs
@@ -102,7 +102,7 @@ namespace AspNet.Security.OAuth.Yandex
                     return null;
                 }
 
-                return Uri.EscapeDataString(value).Replace("%20", "+");
+                return Uri.EscapeDataString(value).Replace("%20", "+", StringComparison.Ordinal);
             }
 
             string credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes(

--- a/src/AspNet.Security.OAuth.Yandex/YandexAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Yandex/YandexAuthenticationOptions.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
-using Microsoft.AspNetCore.Http;
 
 namespace AspNet.Security.OAuth.Yandex
 {
@@ -20,7 +19,7 @@ namespace AspNet.Security.OAuth.Yandex
         public YandexAuthenticationOptions()
         {
             ClaimsIssuer = YandexAuthenticationDefaults.Issuer;
-            CallbackPath = new PathString(YandexAuthenticationDefaults.CallbackPath);
+            CallbackPath = YandexAuthenticationDefaults.CallbackPath;
 
             AuthorizationEndpoint = YandexAuthenticationDefaults.AuthorizationEndpoint;
             TokenEndpoint = YandexAuthenticationDefaults.TokenEndpoint;

--- a/src/AspNet.Security.OAuth.Zalo/ZaloAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.Zalo/ZaloAuthenticationExtensions.cs
@@ -66,7 +66,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="AuthenticationBuilder"/>.</returns>
         public static AuthenticationBuilder AddZalo(
             [NotNull] this AuthenticationBuilder builder,
-            [NotNull] string scheme, [CanBeNull] string caption,
+            [NotNull] string scheme,
+            [CanBeNull] string caption,
             [NotNull] Action<ZaloAuthenticationOptions> configuration)
         {
             return builder.AddOAuth<ZaloAuthenticationOptions, ZaloAuthenticationHandler>(scheme, caption, configuration);

--- a/src/AspNet.Security.OAuth.Zalo/ZaloAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Zalo/ZaloAuthenticationHandler.cs
@@ -66,7 +66,7 @@ namespace AspNet.Security.OAuth.Zalo
             return new AuthenticationTicket(context.Principal, context.Properties, Scheme.Name);
         }
 
-        protected override string BuildChallengeUrl(AuthenticationProperties properties, string redirectUri)
+        protected override string BuildChallengeUrl([NotNull] AuthenticationProperties properties, [NotNull] string redirectUri)
         {
             string address = base.BuildChallengeUrl(properties, redirectUri);
             return QueryHelpers.AddQueryString(address, "app_id", Options.ClientId);

--- a/stylecop.json
+++ b/stylecop.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
+  "settings": {
+    "documentationRules": {
+      "copyrightText": "Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)\nSee https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers\nfor more information concerning the license and the contributors participating to this project.",
+      "documentExposedElements": false,
+      "documentInterfaces": false,
+      "documentInternalElements": false,
+      "documentPrivateElements": false,
+      "documentPrivateFields": false,
+      "fileNamingConvention": "metadata",
+      "xmlHeader": false
+    },
+    "layoutRules": {
+      "newlineAtEndOfFile": "require"
+    },
+    "maintainabilityRules": {},
+    "namingRules": {
+      "allowCommonHungarianPrefixes": true,
+      "allowedHungarianPrefixes": []
+    },
+    "orderingRules": {
+      "elementOrder": [
+        "kind",
+        "accessibility",
+        "constant",
+        "static",
+        "readonly"
+      ],
+      "systemUsingDirectivesFirst": true,
+      "usingDirectivesPlacement": "outsideNamespace"
+    },
+    "readabilityRules": {},
+    "spacingRules": {}
+  }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Amazon/AmazonTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Amazon/AmazonTests.cs
@@ -39,14 +39,13 @@ namespace AspNet.Security.OAuth.Amazon
         public async Task Can_Sign_In_Using_Amazon(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Apple/AppleAuthenticationOptionsTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Apple/AppleAuthenticationOptionsTests.cs
@@ -94,7 +94,7 @@ namespace AspNet.Security.OAuth.Apple
                 ClientId = "my-client-id",
                 GenerateClientSecret = true,
                 KeyId = "my-key-id",
-                TeamId = null,
+                TeamId = null!,
             };
 
             // Act and Assert
@@ -111,7 +111,7 @@ namespace AspNet.Security.OAuth.Apple
                 GenerateClientSecret = true,
                 KeyId = "my-key-id",
                 TeamId = "my-team-id",
-                TokenAudience = null,
+                TokenAudience = null!,
             };
 
             // Act and Assert
@@ -143,7 +143,7 @@ namespace AspNet.Security.OAuth.Apple
             {
                 ClientId = "my-client-id",
                 ClientSecret = "my-client-secret",
-                PublicKeyEndpoint = null,
+                PublicKeyEndpoint = null!,
             };
 
             // Act and Assert

--- a/test/AspNet.Security.OAuth.Providers.Tests/Apple/AppleClientSecretGeneratorTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Apple/AppleClientSecretGeneratorTests.cs
@@ -61,9 +61,11 @@ namespace AspNet.Security.OAuth.Apple
                 securityToken.Payload.ShouldContainKeyAndValue("aud", "https://appleid.apple.com");
                 securityToken.Payload.ShouldContainKeyAndValue("iss", "my-team-id");
                 securityToken.Payload.ShouldContainKeyAndValue("sub", "my-client-id");
+                securityToken.Payload.Iat.HasValue.ShouldBeTrue();
+                securityToken.Payload.Exp.HasValue.ShouldBeTrue();
 
-                ((long)securityToken.Payload.Iat.Value).ShouldBeGreaterThanOrEqualTo(utcNow.ToUnixTimeSeconds());
-                ((long)securityToken.Payload.Exp.Value).ShouldBeGreaterThanOrEqualTo(utcNow.AddSeconds(60).ToUnixTimeSeconds());
+                ((long)securityToken.Payload.Iat!.Value).ShouldBeGreaterThanOrEqualTo(utcNow.ToUnixTimeSeconds());
+                ((long)securityToken.Payload.Exp!.Value).ShouldBeGreaterThanOrEqualTo(utcNow.AddSeconds(60).ToUnixTimeSeconds());
                 ((long)securityToken.Payload.Exp.Value).ShouldBeLessThanOrEqualTo(utcNow.AddSeconds(70).ToUnixTimeSeconds());
             });
         }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Apple/AppleTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Apple/AppleTests.cs
@@ -268,7 +268,9 @@ namespace AspNet.Security.OAuth.Apple
             var exception = await Assert.ThrowsAsync<Exception>(() => AuthenticateUserAsync(server));
 
             // Assert
+            exception.InnerException.ShouldNotBeNull();
             exception.InnerException.ShouldBeOfType<InvalidOperationException>();
+            exception.InnerException!.Message.ShouldNotBeNull();
             exception.InnerException.Message.ShouldBe("No Apple ID token was returned in the OAuth token response.");
         }
 
@@ -291,7 +293,9 @@ namespace AspNet.Security.OAuth.Apple
             var exception = await Assert.ThrowsAsync<Exception>(() => AuthenticateUserAsync(server));
 
             // Assert
+            exception.InnerException.ShouldNotBeNull();
             exception.InnerException.ShouldBeOfType<ArgumentException>();
+            exception.InnerException!.Message.ShouldNotBeNull();
             exception.InnerException.Message.ShouldStartWith("IDX");
         }
 
@@ -314,7 +318,9 @@ namespace AspNet.Security.OAuth.Apple
             var exception = await Assert.ThrowsAsync<Exception>(() => AuthenticateUserAsync(server));
 
             // Assert
+            exception.InnerException.ShouldNotBeNull();
             exception.InnerException.ShouldBeOfType<InvalidOperationException>();
+            exception.InnerException!.Message.ShouldNotBeNull();
             exception.InnerException.Message.ShouldBe("No Apple ID token was returned in the OAuth token response.");
         }
 

--- a/test/AspNet.Security.OAuth.Providers.Tests/ArcGIS/ArcGISTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/ArcGIS/ArcGISTests.cs
@@ -34,14 +34,13 @@ namespace AspNet.Security.OAuth.ArcGIS
         public async Task Can_Sign_In_Using_ArcGIS(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Asana/AsanaTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Asana/AsanaTests.cs
@@ -34,14 +34,13 @@ namespace AspNet.Security.OAuth.Asana
         public async Task Can_Sign_In_Using_Asana(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/AspNet.Security.OAuth.Providers.Tests.csproj
+++ b/test/AspNet.Security.OAuth.Providers.Tests/AspNet.Security.OAuth.Providers.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <NoWarn>$(NoWarn);CA1707</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="xunit.runner.json;**\bundle.json" Exclude="bin\**\bundle.json" CopyToOutputDirectory="PreserveNewest" />

--- a/test/AspNet.Security.OAuth.Providers.Tests/Autodesk/AutodeskTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Autodesk/AutodeskTests.cs
@@ -38,14 +38,13 @@ namespace AspNet.Security.OAuth.Autodesk
         public async Task Can_Sign_In_Using_Autodesk(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Automatic/AutomaticTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Automatic/AutomaticTests.cs
@@ -39,14 +39,13 @@ namespace AspNet.Security.OAuth.Automatic
         public async Task Can_Sign_In_Using_Automatic(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Baidu/BaiduTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Baidu/BaiduTests.cs
@@ -37,14 +37,13 @@ namespace AspNet.Security.OAuth.Baidu
         public async Task Can_Sign_In_Using_Baidu(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/BattleNet/BattleNetTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/BattleNet/BattleNetTests.cs
@@ -33,14 +33,13 @@ namespace AspNet.Security.OAuth.BattleNet
         public async Task Can_Sign_In_Using_BattleNet(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Beam/BeamTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Beam/BeamTests.cs
@@ -34,14 +34,13 @@ namespace AspNet.Security.OAuth.Beam
         public async Task Can_Sign_In_Using_Beam(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Bitbucket/BitbucketTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Bitbucket/BitbucketTests.cs
@@ -41,14 +41,13 @@ namespace AspNet.Security.OAuth.Bitbucket
         public async Task Can_Sign_In_Using_Bitbucket(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Buffer/BufferTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Buffer/BufferTests.cs
@@ -32,14 +32,13 @@ namespace AspNet.Security.OAuth.Buffer
         public async Task Can_Sign_In_Using_Buffer(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/CiscoSpark/CiscoSparkTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/CiscoSpark/CiscoSparkTests.cs
@@ -34,14 +34,13 @@ namespace AspNet.Security.OAuth.CiscoSpark
         public async Task Can_Sign_In_Using_CiscoSpark(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Deezer/DeezerTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Deezer/DeezerTests.cs
@@ -53,14 +53,13 @@ namespace AspNet.Security.OAuth.Deezer
         public async Task Can_Sign_In_Using_Deezer(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/DeviantArt/DeviantArtTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/DeviantArt/DeviantArtTests.cs
@@ -34,14 +34,13 @@ namespace AspNet.Security.OAuth.DeviantArt
         public async Task Can_Sign_In_Using_Deviant_Art(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Discord/DiscordTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Discord/DiscordTests.cs
@@ -38,14 +38,13 @@ namespace AspNet.Security.OAuth.Discord
         public async Task Can_Sign_In_Using_Discord(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Dropbox/DropboxTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Dropbox/DropboxTests.cs
@@ -34,14 +34,13 @@ namespace AspNet.Security.OAuth.Dropbox
         public async Task Can_Sign_In_Using_Dropbox(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/EVEOnline/EVEOnlineTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/EVEOnline/EVEOnlineTests.cs
@@ -35,14 +35,13 @@ namespace AspNet.Security.OAuth.EVEOnline
         public async Task Can_Sign_In_Using_EVE_Online(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Fitbit/FitbitTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Fitbit/FitbitTests.cs
@@ -35,14 +35,13 @@ namespace AspNet.Security.OAuth.Fitbit
         public async Task Can_Sign_In_Using_Fitbit(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Foursquare/FoursquareTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Foursquare/FoursquareTests.cs
@@ -38,14 +38,13 @@ namespace AspNet.Security.OAuth.Foursquare
         public async Task Can_Sign_In_Using_Foursquare(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/GitHub/GitHubTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/GitHub/GitHubTests.cs
@@ -40,14 +40,13 @@ namespace AspNet.Security.OAuth.GitHub
         public async Task Can_Sign_In_Using_GitHub(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/GitLab/GitLabTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/GitLab/GitLabTests.cs
@@ -6,7 +6,6 @@
 
 using System.Security.Claims;
 using System.Threading.Tasks;
-using AspNet.Security.OAuth.GitLab;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -41,14 +40,13 @@ namespace AspNet.Security.OAuth.GitLab
         public async Task Can_Sign_In_Using_GitHub(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Gitee/GiteeTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Gitee/GiteeTests.cs
@@ -24,7 +24,7 @@ namespace AspNet.Security.OAuth.Gitee
 
         protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
         {
-            builder.AddGitee(options => ConfigureDefaults(builder,options));
+            builder.AddGitee(options => ConfigureDefaults(builder, options));
         }
 
         [Theory]

--- a/test/AspNet.Security.OAuth.Providers.Tests/Gitee/GiteeTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Gitee/GiteeTests.cs
@@ -36,14 +36,13 @@ namespace AspNet.Security.OAuth.Gitee
         public async Task Can_Sign_In_Using_Gitee(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Gitter/GitterTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Gitter/GitterTests.cs
@@ -33,14 +33,13 @@ namespace AspNet.Security.OAuth.Gitter
         public async Task Can_Sign_In_Using_Gitter(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Harvest/HarvestTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Harvest/HarvestTests.cs
@@ -39,14 +39,13 @@ namespace AspNet.Security.OAuth.Harvest
         public async Task Can_Sign_In_Using_Harvest(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/HealthGraph/HealthGraphTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/HealthGraph/HealthGraphTests.cs
@@ -32,14 +32,13 @@ namespace AspNet.Security.OAuth.HealthGraph
         public async Task Can_Sign_In_Using_HealthGraph(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Imgur/ImgurTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Imgur/ImgurTests.cs
@@ -37,14 +37,13 @@ namespace AspNet.Security.OAuth.Imgur
         public async Task Can_Sign_In_Using_Imgur(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Infrastructure/ApplicationFactory.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Infrastructure/ApplicationFactory.cs
@@ -35,6 +35,7 @@ namespace AspNet.Security.OAuth.Infrastructure
         public static WebApplicationFactory<Program> CreateApplication<TOptions>(OAuthTests<TOptions> tests, Action<IServiceCollection> configureServices = null)
             where TOptions : OAuthOptions
         {
+#pragma warning disable CA2000
             return new TestApplicationFactory()
                 .WithWebHostBuilder(builder =>
                 {
@@ -45,6 +46,7 @@ namespace AspNet.Security.OAuth.Infrastructure
                         builder.ConfigureServices(configureServices);
                     }
                 });
+#pragma warning restore CA2000
         }
 
         private static void Configure<TOptions>(IWebHostBuilder builder, OAuthTests<TOptions> tests)
@@ -103,7 +105,7 @@ namespace AspNet.Security.OAuth.Infrastructure
                            if (context.User.Identity.IsAuthenticated)
                            {
                                string xml = IdentityToXmlString(context.User);
-                               byte[] buffer = Encoding.UTF8.GetBytes(xml.ToString());
+                               byte[] buffer = Encoding.UTF8.GetBytes(xml);
 
                                context.Response.StatusCode = 200;
                                context.Response.ContentType = "text/xml";

--- a/test/AspNet.Security.OAuth.Providers.Tests/Infrastructure/ApplicationFactory.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Infrastructure/ApplicationFactory.cs
@@ -32,7 +32,7 @@ namespace AspNet.Security.OAuth.Infrastructure
         /// <returns>
         /// The test application to use for the authentication provider.
         /// </returns>
-        public static WebApplicationFactory<Program> CreateApplication<TOptions>(OAuthTests<TOptions> tests, Action<IServiceCollection> configureServices = null)
+        public static WebApplicationFactory<Program> CreateApplication<TOptions>(OAuthTests<TOptions> tests, Action<IServiceCollection>? configureServices = null)
             where TOptions : OAuthOptions
         {
 #pragma warning disable CA2000

--- a/test/AspNet.Security.OAuth.Providers.Tests/Infrastructure/LoopbackRedirectHandler.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Infrastructure/LoopbackRedirectHandler.cs
@@ -22,7 +22,7 @@ namespace AspNet.Security.OAuth.Infrastructure
 
         public IDictionary<string, string> RedirectParameters { get; set; } = new Dictionary<string, string>();
 
-        public string RedirectUri { get; set; }
+        public string? RedirectUri { get; set; }
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
@@ -33,11 +33,11 @@ namespace AspNet.Security.OAuth.Infrastructure
                 !string.Equals(result.Headers.Location?.Host, "localhost", StringComparison.OrdinalIgnoreCase))
             {
                 var uri = BuildLoopbackUri(result);
-                HttpContent content = null;
+                HttpContent? content = null;
 
                 if (RedirectMethod == HttpMethod.Post)
                 {
-                    var queryString = HttpUtility.ParseQueryString(result.Headers.Location.Query);
+                    var queryString = HttpUtility.ParseQueryString(result.Headers.Location!.Query);
                     string state = queryString["state"];
 
                     var parameters = new Dictionary<string, string>()
@@ -89,10 +89,10 @@ namespace AspNet.Security.OAuth.Infrastructure
             // successfully authenticated with the external login page they were redirected to.
             var queryString = HttpUtility.ParseQueryString(responseMessage.Headers.Location.Query);
 
-            string location = queryString["redirect_uri"] ?? RedirectUri;
+            string? location = queryString["redirect_uri"] ?? RedirectUri;
             string state = queryString["state"];
 
-            var builder = new UriBuilder(location);
+            var builder = new UriBuilder(location!);
 
             // Retain the _oauthstate parameter in redirect_uri for WeChat (see #262)
             const string OAuthStateKey = "_oauthstate";

--- a/test/AspNet.Security.OAuth.Providers.Tests/Infrastructure/LoopbackRedirectHandler.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Infrastructure/LoopbackRedirectHandler.cs
@@ -61,7 +61,7 @@ namespace AspNet.Security.OAuth.Infrastructure
                     uri = BuildLoopbackUri(result);
                 }
 
-                var redirectRequest = new HttpRequestMessage(RedirectMethod, uri);
+                using var redirectRequest = new HttpRequestMessage(RedirectMethod, uri);
 
                 if (content != null)
                 {

--- a/test/AspNet.Security.OAuth.Providers.Tests/Instagram/InstagramTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Instagram/InstagramTests.cs
@@ -33,14 +33,13 @@ namespace AspNet.Security.OAuth.Instagram
         public async Task Can_Sign_In_Using_Instagram(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/LinkedIn/LinkedInTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/LinkedIn/LinkedInTests.cs
@@ -35,7 +35,7 @@ namespace AspNet.Security.OAuth.LinkedIn
                 additionalConfiguration?.Invoke(options);
             });
         }
-       
+
         protected internal override void ConfigureApplication(IApplicationBuilder app)
         {
             app.UseRequestLocalization(new RequestLocalizationOptions

--- a/test/AspNet.Security.OAuth.Providers.Tests/LinkedIn/LinkedInTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/LinkedIn/LinkedInTests.cs
@@ -18,7 +18,7 @@ namespace AspNet.Security.OAuth.LinkedIn
 {
     public class LinkedInTests : OAuthTests<LinkedInAuthenticationOptions>
     {
-        private Action<LinkedInAuthenticationOptions> additionalConfiguration = null;
+        private Action<LinkedInAuthenticationOptions>? additionalConfiguration = null;
 
         public LinkedInTests(ITestOutputHelper outputHelper)
         {
@@ -92,7 +92,7 @@ namespace AspNet.Security.OAuth.LinkedIn
             // Arrange
             additionalConfiguration = options => options.MultiLocaleStringResolver = (values, preferredLocale) =>
             {
-                if (values.TryGetValue("fr_FR", out string value))
+                if (values.TryGetValue("fr_FR", out string? value))
                 {
                     return value;
                 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/LinkedIn/LinkedInTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/LinkedIn/LinkedInTests.cs
@@ -56,14 +56,13 @@ namespace AspNet.Security.OAuth.LinkedIn
             // Arrange
             additionalConfiguration = options => options.Fields.Add(LinkedInAuthenticationConstants.ProfileFields.PictureUrl);
 
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
 
         [Theory]
@@ -74,14 +73,13 @@ namespace AspNet.Security.OAuth.LinkedIn
         public async Task Can_Sign_In_Using_LinkedIn_Localized(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
 
         [Theory]
@@ -102,14 +100,13 @@ namespace AspNet.Security.OAuth.LinkedIn
                 return values.Values.FirstOrDefault();
             };
 
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/MailChimp/MailChimpTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/MailChimp/MailChimpTests.cs
@@ -34,14 +34,13 @@ namespace AspNet.Security.OAuth.MailChimp
         public async Task Can_Sign_In_Using_MailChimp(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/MailRu/MailRuTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/MailRu/MailRuTests.cs
@@ -41,14 +41,13 @@ namespace AspNet.Security.OAuth.MailRu
         public async Task Can_Sign_In_Using_MailRu(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Myob/MyobTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Myob/MyobTests.cs
@@ -33,14 +33,13 @@ namespace AspNet.Security.OAuth.Myob
         public async Task Can_Sign_In_Using_Myob(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Nextcloud/NextcloudTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Nextcloud/NextcloudTests.cs
@@ -46,14 +46,13 @@ namespace AspNet.Security.OAuth.Nextcloud
         public async Task Can_Sign_In_Using_Nextcloud(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/OAuthTests`1.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/OAuthTests`1.cs
@@ -51,7 +51,7 @@ namespace AspNet.Security.OAuth
         /// <summary>
         /// Gets or sets the xunit test output helper to route application logs to.
         /// </summary>
-        public ITestOutputHelper OutputHelper { get; set; }
+        public ITestOutputHelper? OutputHelper { get; set; }
 
         /// <summary>
         /// Gets the interceptor to use for configuring stubbed HTTP responses.
@@ -76,7 +76,7 @@ namespace AspNet.Security.OAuth
         /// <summary>
         /// Gets the optional redirect URI to use for OAuth flows.
         /// </summary>
-        protected virtual string RedirectUri { get; }
+        protected virtual string? RedirectUri { get; }
 
         /// <summary>
         /// Registers authentication for the test.
@@ -113,7 +113,7 @@ namespace AspNet.Security.OAuth
         /// <returns>
         /// The test application to use for authentication.
         /// </returns>
-        protected WebApplicationFactory<Program> CreateTestServer(Action<IServiceCollection> configureServices = null)
+        protected WebApplicationFactory<Program> CreateTestServer(Action<IServiceCollection>? configureServices = null)
             => ApplicationFactory.CreateApplication(this, configureServices);
 
         /// <summary>

--- a/test/AspNet.Security.OAuth.Providers.Tests/OAuthTests`1.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/OAuthTests`1.cs
@@ -38,7 +38,7 @@ namespace AspNet.Security.OAuth
         {
             Interceptor = new HttpClientInterceptorOptions()
                 .ThrowsOnMissingRegistration()
-                .RegisterBundle(Path.Combine(GetType().Name.Replace("Tests", string.Empty), "bundle.json"));
+                .RegisterBundle(Path.Combine(GetType().Name.Replace("Tests", string.Empty, StringComparison.OrdinalIgnoreCase), "bundle.json"));
 
             LoopbackRedirectHandler = new LoopbackRedirectHandler
             {

--- a/test/AspNet.Security.OAuth.Providers.Tests/OAuthTests`1.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/OAuthTests`1.cs
@@ -90,7 +90,9 @@ namespace AspNet.Security.OAuth
         /// localization scenario.
         /// </summary>
         /// <param name="app">The application.</param>
-        protected internal virtual void ConfigureApplication(IApplicationBuilder app) { }
+        protected internal virtual void ConfigureApplication(IApplicationBuilder app)
+        {
+        }
 
         /// <summary>
         /// Configures the default authentication options.

--- a/test/AspNet.Security.OAuth.Providers.Tests/Odnoklassniki/OdnoklassnikiTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Odnoklassniki/OdnoklassnikiTests.cs
@@ -46,14 +46,13 @@ namespace AspNet.Security.OAuth.Odnoklassniki
         public async Task Can_Sign_In_Using_Odnoklassniki(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Onshape/OnshapeTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Onshape/OnshapeTests.cs
@@ -33,14 +33,13 @@ namespace AspNet.Security.OAuth.Onshape
         public async Task Can_Sign_In_Using_Onshape(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Patreon/PatreonTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Patreon/PatreonTests.cs
@@ -35,14 +35,13 @@ namespace AspNet.Security.OAuth.Patreon
         public async Task Can_Sign_In_Using_Patreon(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Paypal/PaypalTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Paypal/PaypalTests.cs
@@ -36,14 +36,13 @@ namespace AspNet.Security.OAuth.Paypal
         public async Task Can_Sign_In_Using_Paypal(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/QQ/QQTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/QQ/QQTests.cs
@@ -38,14 +38,13 @@ namespace AspNet.Security.OAuth.QQ
         public async Task Can_Sign_In_Using_QQ(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Reddit/RedditTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Reddit/RedditTests.cs
@@ -34,14 +34,13 @@ namespace AspNet.Security.OAuth.Reddit
         public async Task Can_Sign_In_Using_Reddit(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Salesforce/SalesforceTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Salesforce/SalesforceTests.cs
@@ -37,14 +37,13 @@ namespace AspNet.Security.OAuth.Salesforce
         public async Task Can_Sign_In_Using_Salesforce(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Shopify/ShopifyLoopbackRedirectHandler.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Shopify/ShopifyLoopbackRedirectHandler.cs
@@ -20,7 +20,7 @@ namespace AspNet.Security.OAuth.Shopify
         {
         }
 
-        public string ShopName { get; set; }
+        public string ShopName { get; set; } = string.Empty;
 
         protected override Uri BuildLoopbackUri(HttpResponseMessage responseMessage)
         {

--- a/test/AspNet.Security.OAuth.Providers.Tests/Shopify/ShopifyLoopbackRedirectHandler.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Shopify/ShopifyLoopbackRedirectHandler.cs
@@ -1,4 +1,10 @@
-﻿using System;
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System;
 using System.Globalization;
 using System.Net.Http;
 using System.Web;

--- a/test/AspNet.Security.OAuth.Providers.Tests/Shopify/ShopifyLoopbackRedirectHandler.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Shopify/ShopifyLoopbackRedirectHandler.cs
@@ -18,7 +18,7 @@ namespace AspNet.Security.OAuth.Shopify
 
         protected override Uri BuildLoopbackUri(HttpResponseMessage responseMessage)
         {
-            Uri uri = base.BuildLoopbackUri(responseMessage);
+            var uri = base.BuildLoopbackUri(responseMessage);
 
             var builder = new UriBuilder(uri);
 

--- a/test/AspNet.Security.OAuth.Providers.Tests/Shopify/ShopifyLoopbackRedirectHandler.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Shopify/ShopifyLoopbackRedirectHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Net.Http;
 using System.Web;
 using AspNet.Security.OAuth.Infrastructure;
@@ -23,7 +24,7 @@ namespace AspNet.Security.OAuth.Shopify
 
             var queryString = HttpUtility.ParseQueryString(builder.Query);
 
-            queryString.Add("shop", string.Format(FormatShopParameter, ShopName));
+            queryString.Add("shop", string.Format(CultureInfo.InvariantCulture, FormatShopParameter, ShopName));
 
             builder.Query = queryString.ToString();
 

--- a/test/AspNet.Security.OAuth.Providers.Tests/Shopify/ShopifyTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Shopify/ShopifyTests.cs
@@ -4,6 +4,7 @@
  * for more information concerning the license and the contributors participating to this project.
  */
 
+using System.Globalization;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
@@ -42,9 +43,9 @@ namespace AspNet.Security.OAuth.Shopify
         {
             base.ConfigureDefaults(builder, options);
 
-            options.AuthorizationEndpoint = string.Format(ShopifyAuthenticationDefaults.AuthorizationEndpointFormat, TestShopName);
-            options.TokenEndpoint = string.Format(ShopifyAuthenticationDefaults.TokenEndpointFormat, TestShopName);
-            options.UserInformationEndpoint = string.Format(ShopifyAuthenticationDefaults.UserInformationEndpointFormat, TestShopName);
+            options.AuthorizationEndpoint = string.Format(CultureInfo.InvariantCulture, ShopifyAuthenticationDefaults.AuthorizationEndpointFormat, TestShopName);
+            options.TokenEndpoint = string.Format(CultureInfo.InvariantCulture, ShopifyAuthenticationDefaults.TokenEndpointFormat, TestShopName);
+            options.UserInformationEndpoint = string.Format(CultureInfo.InvariantCulture, ShopifyAuthenticationDefaults.UserInformationEndpointFormat, TestShopName);
         }
 
         [Theory]

--- a/test/AspNet.Security.OAuth.Providers.Tests/Slack/SlackTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Slack/SlackTests.cs
@@ -43,14 +43,13 @@ namespace AspNet.Security.OAuth.Slack
         public async Task Can_Sign_In_Using_Slack(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/SoundCloud/SoundCloudTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/SoundCloud/SoundCloudTests.cs
@@ -37,14 +37,13 @@ namespace AspNet.Security.OAuth.SoundCloud
         public async Task Can_Sign_In_Using_SoundCloud(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Spotify/SpotifyTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Spotify/SpotifyTests.cs
@@ -40,14 +40,13 @@ namespace AspNet.Security.OAuth.Spotify
         public async Task Can_Sign_In_Using_Spotify(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/StackExchange/StackExchangeTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/StackExchange/StackExchangeTests.cs
@@ -35,14 +35,13 @@ namespace AspNet.Security.OAuth.StackExchange
         public async Task Can_Sign_In_Using_StackExchange(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/StaticAnalysisTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/StaticAnalysisTests.cs
@@ -1,0 +1,103 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using Shouldly;
+
+namespace AspNet.Security.OAuth
+{
+    public static class StaticAnalysisTests
+    {
+#if JETBRAINS_ANNOTATIONS
+        [Xunit.Fact]
+#endif
+        public static void Publicly_Visible_Parameters_Have_Null_Annotations()
+        {
+            // Arrange
+            var assemblyNames = GetProviderAssemblyNames();
+            var types = GetPublicTypes(assemblyNames);
+
+            int testedMethods = 0;
+
+            // Act
+            foreach (var type in types)
+            {
+                var methods = GetPublicOrProtectedConstructorsOrMethods(type);
+
+                foreach (var method in methods)
+                {
+                    var parameters = method.GetParameters();
+
+                    foreach (var parameter in parameters)
+                    {
+                        bool hasNullabilityAnnotation = parameter
+                            .GetCustomAttributes()
+                            .Any((p) => p.GetType().FullName == "JetBrains.Annotations.CanBeNullAttribute" ||
+                                        p.GetType().FullName == "JetBrains.Annotations.NotNullAttribute");
+
+                        // Assert
+                        hasNullabilityAnnotation.ShouldBeTrue(
+                            $"The {parameter.Name} parameter of {type.Name}.{method.Name} does not have a [NotNull] or [CanBeNull] annotation.");
+
+                        testedMethods++;
+                    }
+                }
+            }
+
+            testedMethods.ShouldBeGreaterThan(0);
+        }
+
+        private static IList<AssemblyName> GetProviderAssemblyNames()
+        {
+            var thisType = typeof(StaticAnalysisTests);
+
+            var assemblies = thisType.Assembly
+                .GetReferencedAssemblies()
+                .Where((p) => p.FullName.StartsWith(thisType.Namespace + ".", StringComparison.Ordinal))
+                .ToArray();
+
+            assemblies.ShouldNotBeEmpty();
+
+            return assemblies;
+        }
+
+        private static IList<Type> GetPublicTypes(IEnumerable<AssemblyName> assemblyNames)
+        {
+            var types = assemblyNames
+                .Select((p) => AssemblyLoadContext.Default.LoadFromAssemblyName(p))
+                .SelectMany((p) => p.GetTypes())
+                .Where((p) => p.IsPublic || p.IsNestedPublic)
+                .ToArray();
+
+            types.ShouldNotBeEmpty();
+
+            return types;
+        }
+
+        private static IList<MethodBase> GetPublicOrProtectedConstructorsOrMethods(Type type)
+        {
+            var constructors = type
+                .GetConstructors(BindingFlags.Public | BindingFlags.NonPublic)
+                .Select((p) => (MethodBase)p)
+                .ToArray();
+
+            var methods = type
+                .GetMethods(BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static)
+                .ToArray();
+
+            return methods
+                .Concat(constructors)
+                .Where((p) => p.IsPublic || p.IsFamily) // public or protected
+                .Where((p) => !p.IsAbstract)
+                .Where((p) => !p.IsSpecialName) // No property get/set or event add/remove methods
+                .ToArray();
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Strava/StravaTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Strava/StravaTests.cs
@@ -45,14 +45,13 @@ namespace AspNet.Security.OAuth.Strava
         public async Task Can_Sign_In_Using_Strava(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Trakt/TraktTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Trakt/TraktTests.cs
@@ -39,14 +39,13 @@ namespace AspNet.Security.OAuth.Trakt
         public async Task Can_Sign_In_Using_Trakt(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Twitch/TwitchTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Twitch/TwitchTests.cs
@@ -40,14 +40,13 @@ namespace AspNet.Security.OAuth.Twitch
         public async Task Can_Sign_In_Using_Twitch(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Untappd/UntappdTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Untappd/UntappdTests.cs
@@ -37,14 +37,13 @@ namespace AspNet.Security.OAuth.Untappd
         public async Task Can_Sign_In_Using_Untappd(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Vimeo/VimeoTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Vimeo/VimeoTests.cs
@@ -34,14 +34,13 @@ namespace AspNet.Security.OAuth.Vimeo
         public async Task Can_Sign_In_Using_Vimeo(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/VisualStudio/VisualStudioTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/VisualStudio/VisualStudioTests.cs
@@ -35,14 +35,13 @@ namespace AspNet.Security.OAuth.VisualStudio
         public async Task Can_Sign_In_Using_Visual_Studio(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Vkontakte/VkontakteTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Vkontakte/VkontakteTests.cs
@@ -38,14 +38,13 @@ namespace AspNet.Security.OAuth.Vkontakte
         public async Task Can_Sign_In_Using_Vkontakte(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Wechat/WechatTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Wechat/WechatTests.cs
@@ -20,7 +20,7 @@ namespace AspNet.Security.OAuth.Weixin
             OutputHelper = outputHelper;
         }
 
-        public override string DefaultScheme =>  WeixinAuthenticationDefaults.AuthenticationScheme;
+        public override string DefaultScheme => WeixinAuthenticationDefaults.AuthenticationScheme;
 
         protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
         {

--- a/test/AspNet.Security.OAuth.Providers.Tests/Wechat/WechatTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Wechat/WechatTests.cs
@@ -44,14 +44,13 @@ namespace AspNet.Security.OAuth.Weixin
         public async Task Can_Sign_In_Using_Wechat(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Weibo/WeiboTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Weibo/WeiboTests.cs
@@ -41,14 +41,13 @@ namespace AspNet.Security.OAuth.Weibo
         public async Task Can_Sign_In_Using_Weibo(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Weixin/WeixinTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Weixin/WeixinTests.cs
@@ -40,14 +40,13 @@ namespace AspNet.Security.OAuth.Weixin
         public async Task Can_Sign_In_Using_Weixin(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/WordPress/WordPressTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/WordPress/WordPressTests.cs
@@ -38,14 +38,13 @@ namespace AspNet.Security.OAuth.WordPress
         public async Task Can_Sign_In_Using_WordPress(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Yahoo/YahooTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Yahoo/YahooTests.cs
@@ -37,14 +37,13 @@ namespace AspNet.Security.OAuth.Yahoo
         public async Task Can_Sign_In_Using_Yahoo(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Yammer/YammerTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Yammer/YammerTests.cs
@@ -38,14 +38,13 @@ namespace AspNet.Security.OAuth.Yammer
         public async Task Can_Sign_In_Using_Yammer(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Yandex/YandexTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Yandex/YandexTests.cs
@@ -36,14 +36,13 @@ namespace AspNet.Security.OAuth.Yandex
         public async Task Can_Sign_In_Using_Yandex(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Zalo/ZaloTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Zalo/ZaloTests.cs
@@ -29,14 +29,13 @@ namespace AspNet.Security.OAuth.Zalo
         public async Task Can_Sign_In_Using_Zalo(string claimType, string claimValue)
         {
             // Arrange
-            using (var server = CreateTestServer())
-            {
-                // Act
-                var claims = await AuthenticateUserAsync(server);
+            using var server = CreateTestServer();
 
-                // Assert
-                AssertClaim(claims, claimType, claimValue);
-            }
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Zalo/ZaloTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Zalo/ZaloTests.cs
@@ -1,4 +1,10 @@
-﻿using System.Security.Claims;
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.DependencyInjection;


### PR DESCRIPTION
This PR adds some static analysers for code and style, and then fixes (or suppresses) the violations found.

The rationale behind this is to try and reduce the number of small comments made on PRs from contributors for various classes of small issues by having them surfaced to contributors while they're working on a change, rather than at review time by a reviewer.

I've disabled various rules for the analyzers for the majority of cases where the warning is more of a style choice (e.g. ordering of member types and accessibility modifiers) or where a specific warning is not relevant or not a concern for use (e.g. using `ConfigureAwait(false)` or storing strings in resource files).

I've also disabled rules where they _may_ have been useful in the past when code was new, but would be a breaking change to resolve now (e.g. using `Uri` for URLs instead of `string`).

Further to the above, it also fixes some minor trivia for consistency as the framework has evolved over time and/or providers have been added, such as:
  * `string` being implicitly converted to `PathString`
  * New dictionary initializer syntax
  * Missing ReSharper attributes
  * Simplified `using` statements

If any of the new rules that aren't disabled are too controversial for tastes, I can disable more of them. The StyleCop analyzer has certainly found some issues that aren't really style, such as missing/incorrect copyright headers.

Finally, the PR also enables nullable reference types and adds the appropriate annotations.