### PR TITLE
Fix log message when Apple ID token validation fails

### DIFF
--- a/src/AspNet.Security.OAuth.Apple/Internal/DefaultAppleIdTokenValidator.cs
+++ b/src/AspNet.Security.OAuth.Apple/Internal/DefaultAppleIdTokenValidator.cs
@@ -57,9 +57,13 @@ namespace AspNet.Security.OAuth.Apple.Internal
             {
                 _logger.LogError(
                     ex,
-                    "Apple ID token validation failed for issuer {TokenIssuer} and audience {TokenAudience}. ID Token: {IdToken}",
-                    parameters.ValidAudience,
+                    "Apple ID token validation failed for issuer {TokenIssuer} and audience {TokenAudience}.",
                     parameters.ValidIssuer,
+                    parameters.ValidAudience);
+
+                _logger.LogTrace(
+                    ex,
+                    "Apple ID token {IdToken} could not be validated.",
                     context.IdToken);
 
                 throw;


### PR DESCRIPTION
  * Fix the issuer and audience parameters in log message being the wrong way around.
  * Log the Apple ID that failed token validation at Trace, rather than in the Error log message.

Resolves #381.
