### PR TITLE
Update Onshape endpoints

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -62,7 +62,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.NetCore.Analyzers" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,11 +4,11 @@
     <PackageVersion Include="JetBrains.Annotations" Version="2020.1.0" />
     <PackageVersion Include="JustEat.HttpClientInterception" Version="3.0.0" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.1.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Google" Version="3.1.5" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Twitter" Version="3.1.5" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.5" />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="3.1.5" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Google" Version="3.1.7" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Twitter" Version="3.1.7" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.7" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="3.1.7" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0" />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="5.5.0" />
     <PackageVersion Include="Moq" Version="4.14.5" />
     <PackageVersion Include="Shouldly" Version="3.0.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,6 @@
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="3.1.5" />
     <PackageVersion Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0" />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="5.5.0" />
-    <PackageVersion Include="Microsoft.NetCore.Analyzers" Version="3.0.0" />
     <PackageVersion Include="Moq" Version="4.14.5" />
     <PackageVersion Include="Shouldly" Version="3.0.2" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118" />

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "3.1.301"
+    "dotnet": "3.1.401"
   },
 
   "msbuild-sdks": {

--- a/src/AspNet.Security.OAuth.Onshape/OnshapeAuthenticationDefaults.cs
+++ b/src/AspNet.Security.OAuth.Onshape/OnshapeAuthenticationDefaults.cs
@@ -37,16 +37,16 @@ namespace AspNet.Security.OAuth.Onshape
         /// <summary>
         /// Default value for <see cref="OAuthOptions.AuthorizationEndpoint"/>.
         /// </summary>
-        public const string AuthorizationEndpoint = "https://cad.onshape.com/oauth/authorize";
+        public const string AuthorizationEndpoint = "https://oauth.onshape.com/oauth/authorize";
 
         /// <summary>
         /// Default value for <see cref="OAuthOptions.TokenEndpoint"/>.
         /// </summary>
-        public const string TokenEndpoint = "https://cad.onshape.com/oauth/token";
+        public const string TokenEndpoint = "https://oauth.onshape.com/oauth/token";
 
         /// <summary>
         /// Default value for <see cref="OAuthOptions.UserInformationEndpoint"/>.
         /// </summary>
-        public const string UserInformationEndpoint = "https://cad.onshape.com/api/users/session";
+        public const string UserInformationEndpoint = "https://cad.onshape.com/api/users/sessioninfo";
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Onshape/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Onshape/bundle.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/master/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
   "items": [
     {
-      "uri": "https://cad.onshape.com/oauth/token",
+      "uri": "https://oauth.onshape.com/oauth/token",
       "method": "POST",
       "contentFormat": "json",
       "contentJson": {
@@ -13,7 +13,7 @@
       }
     },
     {
-      "uri": "https://cad.onshape.com/api/users/session",
+      "uri": "https://cad.onshape.com/api/users/sessioninfo",
       "contentFormat": "json",
       "contentJson": {
         "id": "my-id",


### PR DESCRIPTION
Update the URLs used by the Onshape provider to resolve #469.

Also:
  * Updates to the latest .NET Core 3.1 SDK.
  * Removes redundant reference to the `Microsoft.NetCore.Analyzers NuGet` package.
  * Updates a number of NuGet packages to their latest versions.
