### PR TITLE
Fix analyzer warnings

### DIFF
--- a/test/AspNet.Security.OAuth.Providers.Tests/Infrastructure/ApplicationFactory.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Infrastructure/ApplicationFactory.cs
@@ -110,7 +110,7 @@ namespace AspNet.Security.OAuth.Infrastructure
                                context.Response.StatusCode = 200;
                                context.Response.ContentType = "text/xml";
 
-                               await context.Response.Body.WriteAsync(buffer, 0, buffer.Length);
+                               await context.Response.Body.WriteAsync(buffer, context.RequestAborted);
                            }
                            else
                            {

--- a/test/AspNet.Security.OAuth.Providers.Tests/LinkedIn/LinkedInTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/LinkedIn/LinkedInTests.cs
@@ -18,7 +18,7 @@ namespace AspNet.Security.OAuth.LinkedIn
 {
     public class LinkedInTests : OAuthTests<LinkedInAuthenticationOptions>
     {
-        private Action<LinkedInAuthenticationOptions>? additionalConfiguration = null;
+        private Action<LinkedInAuthenticationOptions>? additionalConfiguration;
 
         public LinkedInTests(ITestOutputHelper outputHelper)
         {


### PR DESCRIPTION
Fix analyzer warnings found from using the prerelease version of the Roslyn analyzers mentioned [here](https://devblogs.microsoft.com/dotnet/performance-improvements-in-net-5/).
