### PR TITLE
Add support for GitHub Enterprise

### DIFF
--- a/samples/Mvc.Client/Startup.cs
+++ b/samples/Mvc.Client/Startup.cs
@@ -57,6 +57,7 @@ namespace Mvc.Client
             {
                 options.ClientId = Configuration["GitHub:ClientId"];
                 options.ClientSecret = Configuration["GitHub:ClientSecret"];
+                options.EnterpriseDomain = Configuration["GitHub:EnterpriseDomain"];
                 options.Scope.Add("user:email");
             })
 

--- a/src/AspNet.Security.OAuth.GitHub/GitHubAuthenticationDefaults.cs
+++ b/src/AspNet.Security.OAuth.GitHub/GitHubAuthenticationDefaults.cs
@@ -37,21 +37,41 @@ namespace AspNet.Security.OAuth.GitHub
         /// <summary>
         /// Default value for <see cref="OAuthOptions.AuthorizationEndpoint"/>.
         /// </summary>
-        public const string AuthorizationEndpoint = "https://github.com/login/oauth/authorize";
+        public const string AuthorizationEndpoint = "https://github.com" + AuthorizationEndpointPath;
 
         /// <summary>
         /// Default value for <see cref="OAuthOptions.TokenEndpoint"/>.
         /// </summary>
-        public const string TokenEndpoint = "https://github.com/login/oauth/access_token";
+        public const string TokenEndpoint = "https://github.com" + TokenEndpointPath;
 
         /// <summary>
         /// Default value for <see cref="OAuthOptions.UserInformationEndpoint"/>.
         /// </summary>
-        public const string UserInformationEndpoint = "https://api.github.com/user";
+        public const string UserInformationEndpoint = "https://api.github.com" + UserInformationEndpointPath;
 
         /// <summary>
         /// Default value for <see cref="GitHubAuthenticationOptions.UserEmailsEndpoint"/>.
         /// </summary>
-        public const string UserEmailsEndpoint = "https://api.github.com/user/emails";
+        public const string UserEmailsEndpoint = "https://api.github.com" + UserEmailsEndpointPath;
+
+        /// <summary>
+        /// Default path to use for <see cref="OAuthOptions.AuthorizationEndpoint"/>.
+        /// </summary>
+        public const string AuthorizationEndpointPath = "/login/oauth/authorize";
+
+        /// <summary>
+        /// Default path to use for <see cref="OAuthOptions.TokenEndpoint"/>.
+        /// </summary>
+        public const string TokenEndpointPath = "/login/oauth/access_token";
+
+        /// <summary>
+        /// Default path to use for <see cref="OAuthOptions.UserInformationEndpoint"/>.
+        /// </summary>
+        public const string UserInformationEndpointPath = "/user";
+
+        /// <summary>
+        /// Default path to use for <see cref="GitHubAuthenticationOptions.UserEmailsEndpoint"/>.
+        /// </summary>
+        public const string UserEmailsEndpointPath = "/user/emails";
     }
 }

--- a/src/AspNet.Security.OAuth.GitHub/GitHubAuthenticationDefaults.cs
+++ b/src/AspNet.Security.OAuth.GitHub/GitHubAuthenticationDefaults.cs
@@ -55,6 +55,11 @@ namespace AspNet.Security.OAuth.GitHub
         public const string UserEmailsEndpoint = "https://api.github.com" + UserEmailsEndpointPath;
 
         /// <summary>
+        /// Default path to use for the GitHub Enterprise v3 REST API.
+        /// </summary>
+        public const string EnterpriseApiPath = "/api/v3";
+
+        /// <summary>
         /// Default path to use for <see cref="OAuthOptions.AuthorizationEndpoint"/>.
         /// </summary>
         public const string AuthorizationEndpointPath = "/login/oauth/authorize";

--- a/src/AspNet.Security.OAuth.GitHub/GitHubAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.GitHub/GitHubAuthenticationExtensions.cs
@@ -8,6 +8,8 @@ using System;
 using AspNet.Security.OAuth.GitHub;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -72,6 +74,7 @@ namespace Microsoft.Extensions.DependencyInjection
             [CanBeNull] string caption,
             [NotNull] Action<GitHubAuthenticationOptions> configuration)
         {
+            builder.Services.TryAddSingleton<IPostConfigureOptions<GitHubAuthenticationOptions>, GitHubPostConfigureOptions>();
             return builder.AddOAuth<GitHubAuthenticationOptions, GitHubAuthenticationHandler>(scheme, caption, configuration);
         }
     }

