### PR TITLE
Map name identifier to email

### DIFF
--- a/src/AspNet.Security.OAuth.MailRu/MailRuAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.MailRu/MailRuAuthenticationOptions.cs
@@ -25,7 +25,7 @@ namespace AspNet.Security.OAuth.MailRu
             TokenEndpoint = MailRuAuthenticationDefaults.TokenEndpoint;
             UserInformationEndpoint = MailRuAuthenticationDefaults.UserInformationEndpoint;
 
-            ClaimActions.MapJsonKey(ClaimTypes.NameIdentifier, "client_id");
+            ClaimActions.MapJsonKey(ClaimTypes.NameIdentifier, "email");
             ClaimActions.MapJsonKey(ClaimTypes.Name, "nickname");
             ClaimActions.MapJsonKey(ClaimTypes.Gender, "gender");
             ClaimActions.MapJsonKey(ClaimTypes.Email, "email");

--- a/test/AspNet.Security.OAuth.Providers.Tests/MailRu/MailRuTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/MailRu/MailRuTests.cs
@@ -31,7 +31,7 @@ namespace AspNet.Security.OAuth.MailRu
         }
 
         [Theory]
-        [InlineData(ClaimTypes.NameIdentifier, "123abc")]
+        [InlineData(ClaimTypes.NameIdentifier, "vasya@mail.ru")]
         [InlineData(ClaimTypes.Name, "Vasya")]
         [InlineData(ClaimTypes.Email, "vasya@mail.ru")]
         [InlineData(ClaimTypes.GivenName, "Vasiliy")]


### PR DESCRIPTION
Mail.ru for some reasons doesn't return name identifier like other providers. When we use current options after first enter with mail.ru other users will enter as first user because they have the same name identifier. client_id - it's an application identifier, not a user's.