### PR TITLE
Ensure Apple email claim is set for .NET Core 2

### DIFF
--- a/src/AspNet.Security.OAuth.Apple/AppleAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Apple/AppleAuthenticationOptions.cs
@@ -30,6 +30,11 @@ namespace AspNet.Security.OAuth.Apple
 
             Scope.Add("name");
             Scope.Add("email");
+
+            // Add a custom claim action that maps the email claim from the ID token if
+            // it was not otherwise provided in the user endpoint response.
+            // See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/issues/407
+            ClaimActions.Add(new AppleEmailClaimAction(this));
         }
 
         /// <summary>

--- a/src/AspNet.Security.OAuth.Apple/AppleEmailClaimAction.cs
+++ b/src/AspNet.Security.OAuth.Apple/AppleEmailClaimAction.cs
@@ -1,0 +1,37 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authentication.OAuth.Claims;
+using Newtonsoft.Json.Linq;
+
+namespace AspNet.Security.OAuth.Apple
+{
+    internal sealed class AppleEmailClaimAction : ClaimAction
+    {
+        private readonly AppleAuthenticationOptions _options;
+
+        internal AppleEmailClaimAction(AppleAuthenticationOptions options)
+            : base(ClaimTypes.Email, ClaimValueTypes.String)
+        {
+            _options = options;
+        }
+
+        public override void Run(JObject userData, ClaimsIdentity identity, string issuer)
+        {
+            if (!identity.HasClaim((p) => string.Equals(p.Type, ClaimType, StringComparison.OrdinalIgnoreCase)))
+            {
+                var emailClaim = identity.FindFirst("email");
+
+                if (!string.IsNullOrEmpty(emailClaim?.Value))
+                {
+                    identity.AddClaim(new Claim(ClaimType, emailClaim.Value, ValueType, _options.ClaimsIssuer));
+                }
+            }
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/Apple/AppleTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Apple/AppleTests.cs
@@ -31,7 +31,7 @@ namespace AspNet.Security.OAuth.Apple
 
         protected override HttpMethod RedirectMethod => HttpMethod.Post;
 
-        protected override IDictionary<string, string> RedirectParameters => new Dictionary<string, string>()
+        protected override IDictionary<string, string> RedirectParameters { get; } = new Dictionary<string, string>()
         {
             ["user"] = @"{""name"":{""firstName"":""Johnny"",""lastName"":""Appleseed""},""email"":""johnny.appleseed@apple.local""}",
         };
@@ -110,6 +110,46 @@ namespace AspNet.Security.OAuth.Apple
                 // Assert
                 AssertClaim(claims, claimType, claimValue);
             }
+        }
+
+        [Theory]
+        [InlineData("at_hash", "eOy0y7XVexdkzc7uuDZiCQ")]
+        [InlineData("aud", "com.martincostello.signinwithapple.test.client")]
+        [InlineData("auth_time", "1587211556")]
+        [InlineData("email", "ussckefuz6@privaterelay.appleid.com")]
+        [InlineData("email_verified", "true")]
+        [InlineData("exp", "1587212159")]
+        [InlineData("iat", "1587211559")]
+        [InlineData("iss", "https://appleid.apple.com")]
+        [InlineData("is_private_email", "true")]
+        [InlineData("nonce_supported", "true")]
+        [InlineData("sub", "001883.fcc77ba97500402389df96821ad9c790.1517")]
+        [InlineData(ClaimTypes.Email, "ussckefuz6@privaterelay.appleid.com")]
+        [InlineData(ClaimTypes.NameIdentifier, "001883.fcc77ba97500402389df96821ad9c790.1517")]
+        public async Task Can_Sign_In_Using_Apple_And_Receive_Claims_From_Id_Token(string claimType, string claimValue)
+        {
+            // Arrange
+            static void ConfigureServices(IServiceCollection services)
+            {
+                services.AddSingleton<JwtSecurityTokenHandler, FrozenJwtSecurityTokenHandler>();
+                services.PostConfigureAll<AppleAuthenticationOptions>((options) =>
+                {
+                    options.ClientSecret = "my-client-secret";
+                    options.GenerateClientSecret = false;
+                    options.TokenEndpoint = "https://appleid.apple.local/auth/token/email";
+                    options.ValidateTokens = false;
+                });
+            }
+
+            RedirectParameters.Clear(); // Simulate second sign in where user data is not returned
+
+            using var server = CreateTestServer(ConfigureServices);
+
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
         }
 
         [Theory]

--- a/test/AspNet.Security.OAuth.Providers.Tests/Apple/AppleTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Apple/AppleTests.cs
@@ -129,7 +129,7 @@ namespace AspNet.Security.OAuth.Apple
         public async Task Can_Sign_In_Using_Apple_And_Receive_Claims_From_Id_Token(string claimType, string claimValue)
         {
             // Arrange
-            static void ConfigureServices(IServiceCollection services)
+            void ConfigureServices(IServiceCollection services)
             {
                 services.AddSingleton<JwtSecurityTokenHandler, FrozenJwtSecurityTokenHandler>();
                 services.PostConfigureAll<AppleAuthenticationOptions>((options) =>
@@ -143,13 +143,14 @@ namespace AspNet.Security.OAuth.Apple
 
             RedirectParameters.Clear(); // Simulate second sign in where user data is not returned
 
-            using var server = CreateTestServer(ConfigureServices);
+            using (var server = CreateTestServer(ConfigureServices))
+            {
+                // Act
+                var claims = await AuthenticateUserAsync(server);
 
-            // Act
-            var claims = await AuthenticateUserAsync(server);
-
-            // Assert
-            AssertClaim(claims, claimType, claimValue);
+                // Assert
+                AssertClaim(claims, claimType, claimValue);
+            }
         }
 
         [Theory]

--- a/test/AspNet.Security.OAuth.Providers.Tests/Apple/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Apple/bundle.json
@@ -33,6 +33,19 @@
       }
     },
     {
+      "comment": "https://developer.apple.com/documentation/signinwithapplerestapi/generate_and_validate_tokens",
+      "uri": "https://appleid.apple.local/auth/token/email",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "secret-access-token",
+        "expires_in": "300",
+        "id_token": "eyJraWQiOiI4NkQ4OEtmIiwiYWxnIjoiUlMyNTYifQ.eyJpc3MiOiJodHRwczovL2FwcGxlaWQuYXBwbGUuY29tIiwiYXVkIjoiY29tLm1hcnRpbmNvc3RlbGxvLnNpZ25pbndpdGhhcHBsZS50ZXN0LmNsaWVudCIsImV4cCI6MTU4NzIxMjE1OSwiaWF0IjoxNTg3MjExNTU5LCJzdWIiOiIwMDE4ODMuZmNjNzdiYTk3NTAwNDAyMzg5ZGY5NjgyMWFkOWM3OTAuMTUxNyIsImF0X2hhc2giOiJlT3kweTdYVmV4ZGt6Yzd1dURaaUNRIiwiZW1haWwiOiJ1c3Nja2VmdXo2QHByaXZhdGVyZWxheS5hcHBsZWlkLmNvbSIsImVtYWlsX3ZlcmlmaWVkIjoidHJ1ZSIsImlzX3ByaXZhdGVfZW1haWwiOiJ0cnVlIiwiYXV0aF90aW1lIjoxNTg3MjExNTU2LCJub25jZV9zdXBwb3J0ZWQiOnRydWV9.ZPUgcJlCneXLNZiFDraKpWVtFPSyoxkWgrMlTZ8tM3IBBXOmQFbb75OBQC-JbZHciry96y-sy33O_fF8gaudmInH1EorDIsfryafNd0POD-8pJWY9PiGrGx50c_1DLIIIsYEm0p-JEIfQpzJ-lIWpz9ujv4ChmZx-t3PzPzzZOVlC0q1pATqJaxhY_ntL_u98BZnfAKxzqEhb5q-1TmhtHFaEtAtsd2gGm6PTaM5N-2HXQ8Bh_BlJMH3u_KakFNJRhaezlVIlLtmgxM4VjrxUeIqba-fwBlfGXPonA_xZIHg71ZujJSlYJp3yWW3Kjsb4rUUUff7yEQF5A1LVnghwA",
+        "refresh_token": "secret-refresh-token",
+        "token_type": "bearer"
+      }
+    },
+    {
       "uri": "https://appleid.apple.local/auth/keys/none",
       "method": "GET",
       "contentFormat": "json",


### PR DESCRIPTION
Set the ClaimTypes.Email claim from the email claim in the JWT if it is present and an email is not received as a parameter with the sign in.

Resolves https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/issues/407
This pull-request is the .NET Core 2 version of this pull-request: https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/pull/411