### PR TITLE
SuperOffice provider should support ClaimTypes.NameIdentifier and ClaimTypes.Email

### DIFF
--- a/src/AspNet.Security.OAuth.SuperOffice/SuperOfficeAuthenticationConstants.cs
+++ b/src/AspNet.Security.OAuth.SuperOffice/SuperOfficeAuthenticationConstants.cs
@@ -75,6 +75,11 @@ namespace AspNet.Security.OAuth.SuperOffice
             public const string PrimaryEmail = "http://schemes.superoffice.net/identity/so_primary_email_address";
 
             /// <summary>
+            /// Subject Identifier used to uniquely identity user.
+            /// </summary>
+            public const string SubjectIdentifier = "sub";
+
+            /// <summary>
             /// Identifier used to exchange for a system user ticket.
             /// </summary>
             public const string SystemToken = "http://schemes.superoffice.net/identity/system_token";

--- a/src/AspNet.Security.OAuth.SuperOffice/SuperOfficeAuthenticationConstants.cs
+++ b/src/AspNet.Security.OAuth.SuperOffice/SuperOfficeAuthenticationConstants.cs
@@ -75,7 +75,7 @@ namespace AspNet.Security.OAuth.SuperOffice
             public const string PrimaryEmail = "http://schemes.superoffice.net/identity/so_primary_email_address";
 
             /// <summary>
-            /// Subject Identifier used to uniquely identity user.
+            /// Subject Identifier used to uniquely identify the user.
             /// </summary>
             public const string SubjectIdentifier = "sub";
 

--- a/src/AspNet.Security.OAuth.SuperOffice/SuperOfficeAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.SuperOffice/SuperOfficeAuthenticationHandler.cs
@@ -107,7 +107,7 @@ namespace AspNet.Security.OAuth.SuperOffice
 
                 if (claim.Type == SuperOfficeAuthenticationConstants.ClaimNames.SubjectIdentifier)
                 {
-                    identity.AddClaim(claim);
+                    identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, claim.Value));
                     continue;
                 }
 

--- a/src/AspNet.Security.OAuth.SuperOffice/SuperOfficeAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.SuperOffice/SuperOfficeAuthenticationHandler.cs
@@ -105,6 +105,12 @@ namespace AspNet.Security.OAuth.SuperOffice
                     contextIdentifier = claim.Value;
                 }
 
+                if (claim.Type == SuperOfficeAuthenticationConstants.ClaimNames.SubjectIdentifier)
+                {
+                    identity.AddClaim(claim);
+                    continue;
+                }
+
                 if (Options.IncludeIdTokenAsClaims)
                 {
                     // May be possible same claim names from UserInformationEndpoint and IdToken.

--- a/src/AspNet.Security.OAuth.SuperOffice/SuperOfficeAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.SuperOffice/SuperOfficeAuthenticationOptions.cs
@@ -33,7 +33,9 @@ namespace AspNet.Security.OAuth.SuperOffice
             CallbackPath = SuperOfficeAuthenticationDefaults.CallbackPath;
             Scope.Add("openid");
 
+            ClaimActions.MapJsonKey(ClaimTypes.NameIdentifier, ClaimNames.SubjectIdentifier);
             ClaimActions.MapJsonKey(ClaimTypes.Name, PrincipalNames.FullName);
+            ClaimActions.MapJsonKey(ClaimTypes.Email, PrincipalNames.EmailAddress);
 
             ClaimActions.MapJsonKey(ClaimNames.AssociateId, PrincipalNames.AssociateId);
             ClaimActions.MapJsonKey(ClaimNames.Email, PrincipalNames.EmailAddress);

--- a/src/AspNet.Security.OAuth.SuperOffice/SuperOfficeAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.SuperOffice/SuperOfficeAuthenticationOptions.cs
@@ -33,7 +33,6 @@ namespace AspNet.Security.OAuth.SuperOffice
             CallbackPath = SuperOfficeAuthenticationDefaults.CallbackPath;
             Scope.Add("openid");
 
-            ClaimActions.MapJsonKey(ClaimTypes.NameIdentifier, ClaimNames.SubjectIdentifier);
             ClaimActions.MapJsonKey(ClaimTypes.Name, PrincipalNames.FullName);
             ClaimActions.MapJsonKey(ClaimTypes.Email, PrincipalNames.EmailAddress);
 

--- a/test/AspNet.Security.OAuth.Providers.Tests/SuperOffice/SuperOfficeTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/SuperOffice/SuperOfficeTests.cs
@@ -40,6 +40,7 @@ namespace AspNet.Security.OAuth.SuperOffice
         }
 
         [Theory]
+        [InlineData(System.Security.Claims.ClaimTypes.NameIdentifier, "johm.demo.smith@superoffice.com")]
         [InlineData(SuperOfficeAuthenticationConstants.PrincipalNames.BusinessId, "4")]
         [InlineData(SuperOfficeAuthenticationConstants.PrincipalNames.CategoryId, "4")]
         [InlineData(SuperOfficeAuthenticationConstants.PrincipalNames.ContactId, "2")]

--- a/test/AspNet.Security.OAuth.Providers.Tests/SuperOffice/SuperOfficeTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/SuperOffice/SuperOfficeTests.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.DependencyInjection;
@@ -40,8 +41,8 @@ namespace AspNet.Security.OAuth.SuperOffice
         }
 
         [Theory]
-        [InlineData(System.Security.Claims.ClaimTypes.NameIdentifier, "johm.demo.smith@superoffice.com")]
-        [InlineData(System.Security.Claims.ClaimTypes.Email, "johm.demo.smith@superoffice.com")]
+        [InlineData(ClaimTypes.NameIdentifier, "johm.demo.smith@superoffice.com")]
+        [InlineData(ClaimTypes.Email, "johm.demo.smith@superoffice.com")]
         [InlineData(SuperOfficeAuthenticationConstants.PrincipalNames.BusinessId, "4")]
         [InlineData(SuperOfficeAuthenticationConstants.PrincipalNames.CategoryId, "4")]
         [InlineData(SuperOfficeAuthenticationConstants.PrincipalNames.ContactId, "2")]

--- a/test/AspNet.Security.OAuth.Providers.Tests/SuperOffice/SuperOfficeTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/SuperOffice/SuperOfficeTests.cs
@@ -41,6 +41,7 @@ namespace AspNet.Security.OAuth.SuperOffice
 
         [Theory]
         [InlineData(System.Security.Claims.ClaimTypes.NameIdentifier, "johm.demo.smith@superoffice.com")]
+        [InlineData(System.Security.Claims.ClaimTypes.Email, "johm.demo.smith@superoffice.com")]
         [InlineData(SuperOfficeAuthenticationConstants.PrincipalNames.BusinessId, "4")]
         [InlineData(SuperOfficeAuthenticationConstants.PrincipalNames.CategoryId, "4")]
         [InlineData(SuperOfficeAuthenticationConstants.PrincipalNames.ContactId, "2")]

--- a/test/AspNet.Security.OAuth.Providers.Tests/SuperOffice/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/SuperOffice/bundle.json
@@ -23,6 +23,7 @@
         "ContactId": 2,
         "CountryId": 826,
         "DatabaseContextIdentifier": "Cust12345",
+        "EMailAddress": "johm.demo.smith@superoffice.com",
         "FunctionRights": [ "allow-bulk-export" ],
         "GroupId": 2,
         "HomeCountryId": 826,


### PR DESCRIPTION
This PR is to address Issue: #464, where the SuperOffice provider should support ClaimTypes.NameIdentifier and ClaimTypes.Email
