### PR TITLE
Update to Instagram Basic Display API

### DIFF
--- a/docs/instagram.md
+++ b/docs/instagram.md
@@ -14,9 +14,17 @@ A Facebook authentication provider is [available from Microsoft](https://docs.mi
 services.AddAuthentication(options => /* Auth configuration */)
         .AddInstagram(options =>
         {
-            options.ClientId = "my-client-id";
-            options.ClientSecret = "my-client-secret";
-        });
+            options.ClientId = Configuration["Instagram:ClientId"];
+            options.ClientSecret = Configuration["Instagram:ClientSecret"];
+
+            // Optionally return the account type
+            options.Fields.Add("account_type");
+
+            // Optionally return the user's media
+            options.Fields.Add("media_count");
+            options.Fields.Add("media");
+            options.Scope.Add("user_media");
+        })
 ```
 
 ## Required Additional Settings
@@ -27,4 +35,4 @@ _None._
 
 | Property Name | Property Type | Description | Default Value |
 |:--|:--|:--|:--|
-| `UseSignedRequests` | `bool` | Indicates whether requests to the Instagram API's user information endpoint should be signed. | `false` |
+| `Fields` | `ISet<string>` | The list of list of fields and edges to retrieve from the user information endpoint. | `[ "id", "username" ]` |

--- a/src/AspNet.Security.OAuth.Instagram/InstagramAuthenticationConstants.cs
+++ b/src/AspNet.Security.OAuth.Instagram/InstagramAuthenticationConstants.cs
@@ -1,0 +1,30 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+namespace AspNet.Security.OAuth.Instagram
+{
+    /// <summary>
+    /// Contains constants specific to the <see cref="InstagramAuthenticationHandler"/>.
+    /// </summary>
+    public static class InstagramAuthenticationConstants
+    {
+        /// <summary>
+        /// Contains constants for claims.
+        /// </summary>
+        public static class Claims
+        {
+            /// <summary>
+            /// The claim for the user's account type.
+            /// </summary>
+            public const string AccountType = "urn:instagram:accounttype";
+
+            /// <summary>
+            /// The claim for the user's media count.
+            /// </summary>
+            public const string MediaCount = "urn:instagram:mediacount";
+        }
+    }
+}

--- a/src/AspNet.Security.OAuth.Instagram/InstagramAuthenticationDefaults.cs
+++ b/src/AspNet.Security.OAuth.Instagram/InstagramAuthenticationDefaults.cs
@@ -47,6 +47,6 @@ namespace AspNet.Security.OAuth.Instagram
         /// <summary>
         /// Default value for <see cref="OAuthOptions.UserInformationEndpoint"/>.
         /// </summary>
-        public const string UserInformationEndpoint = "https://api.instagram.com/v1/users/self";
+        public const string UserInformationEndpoint = "https://graph.instagram.com/me";
     }
 }

--- a/src/AspNet.Security.OAuth.Instagram/InstagramAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Instagram/InstagramAuthenticationOptions.cs
@@ -4,9 +4,12 @@
  * for more information concerning the license and the contributors participating to this project.
  */
 
+using System;
+using System.Collections.Generic;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
+using static AspNet.Security.OAuth.Instagram.InstagramAuthenticationConstants;
 
 namespace AspNet.Security.OAuth.Instagram
 {
@@ -18,17 +21,18 @@ namespace AspNet.Security.OAuth.Instagram
         public InstagramAuthenticationOptions()
         {
             ClaimsIssuer = InstagramAuthenticationDefaults.Issuer;
-
             CallbackPath = InstagramAuthenticationDefaults.CallbackPath;
 
             AuthorizationEndpoint = InstagramAuthenticationDefaults.AuthorizationEndpoint;
             TokenEndpoint = InstagramAuthenticationDefaults.TokenEndpoint;
             UserInformationEndpoint = InstagramAuthenticationDefaults.UserInformationEndpoint;
 
-            Scope.Add("basic");
+            Scope.Add("user_profile");
 
             ClaimActions.MapJsonKey(ClaimTypes.NameIdentifier, "id");
-            ClaimActions.MapJsonKey(ClaimTypes.Name, "full_name");
+            ClaimActions.MapJsonKey(ClaimTypes.Name, "username");
+            ClaimActions.MapJsonKey(Claims.AccountType, "account_type");
+            ClaimActions.MapJsonKey(Claims.MediaCount, "media_count");
         }
 
         /// <summary>
@@ -38,6 +42,16 @@ namespace AspNet.Security.OAuth.Instagram
         /// Enabling this option is recommended when the client application
         /// has been configured to enforce signed requests.
         /// </summary>
+        [Obsolete("This property no longer has any effect and will be removed in a future version.")]
         public bool UseSignedRequests { get; set; }
+
+        /// <summary>
+        /// Gets the list of list of fields and edges to retrieve from the user information endpoint.
+        /// </summary>
+        public ISet<string> Fields { get; } = new HashSet<string>()
+        {
+            "id",
+            "username",
+        };
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Instagram/InstagramTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Instagram/InstagramTests.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 using Xunit.Abstractions;
+using static AspNet.Security.OAuth.Instagram.InstagramAuthenticationConstants;
 
 namespace AspNet.Security.OAuth.Instagram
 {
@@ -28,12 +29,39 @@ namespace AspNet.Security.OAuth.Instagram
         }
 
         [Theory]
-        [InlineData(ClaimTypes.NameIdentifier, "my-id")]
-        [InlineData(ClaimTypes.Name, "John Smith")]
+        [InlineData(ClaimTypes.Name, "jayposiris")]
+        [InlineData(ClaimTypes.NameIdentifier, "17841405793187218")]
         public async Task Can_Sign_In_Using_Instagram(string claimType, string claimValue)
         {
             // Arrange
             using var server = CreateTestServer();
+
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            AssertClaim(claims, claimType, claimValue);
+        }
+
+        [Theory]
+        [InlineData(ClaimTypes.Name, "jayposiris")]
+        [InlineData(ClaimTypes.NameIdentifier, "17841405793187218")]
+        [InlineData(Claims.AccountType, "PERSONAL")]
+        [InlineData(Claims.MediaCount, "42")]
+        public async Task Can_Sign_In_Using_Instagram_With_Additional_Fields(string claimType, string claimValue)
+        {
+            // Arrange
+            static void ConfigureServices(IServiceCollection services)
+            {
+                services.PostConfigureAll<InstagramAuthenticationOptions>((options) =>
+                {
+                    options.Fields.Add("account_type");
+                    options.Fields.Add("media_count");
+                    options.Scope.Add("user_media");
+                });
+            }
+
+            using var server = CreateTestServer(ConfigureServices);
 
             // Act
             var claims = await AuthenticateUserAsync(server);

--- a/test/AspNet.Security.OAuth.Providers.Tests/Instagram/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Instagram/bundle.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/master/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
   "items": [
     {
+      "comment": "See https://developers.facebook.com/docs/instagram-basic-display-api/getting-started#step-5--exchange-the-code-for-a-token",
       "uri": "https://api.instagram.com/oauth/access_token",
       "method": "POST",
       "contentFormat": "json",
@@ -13,13 +14,23 @@
       }
     },
     {
-      "uri": "https://api.instagram.com/v1/users/self?access_token=secret-access-token",
+      "comment": "See https://developers.facebook.com/docs/instagram-basic-display-api/reference/user#user",
+      "uri": "https://graph.instagram.com/me?access_token=secret-access-token&fields=id,username",
       "contentFormat": "json",
       "contentJson": {
-        "data": {
-          "id": "my-id",
-          "full_name": "John Smith"
-        }
+        "id": "17841405793187218",
+        "username": "jayposiris"
+      }
+    },
+    {
+      "comment": "See https://developers.facebook.com/docs/instagram-basic-display-api/reference/user#user",
+      "uri": "https://graph.instagram.com/me?access_token=secret-access-token&fields=id,username,account_type,media_count",
+      "contentFormat": "json",
+      "contentJson": {
+        "id": "17841405793187218",
+        "username": "jayposiris",
+        "account_type": "PERSONAL",
+        "media_count": 42
       }
     }
   ]


### PR DESCRIPTION
Update the Instagram provider to use the Basic Display API.

See #441.

While the new API requires more permissions and approvals than the old API, I've validated this works with an in-development application set up using the process documented [here](https://developers.facebook.com/docs/instagram-basic-display-api/getting-started).