### PR TITLE
Switch "public" with "read" since that is the base scope for Strava.

### DIFF
--- a/src/AspNet.Security.OAuth.Strava/StravaAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Strava/StravaAuthenticationOptions.cs
@@ -25,7 +25,7 @@ namespace AspNet.Security.OAuth.Strava
             TokenEndpoint = StravaAuthenticationDefaults.TokenEndpoint;
             UserInformationEndpoint = StravaAuthenticationDefaults.UserInformationEndpoint;
 
-            Scope.Add("public");
+            Scope.Add("read");
 
             ClaimActions.MapJsonKey(ClaimTypes.NameIdentifier, "id");
             ClaimActions.MapJsonKey(ClaimTypes.Name, "username");


### PR DESCRIPTION
Based on https://developers.strava.com/docs/authentication/ there is no "public" scope for Strava.

Uses "read" instead of "public" as the default scope.