### PR TITLE
Refactor use of FormUrlEncodedContent

### DIFF
--- a/src/AspNet.Security.OAuth.Fitbit/FitbitAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Fitbit/FitbitAuthenticationHandler.cs
@@ -69,12 +69,14 @@ namespace AspNet.Security.OAuth.Fitbit
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             request.Headers.Authorization = CreateAuthorizationHeader();
 
-            request.Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            var parameters = new Dictionary<string, string>
             {
                 ["grant_type"] = "authorization_code",
                 ["redirect_uri"] = context.RedirectUri,
                 ["code"] = context.Code
-            });
+            };
+
+            request.Content = new FormUrlEncodedContent(parameters);
 
             using var response = await Backchannel.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, Context.RequestAborted);
             if (!response.IsSuccessStatusCode)

--- a/src/AspNet.Security.OAuth.Reddit/RedditAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Reddit/RedditAuthenticationHandler.cs
@@ -101,12 +101,14 @@ namespace AspNet.Security.OAuth.Reddit
                 request.Headers.UserAgent.ParseAdd(Options.UserAgent);
             }
 
-            request.Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            var parameters = new Dictionary<string, string>
             {
                 ["grant_type"] = "authorization_code",
                 ["redirect_uri"] = context.RedirectUri,
                 ["code"] = context.Code
-            });
+            };
+
+            request.Content = new FormUrlEncodedContent(parameters);
 
             using var response = await Backchannel.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, Context.RequestAborted);
             if (!response.IsSuccessStatusCode)

--- a/src/AspNet.Security.OAuth.Shopify/ShopifyAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Shopify/ShopifyAuthenticationHandler.cs
@@ -179,12 +179,14 @@ namespace AspNet.Security.OAuth.Shopify
             using var request = new HttpRequestMessage(HttpMethod.Post, uri);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/x-www-form-urlencoded"));
 
-            request.Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            var parameters = new Dictionary<string, string>
             {
                 ["client_id"] = Options.ClientId,
                 ["client_secret"] = Options.ClientSecret,
                 ["code"] = context.Code
-            });
+            };
+
+            request.Content = new FormUrlEncodedContent(parameters);
 
             using var response = await Backchannel.SendAsync(request, Context.RequestAborted);
 

--- a/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationHandler.cs
@@ -85,16 +85,18 @@ namespace AspNet.Security.OAuth.StackExchange
 
         protected override async Task<OAuthTokenResponse> ExchangeCodeAsync([NotNull] OAuthCodeExchangeContext context)
         {
+            var parameters = new Dictionary<string, string>
+            {
+                ["client_id"] = Options.ClientId,
+                ["redirect_uri"] = context.RedirectUri,
+                ["client_secret"] = Options.ClientSecret,
+                ["code"] = context.Code,
+                ["grant_type"] = "authorization_code"
+            };
+
             using var request = new HttpRequestMessage(HttpMethod.Post, Options.TokenEndpoint)
             {
-                Content = new FormUrlEncodedContent(new Dictionary<string, string>
-                {
-                    ["client_id"] = Options.ClientId,
-                    ["redirect_uri"] = context.RedirectUri,
-                    ["client_secret"] = Options.ClientSecret,
-                    ["code"] = context.Code,
-                    ["grant_type"] = "authorization_code"
-                })
+                Content = new FormUrlEncodedContent(parameters)
             };
 
             using var response = await Backchannel.SendAsync(request, Context.RequestAborted);

--- a/src/AspNet.Security.OAuth.VisualStudio/VisualStudioAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.VisualStudio/VisualStudioAuthenticationHandler.cs
@@ -68,14 +68,16 @@ namespace AspNet.Security.OAuth.VisualStudio
             using var request = new HttpRequestMessage(HttpMethod.Post, Options.TokenEndpoint);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/x-www-form-urlencoded"));
 
-            request.Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            var parameters = new Dictionary<string, string>
             {
                 ["redirect_uri"] = context.RedirectUri,
                 ["client_assertion"] = Options.ClientSecret,
                 ["assertion"] = context.Code,
                 ["grant_type"] = "urn:ietf:params:oauth:grant-type:jwt-bearer",
                 ["client_assertion_type"] = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
-            });
+            };
+
+            request.Content = new FormUrlEncodedContent(parameters);
 
             using var response = await Backchannel.SendAsync(request, Context.RequestAborted);
 

--- a/src/AspNet.Security.OAuth.Yahoo/YahooAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Yahoo/YahooAuthenticationHandler.cs
@@ -69,12 +69,14 @@ namespace AspNet.Security.OAuth.Yahoo
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             request.Headers.Authorization = CreateAuthorizationHeader();
 
-            request.Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            var parameters = new Dictionary<string, string>
             {
                 ["grant_type"] = "authorization_code",
                 ["redirect_uri"] = context.RedirectUri,
                 ["code"] = context.Code
-            });
+            };
+
+            request.Content = new FormUrlEncodedContent(parameters);
 
             using var response = await Backchannel.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, Context.RequestAborted);
             if (!response.IsSuccessStatusCode)

--- a/src/AspNet.Security.OAuth.Yammer/YammerAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Yammer/YammerAuthenticationHandler.cs
@@ -68,14 +68,16 @@ namespace AspNet.Security.OAuth.Yammer
             using var request = new HttpRequestMessage(HttpMethod.Post, Options.TokenEndpoint);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
 
-            request.Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            var parameters = new Dictionary<string, string>
             {
                 ["client_id"] = Options.ClientId,
                 ["redirect_uri"] = context.RedirectUri,
                 ["client_secret"] = Options.ClientSecret,
                 ["code"] = context.Code,
                 ["grant_type"] = "authorization_code"
-            });
+            };
+
+            request.Content = new FormUrlEncodedContent(parameters);
 
             using var response = await Backchannel.SendAsync(request, Context.RequestAborted);
             if (!response.IsSuccessStatusCode)

--- a/src/AspNet.Security.OAuth.Yandex/YandexAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Yandex/YandexAuthenticationHandler.cs
@@ -69,12 +69,14 @@ namespace AspNet.Security.OAuth.Yandex
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             request.Headers.Authorization = CreateAuthorizationHeader();
 
-            request.Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            var parameters = new Dictionary<string, string>
             {
                 ["grant_type"] = "authorization_code",
                 ["redirect_uri"] = context.RedirectUri,
                 ["code"] = context.Code
-            });
+            };
+
+            request.Content = new FormUrlEncodedContent(parameters);
 
             using var response = await Backchannel.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, Context.RequestAborted);
             if (!response.IsSuccessStatusCode)


### PR DESCRIPTION
Move the parameters into a local variable before passing to the `FormUrlEncodedContent` constructor so that it's easier to make nullable annotations happier in .NET 5 (see #438 and 53ff96a2d25b3a3f0a1225118f7338357c8982b3).