--- a/src/AspNet.Security.OAuth.GitHub/GitHubAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.GitHub/GitHubAuthenticationOptions.cs
@@ -19,7 +19,6 @@ namespace AspNet.Security.OAuth.GitHub
         public GitHubAuthenticationOptions()
         {
             ClaimsIssuer = GitHubAuthenticationDefaults.Issuer;
-
             CallbackPath = GitHubAuthenticationDefaults.CallbackPath;
 
             AuthorizationEndpoint = GitHubAuthenticationDefaults.AuthorizationEndpoint;
@@ -32,6 +31,11 @@ namespace AspNet.Security.OAuth.GitHub
             ClaimActions.MapJsonKey(Claims.Name, "name");
             ClaimActions.MapJsonKey(Claims.Url, "url");
         }
+
+        /// <summary>
+        /// Gets or sets the domain name to use if using a GitHub Enterprise on-premises deployment.
+        /// </summary>
+        public string? EnterpriseDomain { get; set; }
 
         /// <summary>
         /// Gets or sets the address of the endpoint exposing

--- a/src/AspNet.Security.OAuth.GitHub/GitHubPostConfigureOptions.cs
+++ b/src/AspNet.Security.OAuth.GitHub/GitHubPostConfigureOptions.cs
@@ -1,0 +1,50 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System;
+using JetBrains.Annotations;
+using Microsoft.Extensions.Options;
+
+namespace AspNet.Security.OAuth.GitHub
+{
+    /// <summary>
+    /// A class used to setup defaults for all <see cref="GitHubAuthenticationOptions"/>.
+    /// </summary>
+    public class GitHubPostConfigureOptions : IPostConfigureOptions<GitHubAuthenticationOptions>
+    {
+        /// <inheritdoc/>
+        public void PostConfigure(
+            [NotNull] string name,
+            [NotNull] GitHubAuthenticationOptions options)
+        {
+            if (!string.IsNullOrWhiteSpace(options.EnterpriseDomain))
+            {
+                options.AuthorizationEndpoint = CreateUrl(options.EnterpriseDomain, GitHubAuthenticationDefaults.AuthorizationEndpointPath);
+                options.TokenEndpoint = CreateUrl(options.EnterpriseDomain, GitHubAuthenticationDefaults.TokenEndpointPath);
+                options.UserEmailsEndpoint = CreateUrl(options.EnterpriseDomain, GitHubAuthenticationDefaults.UserEmailsEndpointPath, "api");
+                options.UserInformationEndpoint = CreateUrl(options.EnterpriseDomain, GitHubAuthenticationDefaults.UserInformationEndpointPath, "api");
+            }
+        }
+
+        private static string CreateUrl(string domain, string path, string? subdomain = null)
+        {
+            // Enforce use of HTTPS
+            var builder = new UriBuilder(domain)
+            {
+                Path = path,
+                Port = -1,
+                Scheme = "https",
+            };
+
+            if (!string.IsNullOrEmpty(subdomain))
+            {
+                builder.Host = subdomain + "." + builder.Host;
+            }
+
+            return builder.Uri.ToString();
+        }
+    }
+}

--- a/src/AspNet.Security.OAuth.GitHub/GitHubPostConfigureOptions.cs
+++ b/src/AspNet.Security.OAuth.GitHub/GitHubPostConfigureOptions.cs
@@ -7,6 +7,7 @@
 using System;
 using JetBrains.Annotations;
 using Microsoft.Extensions.Options;
