### PR TITLE
Add Client-ID header for Helix Twitch API Endpoints

### DIFF
--- a/src/AspNet.Security.OAuth.Twitch/TwitchAuthenticationConstants.cs
+++ b/src/AspNet.Security.OAuth.Twitch/TwitchAuthenticationConstants.cs
@@ -20,5 +20,10 @@ namespace AspNet.Security.OAuth.Twitch
             public const string ProfileImageUrl = "urn:twitch:profileimageurl";
             public const string Type = "urn:twitch:type";
         }
+
+        public static class Headers
+        {
+            public const string ClientId = "Client-ID";
+        }
     }
 }

--- a/src/AspNet.Security.OAuth.Twitch/TwitchAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Twitch/TwitchAuthenticationHandler.cs
@@ -50,6 +50,7 @@ namespace AspNet.Security.OAuth.Twitch
             using var request = new HttpRequestMessage(HttpMethod.Get, Options.UserInformationEndpoint);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", tokens.AccessToken);
+            request.Headers.Add(TwitchAuthenticationConstants.Headers.ClientId, Options.ClientId);
 
             using var response = await Backchannel.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, Context.RequestAborted);
             if (!response.IsSuccessStatusCode)


### PR DESCRIPTION
Add Client-ID header for Helix Twitch API Endpoints.

fix #419 