### PR TITLE
Workflow fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,7 @@ jobs:
 
     - name: Push NuGet packages to aspnet-contrib MyGet
       run: dotnet nuget push "artifacts\packages\Release\Shipping\*.nupkg" --api-key ${{ secrets.MYGET_API_KEY }} --skip-duplicate --source https://www.myget.org/F/aspnet-contrib/ --symbol-source https://www.myget.org/F/aspnet-contrib/
-      if: ${{ github.repository_owner == 'aspnet-contrib' && (github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/tags/')) && runner.os == 'Windows' }}
+      if: ${{ github.repository_owner == 'aspnet-contrib' && (github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/heads/rel/') || startsWith(github.ref, 'refs/tags/')) && runner.os == 'Windows' }}
 
     - name: Push NuGet packages to NuGet.org
       run: dotnet nuget push "artifacts\packages\Release\Shipping\*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,13 +50,21 @@ jobs:
         Write-Host "::set-env name=_AspNetContribBuildNumber::${BuildId}"
 
     - name: Build, Test and Package
-      run: eng\common\CIBuild.cmd -configuration Release -prepareMachine
       if: ${{ runner.os == 'Windows' }}
+      run: eng\common\CIBuild.cmd -configuration Release -prepareMachine
+      env:
+        DOTNET_MULTILEVEL_LOOKUP: 0
+        DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+        NUGET_XMLDOC_MODE: skip
 
     - name: Build, Test and Package
       shell: pwsh
-      run: ./eng/common/cibuild.sh -configuration Release -prepareMachine
       if: ${{ runner.os != 'Windows' }}
+      run: ./eng/common/cibuild.sh -configuration Release -prepareMachine
+      env:
+        DOTNET_MULTILEVEL_LOOKUP: 0
+        DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+        NUGET_XMLDOC_MODE: skip
 
     - name: Publish logs
       uses: actions/upload-artifact@v1


### PR DESCRIPTION
  * Fix packages not being pushed to MyGet from `rel/*` branches.
  * Set some environment variables for the scripts that I noticed the Arcade scripts try to set for Azure Pipelines via console output using `##vso[task.setvariable ...` syntax.