+using static AspNet.Security.OAuth.GitHub.GitHubAuthenticationDefaults;
 
 namespace AspNet.Security.OAuth.GitHub
 {
@@ -22,14 +23,14 @@ namespace AspNet.Security.OAuth.GitHub
         {
             if (!string.IsNullOrWhiteSpace(options.EnterpriseDomain))
             {
-                options.AuthorizationEndpoint = CreateUrl(options.EnterpriseDomain, GitHubAuthenticationDefaults.AuthorizationEndpointPath);
-                options.TokenEndpoint = CreateUrl(options.EnterpriseDomain, GitHubAuthenticationDefaults.TokenEndpointPath);
-                options.UserEmailsEndpoint = CreateUrl(options.EnterpriseDomain, GitHubAuthenticationDefaults.UserEmailsEndpointPath, "api");
-                options.UserInformationEndpoint = CreateUrl(options.EnterpriseDomain, GitHubAuthenticationDefaults.UserInformationEndpointPath, "api");
+                options.AuthorizationEndpoint = CreateUrl(options.EnterpriseDomain, AuthorizationEndpointPath);
+                options.TokenEndpoint = CreateUrl(options.EnterpriseDomain, TokenEndpointPath);
+                options.UserEmailsEndpoint = CreateUrl(options.EnterpriseDomain, EnterpriseApiPath + UserEmailsEndpointPath);
+                options.UserInformationEndpoint = CreateUrl(options.EnterpriseDomain, EnterpriseApiPath + UserInformationEndpointPath);
             }
         }
 
-        private static string CreateUrl(string domain, string path, string? subdomain = null)
+        private static string CreateUrl(string domain, string path)
         {
             // Enforce use of HTTPS
             var builder = new UriBuilder(domain)
@@ -38,11 +39,6 @@ namespace AspNet.Security.OAuth.GitHub
                 Port = -1,
                 Scheme = "https",
             };
-
-            if (!string.IsNullOrEmpty(subdomain))
-            {
-                builder.Host = subdomain + "." + builder.Host;
-            }
 
             return builder.Uri.ToString();
         }

