### PR TITLE
Update System.IdentityModel.Tokens.Jwt to v5.5.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,6 +10,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="3.1.5" />
     <PackageVersion Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0" />
     <PackageVersion Include="Microsoft.NetCore.Analyzers" Version="3.0.0" />
+    <PackageVersion Include="Moq" Version="4.14.5" />
     <PackageVersion Include="Shouldly" Version="3.0.2" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="5.5.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,7 +12,7 @@
     <PackageVersion Include="Microsoft.NetCore.Analyzers" Version="3.0.0" />
     <PackageVersion Include="Shouldly" Version="3.0.2" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118" />
-    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="5.4.0" />
+    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="5.5.0" />
   </ItemGroup>
 
 </Project>

--- a/src/AspNet.Security.OAuth.Apple/AppleAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.Apple/AppleAuthenticationExtensions.cs
@@ -11,6 +11,7 @@ using AspNet.Security.OAuth.Apple.Internal;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.IdentityModel.Tokens;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -79,6 +80,11 @@ namespace Microsoft.Extensions.DependencyInjection
             builder.Services.TryAddSingleton<AppleIdTokenValidator, DefaultAppleIdTokenValidator>();
             builder.Services.TryAddSingleton<AppleKeyStore, DefaultAppleKeyStore>();
             builder.Services.TryAddSingleton<JwtSecurityTokenHandler>();
+
+            // Use a custom CryptoProviderFactory so that keys are not cached and then disposed of, see below:
+            // https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/1302
+            builder.Services.TryAddSingleton(
+                (_) => new CryptoProviderFactory() { CacheSignatureProviders = false });
 
             return builder.AddOAuth<AppleAuthenticationOptions, AppleAuthenticationHandler>(scheme, caption, configuration);
         }

--- a/src/AspNet.Security.OAuth.Apple/Internal/DefaultAppleClientSecretGenerator.cs
+++ b/src/AspNet.Security.OAuth.Apple/Internal/DefaultAppleClientSecretGenerator.cs
@@ -18,15 +18,11 @@ namespace AspNet.Security.OAuth.Apple.Internal
 {
     internal sealed class DefaultAppleClientSecretGenerator : AppleClientSecretGenerator
     {
-        private static readonly CryptoProviderFactory CryptoProviderFactory = new CryptoProviderFactory()
-        {
-            CacheSignatureProviders = false,
-        };
-
         private readonly ISystemClock _clock;
         private readonly ILogger _logger;
         private readonly AppleKeyStore _keyStore;
         private readonly JwtSecurityTokenHandler _tokenHandler;
+        private readonly CryptoProviderFactory _cryptoProviderFactory;
 
         private string? _clientSecret;
         private DateTimeOffset _expiresAt;
@@ -35,11 +31,13 @@ namespace AspNet.Security.OAuth.Apple.Internal
             [NotNull] AppleKeyStore keyStore,
             [NotNull] ISystemClock clock,
             [NotNull] JwtSecurityTokenHandler tokenHandler,
+            [NotNull] CryptoProviderFactory cryptoProviderFactory,
             [NotNull] ILogger<DefaultAppleClientSecretGenerator> logger)
         {
             _keyStore = keyStore;
             _clock = clock;
             _tokenHandler = tokenHandler;
+            _cryptoProviderFactory = cryptoProviderFactory;
             _logger = logger;
         }
 
@@ -112,7 +110,7 @@ namespace AspNet.Security.OAuth.Apple.Internal
             }
         }
 
-        private static SigningCredentials CreateSigningCredentials(string keyId, ECDsa algorithm)
+        private SigningCredentials CreateSigningCredentials(string keyId, ECDsa algorithm)
         {
             var key = new ECDsaSecurityKey(algorithm) { KeyId = keyId };
 
@@ -120,7 +118,7 @@ namespace AspNet.Security.OAuth.Apple.Internal
             // https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/1302
             return new SigningCredentials(key, SecurityAlgorithms.EcdsaSha256Signature)
             {
-                CryptoProviderFactory = CryptoProviderFactory,
+                CryptoProviderFactory = _cryptoProviderFactory,
             };
         }
     }

--- a/src/AspNet.Security.OAuth.Apple/Internal/DefaultAppleIdTokenValidator.cs
+++ b/src/AspNet.Security.OAuth.Apple/Internal/DefaultAppleIdTokenValidator.cs
@@ -19,14 +19,17 @@ namespace AspNet.Security.OAuth.Apple.Internal
         private readonly ILogger _logger;
         private readonly AppleKeyStore _keyStore;
         private readonly JwtSecurityTokenHandler _tokenHandler;
