### PR TITLE
Periodically reload Apple public keys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: csharp
 mono: none
-sudo: false
 dist: xenial
 addons:
   apt:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ nuget:
 skip_tags: false
 test: off
 
-after_build:
+on_finish:
   - ps: $wc = New-Object 'System.Net.WebClient'
   - ps: $wc.UploadFile("https://ci.appveyor.com/api/testresults/xunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\artifacts\TestResults\Release\AspNet.Security.OAuth.Providers.Tests_netcoreapp3.1_x64.xml))
 

--- a/src/AspNet.Security.OAuth.Apple/AppleAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Apple/AppleAuthenticationOptions.cs
@@ -62,7 +62,7 @@ namespace AspNet.Security.OAuth.Apple
 
         /// <summary>
         /// Gets or sets the default period of time to cache the Apple public key(s)
-        /// retreived from the endpoint specified by <see cref="PublicKeyEndpoint"/> for.
+        /// retrieved from the endpoint specified by <see cref="PublicKeyEndpoint"/> for.
         /// </summary>
         public TimeSpan PublicKeyCacheLifetime { get; set; } = TimeSpan.FromMinutes(15);
 

--- a/src/AspNet.Security.OAuth.Apple/AppleAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Apple/AppleAuthenticationOptions.cs
@@ -37,7 +37,7 @@ namespace AspNet.Security.OAuth.Apple
         /// if <see cref="GenerateClientSecret"/> is set to <see langword="true"/>.
         /// </summary>
         /// <remarks>
-        /// The default client secret lifetime is six months.
+        /// The default client secret lifetime is 6 months.
         /// </remarks>
         public TimeSpan ClientSecretExpiresAfter { get; set; } = TimeSpan.FromSeconds(15777000); // 6 months in seconds
 
@@ -62,8 +62,11 @@ namespace AspNet.Security.OAuth.Apple
 
         /// <summary>
         /// Gets or sets the default period of time to cache the Apple public key(s)
-        /// retrieved from the endpoint specified by <see cref="PublicKeyEndpoint"/> for.
+        /// retrieved from the endpoint specified by <see cref="PublicKeyEndpoint"/>.
         /// </summary>
+        /// <remarks>
+        /// The default public key cache lifetime is 15 minutes.
+        /// </remarks>
         public TimeSpan PublicKeyCacheLifetime { get; set; } = TimeSpan.FromMinutes(15);
 
         /// <summary>

--- a/src/AspNet.Security.OAuth.Apple/AppleAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Apple/AppleAuthenticationOptions.cs
@@ -61,6 +61,12 @@ namespace AspNet.Security.OAuth.Apple
         public string KeyId { get; set; }
 
         /// <summary>
+        /// Gets or sets the default period of time to cache the Apple public key(s)
+        /// retreived from the endpoint specified by <see cref="PublicKeyEndpoint"/> for.
+        /// </summary>
+        public TimeSpan PublicKeyCacheLifetime { get; set; } = TimeSpan.FromMinutes(15);
+
+        /// <summary>
         /// Gets or sets the URI the middleware will access to obtain the public key for
         /// validating tokens if <see cref="ValidateTokens"/> is <see langword="true"/>.
         /// </summary>

--- a/src/AspNet.Security.OAuth.Apple/Internal/DefaultAppleKeyStore.cs
+++ b/src/AspNet.Security.OAuth.Apple/Internal/DefaultAppleKeyStore.cs
@@ -8,19 +8,24 @@ using System;
 using System.Net.Http;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Logging;
 
 namespace AspNet.Security.OAuth.Apple.Internal
 {
     internal sealed class DefaultAppleKeyStore : AppleKeyStore
     {
+        private readonly ISystemClock _clock;
         private readonly ILogger _logger;
 
         private byte[] _publicKey;
+        private DateTimeOffset _reloadKeysAfter;
 
         public DefaultAppleKeyStore(
+            [NotNull] ISystemClock clock,
             [NotNull] ILogger<DefaultAppleKeyStore> logger)
         {
+            _clock = clock;
             _logger = logger;
         }
 
@@ -40,9 +45,19 @@ namespace AspNet.Security.OAuth.Apple.Internal
         /// <inheritdoc />
         public override async Task<byte[]> LoadPublicKeysAsync([NotNull] AppleValidateIdTokenContext context)
         {
-            if (_publicKey == null)
+            var utcNow = _clock.UtcNow;
+
+            if (_publicKey == null || _reloadKeysAfter < utcNow)
             {
+                _logger.LogInformation("Loading Apple public keys from {PublicKeyEndpoint}.", context.Options.PublicKeyEndpoint);
+
                 _publicKey = await LoadApplePublicKeysAsync(context);
+                _reloadKeysAfter = utcNow.Add(context.Options.PublicKeyCacheLifetime);
+
+                _logger.LogInformation(
+                    "Loaded Apple public keys from {PublicKeyEndpoint}. Keys will be reloaded at or after {ReloadKeysAfter}.",
+                    context.Options.PublicKeyEndpoint,
+                    _reloadKeysAfter);
             }
 
             return _publicKey;
@@ -50,8 +65,6 @@ namespace AspNet.Security.OAuth.Apple.Internal
 
         private async Task<byte[]> LoadApplePublicKeysAsync([NotNull] AppleValidateIdTokenContext context)
         {
-            _logger.LogInformation("Loading Apple public keys from {PublicKeyEndpoint}.", context.Options.PublicKeyEndpoint);
-
             var response = await context.Options.Backchannel.GetAsync(context.Options.PublicKeyEndpoint, context.HttpContext.RequestAborted);
 
             if (!response.IsSuccessStatusCode)

--- a/test/AspNet.Security.OAuth.Providers.Tests/Apple/AppleTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Apple/AppleTests.cs
@@ -375,26 +375,22 @@ namespace AspNet.Security.OAuth.Apple
                 "my-token");
 
             // Act
-            byte[] actual1 = await keyStore.LoadPublicKeysAsync(context);
-            byte[] actual2 = await keyStore.LoadPublicKeysAsync(context);
+            byte[] first = await keyStore.LoadPublicKeysAsync(context);
 
             // Assert
-            actual1.ShouldNotBeNull();
-            actual1.ShouldNotBeEmpty();
-            actual1.ShouldBeSameAs(actual2);
+            first.ShouldNotBeNull();
+            first.ShouldNotBeEmpty();
 
             // Arrange
-            await Task.Delay(TimeSpan.FromSeconds(1.5));
+            await Task.Delay(TimeSpan.FromSeconds(1));
 
             // Act
-            actual2 = await keyStore.LoadPublicKeysAsync(context);
+            byte[] second = await keyStore.LoadPublicKeysAsync(context);
 
             // Assert
-            actual1.ShouldNotBeNull();
-            actual1.ShouldNotBeEmpty();
-            actual2.ShouldNotBeNull();
-            actual2.ShouldNotBeEmpty();
-            actual1.ShouldNotBeSameAs(actual2);
+            second.ShouldNotBeNull();
+            second.ShouldNotBeEmpty();
+            first.ShouldNotBeSameAs(second);
         }
 
         private sealed class FrozenJwtSecurityTokenHandler : JwtSecurityTokenHandler

--- a/test/AspNet.Security.OAuth.Providers.Tests/Apple/AppleTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Apple/AppleTests.cs
@@ -384,7 +384,7 @@ namespace AspNet.Security.OAuth.Apple
             actual1.ShouldBeSameAs(actual2);
 
             // Arrange
-            await Task.Delay(TimeSpan.FromSeconds(1));
+            await Task.Delay(TimeSpan.FromSeconds(1.5));
 
             // Act
             actual2 = await keyStore.LoadPublicKeysAsync(context);


### PR DESCRIPTION
Reload the cached Apple public keys, with a default reload period of at least every 15 minutes after first load.

The cache period can be configured with the new `PublicKeyCacheLifetime` property on the `AppleAuthenticationOptions` class.

Resolves #383.
