### PR TITLE
Add email to Yahoo tests

### DIFF
--- a/test/AspNet.Security.OAuth.Providers.Tests/Yahoo/YahooTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Yahoo/YahooTests.cs
@@ -28,6 +28,7 @@ namespace AspNet.Security.OAuth.Yahoo
         }
 
         [Theory]
+        [InlineData(ClaimTypes.Email, "john@john-smith.local")]
         [InlineData(ClaimTypes.NameIdentifier, "my-id")]
         [InlineData(ClaimTypes.Name, "John Smith")]
         [InlineData("urn:yahoo:familyname", "Smith")]

--- a/test/AspNet.Security.OAuth.Providers.Tests/Yahoo/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Yahoo/bundle.json
@@ -17,6 +17,7 @@
       "contentFormat": "json",
       "contentJson": {
         "sub": "my-id",
+        "email": "john@john-smith.local",
         "name": "John Smith",
         "family_name": "Smith",
         "given_name": "John",


### PR DESCRIPTION
Add a test for the email claim for the Yahoo provider.

Relates to #488.