+        private readonly CryptoProviderFactory _cryptoProviderFactory;
 
         public DefaultAppleIdTokenValidator(
             [NotNull] AppleKeyStore keyStore,
             [NotNull] JwtSecurityTokenHandler tokenHandler,
+            [NotNull] CryptoProviderFactory cryptoProviderFactory,
             [NotNull] ILogger<DefaultAppleIdTokenValidator> logger)
         {
             _keyStore = keyStore;
             _tokenHandler = tokenHandler;
+            _cryptoProviderFactory = cryptoProviderFactory;
             _logger = logger;
         }
 
@@ -44,9 +47,10 @@ namespace AspNet.Security.OAuth.Apple.Internal
 
             var parameters = new TokenValidationParameters()
             {
+                CryptoProviderFactory = _cryptoProviderFactory,
+                IssuerSigningKeys = keySet.Keys,
                 ValidAudience = context.Options.ClientId,
                 ValidIssuer = context.Options.TokenAudience,
-                IssuerSigningKeys = keySet.Keys,
             };
 
             try

--- a/src/AspNet.Security.OAuth.Okta/OktaPostConfigureOptions.cs
+++ b/src/AspNet.Security.OAuth.Okta/OktaPostConfigureOptions.cs
@@ -5,6 +5,7 @@
  */
 
 using System;
+using JetBrains.Annotations;
 using Microsoft.Extensions.Options;
 
 namespace AspNet.Security.OAuth.Okta
