### PR TITLE
Fix SuperOffice token validation

### DIFF
--- a/src/AspNet.Security.OAuth.SuperOffice/SuperOfficeAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.SuperOffice/SuperOfficeAuthenticationHandler.cs
@@ -5,7 +5,6 @@
  */
 
 using System;
-using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Net.Http;
@@ -161,12 +160,18 @@ namespace AspNet.Security.OAuth.SuperOffice
 
             try
             {
-                return Options.SecurityTokenHandler.ValidateToken(idToken, validationParameters);
+                var result = Options.SecurityTokenHandler.ValidateToken(idToken, validationParameters);
+
+                if (result.Exception != null || !result.IsValid)
+                {
+                    throw new SecurityTokenValidationException("SuperOffice ID token validation failed.", result.Exception);
+                }
+
+                return result;
             }
             catch (Exception ex)
             {
-                throw new SecurityTokenValidationException(
-                    "SuperOffice ID token validation failed for issuer and/or audience.", ex);
+                throw new SecurityTokenValidationException("SuperOffice ID token validation failed.", ex);
             }
         }
     }

--- a/src/AspNet.Security.OAuth.SuperOffice/SuperOfficeAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.SuperOffice/SuperOfficeAuthenticationHandler.cs
@@ -71,8 +71,12 @@ namespace AspNet.Security.OAuth.SuperOffice
             }
 
             using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
-            var context = new OAuthCreatingTicketContext(new ClaimsPrincipal(identity), properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
+
+            var principal = new ClaimsPrincipal(identity);
+
+            var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
+
             await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal, context.Properties, Scheme.Name);
         }
@@ -82,8 +86,6 @@ namespace AspNet.Security.OAuth.SuperOffice
             [NotNull] AuthenticationProperties properties,
             [NotNull] ClaimsIdentity identity)
         {
-            var contextIdentifier = string.Empty;
-
             var idToken = tokens.Response.RootElement.GetString("id_token");
 
             if (Options.SaveTokens)
@@ -93,6 +95,8 @@ namespace AspNet.Security.OAuth.SuperOffice
             }
 
             var tokenValidationResult = await ValidateAsync(idToken, Options.TokenValidationParameters.Clone());
+
+            var contextIdentifier = string.Empty;
 
             foreach (var claim in tokenValidationResult.ClaimsIdentity.Claims)
             {

--- a/src/AspNet.Security.OAuth.SuperOffice/SuperOfficeAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.SuperOffice/SuperOfficeAuthenticationOptions.cs
@@ -114,7 +114,7 @@ namespace AspNet.Security.OAuth.SuperOffice
             base.Validate();
 
             if (_environment == SuperOfficeAuthenticationEnvironment.Production
-                && !AuthorizationEndpoint.StartsWith("https://", System.StringComparison.OrdinalIgnoreCase))
+                && !AuthorizationEndpoint.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
             {
                 throw new NotSupportedException("Production environment requires secure endpoints, i.e. begins with 'https://'.");
             }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Apple/AppleTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Apple/AppleTests.cs
@@ -438,13 +438,5 @@ namespace AspNet.Security.OAuth.Apple
             second.ShouldNotBeEmpty();
             first.ShouldNotBeSameAs(second);
         }
