### PR TITLE
Bump version + dependency updates

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 3.1.1.{build}
+version: 3.1.2.{build}
 
 build_script:
   - eng\common\CIBuild.cmd -configuration Release -prepareMachine

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <MajorVersion>3</MajorVersion>
     <MinorVersion>1</MinorVersion>
-    <PatchVersion>1</PatchVersion>
+    <PatchVersion>2</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -10,13 +10,13 @@
   </PropertyGroup>
   <PropertyGroup>
     <GoogleProviderVersion>3.1.3</GoogleProviderVersion>
-    <JetBrainsVersion>2019.1.3</JetBrainsVersion>
+    <JetBrainsVersion>2020.1.0</JetBrainsVersion>
     <JustEatHttpClientInterceptionVersion>3.0.0</JustEatHttpClientInterceptionVersion>
     <MartinCostelloLoggingXUnitVersion>0.1.0</MartinCostelloLoggingXUnitVersion>
     <MicrosoftAspNetCoreMvcTestingVersion>3.1.3</MicrosoftAspNetCoreMvcTestingVersion>
     <MicrosoftAspNetCoreTestHostVersion>3.1.3</MicrosoftAspNetCoreTestHostVersion>
-    <MicrosoftNETTestSdkVersion>16.6.0</MicrosoftNETTestSdkVersion>
-    <RoslynAnalyzersVersion>2.9.8</RoslynAnalyzersVersion>
+    <MicrosoftNETTestSdkVersion>16.6.1</MicrosoftNETTestSdkVersion>
+    <RoslynAnalyzersVersion>3.0.0</RoslynAnalyzersVersion>
     <ShouldlyVersion>3.0.2</ShouldlyVersion>
     <StyleCopAnalyzersVersion>1.1.118</StyleCopAnalyzersVersion>
     <!--

--- a/src/AspNet.Security.OAuth.QQ/QQAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.QQ/QQAuthenticationHandler.cs
@@ -149,7 +149,7 @@ namespace AspNet.Security.OAuth.QQ
 
         protected override string FormatScope() => string.Join(",", Options.Scope);
 
-        private async Task<JsonDocument> CopyPayloadAsync(Dictionary<string, StringValues> content)
+        private static async Task<JsonDocument> CopyPayloadAsync(Dictionary<string, StringValues> content)
         {
             var bufferWriter = new ArrayBufferWriter<byte>();
 

--- a/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationHandler.cs
@@ -117,7 +117,7 @@ namespace AspNet.Security.OAuth.StackExchange
             return OAuthTokenResponse.Success(copy);
         }
 
-        private async Task<JsonDocument> CopyPayloadAsync(Dictionary<string, StringValues> content)
+        private static async Task<JsonDocument> CopyPayloadAsync(Dictionary<string, StringValues> content)
         {
             var bufferWriter = new ArrayBufferWriter<byte>();
 

--- a/src/AspNet.Security.OAuth.Yammer/YammerAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Yammer/YammerAuthenticationHandler.cs
@@ -99,7 +99,7 @@ namespace AspNet.Security.OAuth.Yammer
             return OAuthTokenResponse.Success(token);
         }
 
-        private async Task<JsonDocument> CreateAccessTokenAsync(string accessToken)
+        private static async Task<JsonDocument> CreateAccessTokenAsync(string accessToken)
         {
             var bufferWriter = new ArrayBufferWriter<byte>();
 


### PR DESCRIPTION
  * Bump version to 3.1.2 for next patch release.
  * Make three private methods that do not use any instance members static.
  * Update the .NET test SDK, Roslyn analyzers and JetBrains annotations to their latest versions.
