### PR TITLE
Update Reference Assemblies

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -80,7 +80,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(OS)' != 'Windows_NT' ">
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0-preview.2" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Update to the latest stable version of `Microsoft.NETFramework.ReferenceAssemblies`.
