### PR TITLE
Use <DebugType>portable</DebugType> to avoid embedding the PDBs in the assemblies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,7 @@ jobs:
         path: ./artifacts/TestResults/Release
 
     - name: Push NuGet packages to aspnet-contrib MyGet
-      run: dotnet nuget push "artifacts\packages\Release\Shipping\*.nupkg" --api-key ${{ secrets.MYGET_API_KEY }} --skip-duplicate --source https://www.myget.org/F/aspnet-contrib/ --symbol-source https://www.myget.org/F/aspnet-contrib/
+      run: dotnet nuget push "artifacts\packages\Release\Shipping\*.nupkg" --api-key ${{ secrets.MYGET_API_KEY }} --skip-duplicate --source https://www.myget.org/F/aspnet-contrib/api/v3/index.json
       if: ${{ github.repository_owner == 'aspnet-contrib' && (github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/heads/rel/') || startsWith(github.ref, 'refs/tags/')) && runner.os == 'Windows' }}
 
     - name: Push NuGet packages to NuGet.org

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,6 +7,8 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DebugSymbols>true</DebugSymbols>
+    <DebugType>portable</DebugType>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <DefineConstants Condition=" '$(Configuration)' == 'Debug' ">$(DefineConstants);JETBRAINS_ANNOTATIONS</DefineConstants>
     <Nullable>enable</Nullable>
@@ -49,7 +51,6 @@
 
   <PropertyGroup Condition=" $(RepoRelativeProjectDir.Contains('src')) ">
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <IncludeSource>true</IncludeSource>
     <IncludeSymbols>true</IncludeSymbols>
     <IsPackable>true</IsPackable>
     <IsShipping>true</IsShipping>


### PR DESCRIPTION
Fixes https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/issues/475.

@martincostello should I target the `rel/5.0.0` branch for this PR?