--- a/test/AspNet.Security.OAuth.Providers.Tests/GitHub/GitHubEnterpriseTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/GitHub/GitHubEnterpriseTests.cs
@@ -1,0 +1,55 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AspNet.Security.OAuth.GitHub
+{
+    public class GitHubEnterpriseTests : OAuthTests<GitHubAuthenticationOptions>
+    {
+        public GitHubEnterpriseTests(ITestOutputHelper outputHelper)
+        {
+            OutputHelper = outputHelper;
+        }
+
+        public override string DefaultScheme => GitHubAuthenticationDefaults.AuthenticationScheme;
+
+        protected override string BundleName => "GitHub";
+
+        protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
+        {
+            builder.AddGitHub(options =>
+            {
+                ConfigureDefaults(builder, options);
+                options.EnterpriseDomain = "github.enterprise.local";
+                options.Scope.Add("user:email");
+            });
+        }
+
+        [Theory]
+        [InlineData(ClaimTypes.NameIdentifier, "1")]
+        [InlineData(ClaimTypes.Name, "octocat-work")]
+        [InlineData(ClaimTypes.Email, "octocat@enterprise.local")]
+        [InlineData("urn:github:name", "monalisa octocat")]
+        [InlineData("urn:github:url", "https://api.github.enterprise.local/users/octocat")]
+        public async Task Can_Sign_In_Using_GitHub_Enterprise(string claimType, string claimValue)
+        {
+            // Arrange
+            using var server = CreateTestServer();
+
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/GitHub/GitHubPostConfigureOptionsTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/GitHub/GitHubPostConfigureOptionsTests.cs
@@ -39,10 +39,10 @@ namespace AspNet.Security.OAuth.GitHub
             options.TokenEndpoint.ShouldStartWith("https://github.local/");
             Uri.TryCreate(options.TokenEndpoint, UriKind.Absolute, out var _).ShouldBeTrue();
 
-            options.UserEmailsEndpoint.ShouldStartWith("https://api.github.local/");
+            options.UserEmailsEndpoint.ShouldStartWith("https://github.local/api/v3/");
             Uri.TryCreate(options.UserEmailsEndpoint, UriKind.Absolute, out var _).ShouldBeTrue();
 
-            options.UserInformationEndpoint.ShouldStartWith("https://api.github.local/");
+            options.UserInformationEndpoint.ShouldStartWith("https://github.local/api/v3/");
             Uri.TryCreate(options.UserInformationEndpoint, UriKind.Absolute, out var _).ShouldBeTrue();
         }
 

--- a/test/AspNet.Security.OAuth.Providers.Tests/GitHub/GitHubPostConfigureOptionsTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/GitHub/GitHubPostConfigureOptionsTests.cs
@@ -1,0 +1,81 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System;
+using Shouldly;
+using Xunit;
+
+namespace AspNet.Security.OAuth.GitHub
+{
+    public static class GitHubPostConfigureOptionsTests
+    {
+        [Theory]
+        [InlineData("github.local")]
+        [InlineData("http://github.local")]
+        [InlineData("http://github.local/")]
+        [InlineData("https://github.local")]
+        [InlineData("https://github.local/")]
+        public static void PostConfigure_Configures_Valid_Endpoints_For_GitHub_Enterprise(string value)
+        {
+            // Arrange
+            string name = "GitHub";
+            var target = new GitHubPostConfigureOptions();
+
+            var options = new GitHubAuthenticationOptions()
+            {
+                EnterpriseDomain = value,
+            };
+
+            // Act
+            target.PostConfigure(name, options);
+
+            // Assert
+            options.AuthorizationEndpoint.ShouldStartWith("https://github.local/");
+            Uri.TryCreate(options.AuthorizationEndpoint, UriKind.Absolute, out var _).ShouldBeTrue();
+
+            options.TokenEndpoint.ShouldStartWith("https://github.local/");
+            Uri.TryCreate(options.TokenEndpoint, UriKind.Absolute, out var _).ShouldBeTrue();
+
+            options.UserEmailsEndpoint.ShouldStartWith("https://api.github.local/");
+            Uri.TryCreate(options.UserEmailsEndpoint, UriKind.Absolute, out var _).ShouldBeTrue();
+
+            options.UserInformationEndpoint.ShouldStartWith("https://api.github.local/");
+            Uri.TryCreate(options.UserInformationEndpoint, UriKind.Absolute, out var _).ShouldBeTrue();
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        public static void PostConfigure_Does_Not_Update_Endpoints_If_EnterpriseDomain_Not_Set(string value)
+        {
+            // Arrange
+            string name = "GitHub";
+            var target = new GitHubPostConfigureOptions();
+
+            var options = new GitHubAuthenticationOptions()
+            {
+                EnterpriseDomain = value,
+            };
+
+            // Act
+            target.PostConfigure(name, options);
+
+            // Assert
+            options.AuthorizationEndpoint.ShouldStartWith("https://github.com/");
+            Uri.TryCreate(options.AuthorizationEndpoint, UriKind.Absolute, out var _).ShouldBeTrue();
+
+            options.TokenEndpoint.ShouldStartWith("https://github.com/");
+            Uri.TryCreate(options.TokenEndpoint, UriKind.Absolute, out var _).ShouldBeTrue();
+
+            options.UserEmailsEndpoint.ShouldStartWith("https://api.github.com/");
+            Uri.TryCreate(options.UserEmailsEndpoint, UriKind.Absolute, out var _).ShouldBeTrue();
+
+            options.UserInformationEndpoint.ShouldStartWith("https://api.github.com/");
+            Uri.TryCreate(options.UserInformationEndpoint, UriKind.Absolute, out var _).ShouldBeTrue();
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/GitHub/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/GitHub/bundle.json
@@ -75,7 +75,7 @@
       ]
     },
     {
-      "comment": "https://developer.github.com/apps/building-oauth-apps/authorizing-oauth-apps/#2-users-are-redirected-back-to-your-site-by-github",
+      "comment": "See https://developer.github.com/enterprise/apps/building-oauth-apps/authorizing-oauth-apps/#2-users-are-redirected-back-to-your-site-by-github",
       "uri": "https://github.enterprise.local/login/oauth/access_token",
       "method": "POST",
       "contentFormat": "json",
@@ -86,8 +86,8 @@
       }
     },
     {
-      "comment": "See https://developer.github.com/v3/users/#get-the-authenticated-user",
-      "uri": "https://api.github.enterprise.local/user",
+      "comment": "See https://developer.github.com/enterprise/v3/users/#get-a-user",
+      "uri": "https://github.enterprise.local/api/v3/user",
       "contentFormat": "json",
       "contentJson": {
         "login": "octocat-work",
@@ -135,8 +135,8 @@
       }
     },
     {
-      "comment": "See https://developer.github.com/v3/users/emails/#list-email-addresses-for-a-user",
-      "uri": "https://api.github.enterprise.local/user/emails",
+      "comment": "See https://developer.github.com/enterprise/v3/users/emails/#list-email-addresses-for-the-authenticated-user",
+      "uri": "https://github.enterprise.local/api/v3/user/emails",
       "contentFormat": "json",
       "contentJson": [
         {

--- a/test/AspNet.Security.OAuth.Providers.Tests/GitHub/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/GitHub/bundle.json
@@ -73,6 +73,79 @@
           "visibility": "public"
         }
       ]
+    },
+    {
+      "comment": "https://developer.github.com/apps/building-oauth-apps/authorizing-oauth-apps/#2-users-are-redirected-back-to-your-site-by-github",
+      "uri": "https://github.enterprise.local/login/oauth/access_token",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "secret-access-token",
+        "token_type": "bearer",
+        "scope": "repo,gist"
+      }
+    },
+    {
+      "comment": "See https://developer.github.com/v3/users/#get-the-authenticated-user",
+      "uri": "https://api.github.enterprise.local/user",
+      "contentFormat": "json",
+      "contentJson": {
+        "login": "octocat-work",
+        "id": 1,
+        "node_id": "MDQ6VXNlcjE=",
+        "avatar_url": "https://github.enterprise.local/images/error/octocat_happy.gif",
+        "gravatar_id": "",
+        "url": "https://api.github.enterprise.local/users/octocat",
+        "html_url": "https://github.enterprise.local/octocat",
+        "followers_url": "https://api.github.enterprise.local/users/octocat/followers",
+        "following_url": "https://api.github.enterprise.local/users/octocat/following{/other_user}",
+        "gists_url": "https://api.github.enterprise.local/users/octocat/gists{/gist_id}",
+        "starred_url": "https://api.github.enterprise.local/users/octocat/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.enterprise.local/users/octocat/subscriptions",
+        "organizations_url": "https://api.github.enterprise.local/users/octocat/orgs",
+        "repos_url": "https://api.github.enterprise.local/users/octocat/repos",
+        "events_url": "https://api.github.enterprise.local/users/octocat/events{/privacy}",
+        "received_events_url": "https://api.github.enterprise.local/users/octocat/received_events",
+        "type": "User",
+        "site_admin": false,
+        "name": "monalisa octocat",
+        "company": "GitHub",
+        "blog": "https://github.enterprise.local/blog",
+        "location": "San Francisco",
+        "hireable": false,
+        "bio": "There once was...",
+        "public_repos": 2,
+        "public_gists": 1,
+        "followers": 20,
+        "following": 0,
+        "created_at": "2008-01-14T04:33:35Z",
+        "updated_at": "2008-01-14T04:33:35Z",
+        "private_gists": 81,
+        "total_private_repos": 100,
+        "owned_private_repos": 100,
+        "disk_usage": 10000,
+        "collaborators": 8,
+        "two_factor_authentication": true,
+        "plan": {
+          "name": "Medium",
+          "space": 400,
+          "private_repos": 20,
+          "collaborators": 0
+        }
+      }
+    },
+    {
+      "comment": "See https://developer.github.com/v3/users/emails/#list-email-addresses-for-a-user",
+      "uri": "https://api.github.enterprise.local/user/emails",
+      "contentFormat": "json",
+      "contentJson": [
+        {
+          "email": "octocat@enterprise.local",
+          "verified": true,
+          "primary": true,
+          "visibility": "public"
+        }
+      ]
     }
   ]
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/OAuthTests`1.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/OAuthTests`1.cs
@@ -38,7 +38,7 @@ namespace AspNet.Security.OAuth
         {
             Interceptor = new HttpClientInterceptorOptions()
                 .ThrowsOnMissingRegistration()
-                .RegisterBundle(Path.Combine(GetType().Name.Replace("Tests", string.Empty, StringComparison.OrdinalIgnoreCase), "bundle.json"));
+                .RegisterBundle(Path.Combine(BundleName, "bundle.json"));
 
             LoopbackRedirectHandler = new LoopbackRedirectHandler
             {
@@ -62,6 +62,11 @@ namespace AspNet.Security.OAuth
         /// Gets the name of the authentication scheme being tested.
         /// </summary>
         public abstract string DefaultScheme { get; }
+
+        /// <summary>
+        /// Gets the HTTP bundle name to use for the test.
+        /// </summary>
+        protected virtual string BundleName => GetType().Name.Replace("Tests", string.Empty, StringComparison.OrdinalIgnoreCase);
 
         /// <summary>
         /// Gets the optional redirect HTTP method to use for OAuth flows.


### PR DESCRIPTION
Add built-in support for GitHub Enterprise by allowing the user to just specify a domain name and the provider then automatically configuring the URLs as appropriate.

Previously the user had to explicitly redefine all of the `*Endpoint` properties on the options.