-
-        private sealed class FrozenJwtSecurityTokenHandler : JwtSecurityTokenHandler
-        {
-            protected override void ValidateLifetime(DateTime? notBefore, DateTime? expires, JwtSecurityToken jwtToken, TokenValidationParameters validationParameters)
-            {
-                // Do not validate the lifetime as the test token has expired
-            }
-        }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/FrozenJwtSecurityTokenHandler.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/FrozenJwtSecurityTokenHandler.cs
@@ -1,0 +1,24 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System;
+using System.IdentityModel.Tokens.Jwt;
+using Microsoft.IdentityModel.Tokens;
+
+namespace AspNet.Security.OAuth
+{
+    internal sealed class FrozenJwtSecurityTokenHandler : JwtSecurityTokenHandler
+    {
+        protected override void ValidateLifetime(
+            DateTime? notBefore,
+            DateTime? expires,
+            JwtSecurityToken jwtToken,
+            TokenValidationParameters validationParameters)
+        {
+            // Do not validate the lifetime as the test token has expired
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/OAuthTests`1.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/OAuthTests`1.cs
@@ -142,6 +142,7 @@ namespace AspNet.Security.OAuth
 
             void ConfigureServices(IServiceCollection services)
             {
+                services.AddSingleton<System.IdentityModel.Tokens.Jwt.JwtSecurityTokenHandler, FrozenJwtSecurityTokenHandler>();
                 services.PostConfigureAll<TOptions>((options) =>
                 {
                     options.Events.OnCreatingTicket = (context) =>
@@ -149,11 +150,6 @@ namespace AspNet.Security.OAuth
                         onCreatingTicketEventRaised = true;
                         return Task.CompletedTask;
                     };
-
-                    if (options is Apple.AppleAuthenticationOptions appleOptions)
-                    {
-                        appleOptions.ValidateTokens = false; // Apple test token has expired
-                    }
                 });
             }
 

--- a/test/AspNet.Security.OAuth.Providers.Tests/SuperOffice/SuperOfficeTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/SuperOffice/SuperOfficeTests.cs
@@ -92,5 +92,27 @@ namespace AspNet.Security.OAuth.SuperOffice
             // Assert
             AssertClaim(claims, claimType, claimValue);
         }
+
+        [Fact]
+        public async Task Cannot_Sign_In_Using_SuperOffice_With_Invalid_Token_Audience()
+        {
+            // Arrange
+            static void ConfigureServices(IServiceCollection services)
+            {
+                services.AddSingleton<JwtSecurityTokenHandler, FrozenJwtSecurityTokenHandler>();
+                services.PostConfigureAll<SuperOfficeAuthenticationOptions>((options) =>
+                {
+                    options.TokenValidationParameters.ValidAudience = "not-the-right-audience";
+                });
+            }
+
+            using var server = CreateTestServer(ConfigureServices);
+
+            // Act
+            var exception = await Assert.ThrowsAsync<Exception>(() => AuthenticateUserAsync(server));
+
+            // Assert
+            exception.InnerException.ShouldBeOfType<SecurityTokenValidationException>();
+        }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/SuperOffice/SuperOfficeTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/SuperOffice/SuperOfficeTests.cs
@@ -35,6 +35,7 @@ namespace AspNet.Security.OAuth.SuperOffice
 
                 options.ClientId = "gg454918d75b1b53101065c16ee51123";
                 options.TokenValidationParameters.ValidAudience = options.ClientId;
+                options.TokenValidationParameters.ValidIssuer = "https://sod.superoffice.com";
             });
         }
 


### PR DESCRIPTION
While adding a test to make sure all our providers raise the `OnCreatingTicket` event (which they do, and is commit 1dd3b3a4b3a078484880e6bd339e0ba543c003bd), I found that the SuperOffice provider was throwing a `NullReferenceException` during the test from this line:

https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/blob/e693c2c5ab7e1b6b254ad7ca6dee85676470a5e8/src/AspNet.Security.OAuth.SuperOffice/SuperOfficeAuthenticationHandler.cs#L98

It turns out that if token validation fails, it doesn't throw, but instead returns the exception in the result, which the caller has to decide what to do with. The provider wasn't doing this, but as the validation failed and there was no identity, instead it just threw an exception when searching for the context identifier because `ClaimsIdentity` was `null`, causing the login to fail.

This PR fixes that by checking the result, and throwing an exception if one is present or the token is otherwise invalid. It also exposed that the tests weren't specifying the token issuer, which also made the existing tests fail once the fix was committed.

/cc @AnthonyYates 