@@ -15,7 +16,9 @@ namespace AspNet.Security.OAuth.Okta
     public class OktaPostConfigureOptions : IPostConfigureOptions<OktaAuthenticationOptions>
     {
         /// <inheritdoc/>
-        public void PostConfigure(string name, OktaAuthenticationOptions options)
+        public void PostConfigure(
+            [NotNull] string name,
+            [NotNull] OktaAuthenticationOptions options)
         {
             if (string.IsNullOrWhiteSpace(options.Domain))
             {

--- a/test/AspNet.Security.OAuth.Providers.Tests/Apple/AppleAuthenticationOptionsExtensionsTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Apple/AppleAuthenticationOptionsExtensionsTests.cs
@@ -1,0 +1,75 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.IdentityModel.Tokens.Jwt;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace AspNet.Security.OAuth.Apple
+{
+    public static class AppleAuthenticationOptionsExtensionsTests
+    {
+        [Fact]
+        public static void AddApple_Registers_Services()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            services.AddLogging()
+                    .AddAuthentication()
+                    .AddApple();
+
+            // Act
+            using var serviceProvider = services.BuildServiceProvider();
+
+            // Assert
+            serviceProvider.GetRequiredService<AppleAuthenticationHandler>().ShouldNotBeNull();
+            serviceProvider.GetRequiredService<AppleClientSecretGenerator>().ShouldNotBeNull();
+            serviceProvider.GetRequiredService<AppleIdTokenValidator>().ShouldNotBeNull();
+            serviceProvider.GetRequiredService<AppleKeyStore>().ShouldNotBeNull();
+            serviceProvider.GetRequiredService<IOptions<AppleAuthenticationOptions>>().ShouldNotBeNull();
+        }
+
+        [Fact]
+        public static void AddApple_Does_Not_Overwrite_Existing_Service_Registrations()
+        {
+            // Arrange
+            var cryptoProviderFactory = Mock.Of<CryptoProviderFactory>();
+            var keyStore = Mock.Of<AppleKeyStore>();
+            var secretGenerator = Mock.Of<AppleClientSecretGenerator>();
+            var tokenHandler = Mock.Of<JwtSecurityTokenHandler>();
+            var tokenValidator = Mock.Of<AppleIdTokenValidator>();
+
+            var services = new ServiceCollection()
+                .AddSingleton(cryptoProviderFactory)
+                .AddSingleton(keyStore)
+                .AddSingleton(secretGenerator)
+                .AddSingleton(tokenHandler)
+                .AddSingleton(tokenValidator);
+
+            services.AddLogging()
+                    .AddAuthentication()
+                    .AddApple();
+
+            // Act
+            using var serviceProvider = services.BuildServiceProvider();
+
+            // Assert
+            serviceProvider.GetRequiredService<AppleAuthenticationHandler>().ShouldNotBeNull();
+            serviceProvider.GetRequiredService<IOptions<AppleAuthenticationOptions>>().ShouldNotBeNull();
+
+            serviceProvider.GetRequiredService<AppleClientSecretGenerator>().ShouldBeSameAs(secretGenerator);
+            serviceProvider.GetRequiredService<AppleIdTokenValidator>().ShouldBeSameAs(tokenValidator);
+            serviceProvider.GetRequiredService<AppleKeyStore>().ShouldBeSameAs(keyStore);
+            serviceProvider.GetRequiredService<CryptoProviderFactory>().ShouldBeSameAs(cryptoProviderFactory);
+            serviceProvider.GetRequiredService<JwtSecurityTokenHandler>().ShouldBeSameAs(tokenHandler);
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/AspNet.Security.OAuth.Providers.Tests.csproj
+++ b/test/AspNet.Security.OAuth.Providers.Tests/AspNet.Security.OAuth.Providers.Tests.csproj
@@ -22,10 +22,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="JetBrains.Annotations" PrivateAssets="All" />
     <PackageReference Include="JustEat.HttpClientInterception" />
     <PackageReference Include="MartinCostello.Logging.XUnit" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" />
+    <PackageReference Include="Moq" />
     <PackageReference Include="Shouldly" />
   </ItemGroup>
 

--- a/test/AspNet.Security.OAuth.Providers.Tests/StaticAnalysisTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/StaticAnalysisTests.cs
@@ -1,0 +1,103 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using Shouldly;
+
+namespace AspNet.Security.OAuth
+{
+    public static class StaticAnalysisTests
+    {
+#if JETBRAINS_ANNOTATIONS
+        [Xunit.Fact]
+#endif
+        public static void Publicly_Visible_Parameters_Have_Null_Annotations()
+        {
+            // Arrange
+            var assemblyNames = GetProviderAssemblyNames();
+            var types = GetPublicTypes(assemblyNames);
+
+            int testedMethods = 0;
+
+            // Act
+            foreach (var type in types)
+            {
+                var methods = GetPublicOrProtectedConstructorsOrMethods(type);
+
+                foreach (var method in methods)
+                {
+                    var parameters = method.GetParameters();
+
+                    foreach (var parameter in parameters)
+                    {
+                        bool hasNullabilityAnnotation = parameter
+                            .GetCustomAttributes()
+                            .Any((p) => p.GetType().FullName == "JetBrains.Annotations.CanBeNullAttribute" ||
+                                        p.GetType().FullName == "JetBrains.Annotations.NotNullAttribute");
+
+                        // Assert
+                        hasNullabilityAnnotation.ShouldBeTrue(
+                            $"The {parameter.Name} parameter of {type.Name}.{method.Name} does not have a [NotNull] or [CanBeNull] annotation.");
+
+                        testedMethods++;
+                    }
+                }
+            }
+
+            testedMethods.ShouldBeGreaterThan(0);
+        }
+
+        private static IList<AssemblyName> GetProviderAssemblyNames()
+        {
+            var thisType = typeof(StaticAnalysisTests);
+
+            var assemblies = thisType.Assembly
+                .GetReferencedAssemblies()
+                .Where((p) => p.FullName.StartsWith(thisType.Namespace + ".", StringComparison.Ordinal))
+                .ToArray();
+
+            assemblies.ShouldNotBeEmpty();
+
+            return assemblies;
+        }
+
+        private static IList<Type> GetPublicTypes(IEnumerable<AssemblyName> assemblyNames)
+        {
+            var types = assemblyNames
+                .Select((p) => AssemblyLoadContext.Default.LoadFromAssemblyName(p))
+                .SelectMany((p) => p.GetTypes())
+                .Where((p) => p.IsPublic || p.IsNestedPublic)
+                .ToArray();
+
+            types.ShouldNotBeEmpty();
+
+            return types;
+        }
+
+        private static IList<MethodBase> GetPublicOrProtectedConstructorsOrMethods(Type type)
+        {
+            var constructors = type
+                .GetConstructors(BindingFlags.Public | BindingFlags.NonPublic)
+                .Select((p) => (MethodBase)p)
+                .ToArray();
+
+            var methods = type
+                .GetMethods(BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static)
+                .ToArray();
+
+            return methods
+                .Concat(constructors)
+                .Where((p) => p.IsPublic || p.IsFamily) // public or protected
+                .Where((p) => !p.IsAbstract)
+                .Where((p) => !p.IsSpecialName) // No property get/set or event add/remove methods
+                .ToArray();
+        }
+    }
+}


### PR DESCRIPTION
  * Update System.IdentityModel.Tokens.Jwt to v5.5.0, which matches the version that ASP.NET Core 3.x itself depends on.
  * Use a custom `CryptoProviderFactory` in an additional place to prevent key caching in a similar manner to the fix from #439. This moves the custom value up into DI, rather than being static, so users can restore the functionality if they so wish by registering their own `CryptoProviderFactory`. This issue was surfaced by the package upgrade from v5.4.0 in #417.
  * Restore the static analysis removed in #439 as it's working now with a reference to `JetBrains.Annotations`.
  * Add missing `[NotNull]` attributes to the `OktaPostConfigureOptions` class.
