### PR TITLE
Fix incorrect logged value

### DIFF
--- a/src/AspNet.Security.OAuth.Apple/AppleAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Apple/AppleAuthenticationHandler.cs
@@ -90,7 +90,7 @@ namespace AspNet.Security.OAuth.Apple
                 Logger.LogTrace("Refresh Token: {RefreshToken}", tokens.RefreshToken);
                 Logger.LogTrace("Token Type: {TokenType}", tokens.TokenType);
                 Logger.LogTrace("Expires In: {ExpiresIn}", tokens.ExpiresIn);
-                Logger.LogTrace("Response: {TokenResponse}", tokens.Response);
+                Logger.LogTrace("Response: {TokenResponse}", tokens.Response.RootElement);
                 Logger.LogTrace("ID Token: {IdToken}", idToken);
             }
 


### PR DESCRIPTION
Fix `System.Text.Json.JsonDocument` being logged instead of the actual JSON.

Found while debugging #407.
