### PR TITLE
Bump version

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 3.1.0.{build}
+version: 3.1.1.{build}
 
 build_script:
   - eng\common\CIBuild.cmd -configuration Release -prepareMachine

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <MajorVersion>3</MajorVersion>
     <MinorVersion>1</MinorVersion>
-    <PatchVersion>0</PatchVersion>
+    <PatchVersion>1</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -9,13 +9,13 @@
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
   </PropertyGroup>
   <PropertyGroup>
-    <GoogleProviderVersion>3.1.1</GoogleProviderVersion>
+    <GoogleProviderVersion>3.1.3</GoogleProviderVersion>
     <JetBrainsVersion>2019.1.3</JetBrainsVersion>
     <JustEatHttpClientInterceptionVersion>3.0.0</JustEatHttpClientInterceptionVersion>
     <MartinCostelloLoggingXUnitVersion>0.1.0</MartinCostelloLoggingXUnitVersion>
-    <MicrosoftAspNetCoreMvcTestingVersion>3.1.1</MicrosoftAspNetCoreMvcTestingVersion>
-    <MicrosoftAspNetCoreTestHostVersion>3.1.1</MicrosoftAspNetCoreTestHostVersion>
-    <MicrosoftNETTestSdkVersion>16.5.0</MicrosoftNETTestSdkVersion>
+    <MicrosoftAspNetCoreMvcTestingVersion>3.1.3</MicrosoftAspNetCoreMvcTestingVersion>
+    <MicrosoftAspNetCoreTestHostVersion>3.1.3</MicrosoftAspNetCoreTestHostVersion>
+    <MicrosoftNETTestSdkVersion>16.6.0</MicrosoftNETTestSdkVersion>
     <RoslynAnalyzersVersion>2.9.8</RoslynAnalyzersVersion>
     <ShouldlyVersion>3.0.2</ShouldlyVersion>
     <StyleCopAnalyzersVersion>1.1.118</StyleCopAnalyzersVersion>
@@ -23,6 +23,6 @@
       Cannot use later versions (5.5.0+) due to https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/1302.
     -->
     <SystemIdentityModelTokensJwtVersion>5.4.0</SystemIdentityModelTokensJwtVersion>
-    <TwitterProviderVersion>3.1.1</TwitterProviderVersion>
+    <TwitterProviderVersion>3.1.3</TwitterProviderVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
  * Now 3.1.0 has shipped, bump the patch version to 3.1.1.
  * Bump the NuGet package versions of various dependencies to their latest versions.
