### PR TITLE
Rename property and fix test

### DIFF
--- a/docs/qq.md
+++ b/docs/qq.md
@@ -19,5 +19,5 @@ _None._
 
 | Property Name | Property Type | Description | Default Value |
 |:--|:--|:--|:--|
-| `ApplyForUnionID` | `bool` | Set if the UnionID should be retrieved and put into user claims. | `false` |
+| `ApplyForUnionId` | `bool` | Set if the UnionID should be retrieved and put into user claims. | `false` |
 | `UserIdentificationEndpoint` | `string` | The address of the endpoint to use for user identification. | `QQAuthenticationDefaults.UserIdentificationEndpoint` |

--- a/src/AspNet.Security.OAuth.QQ/QQAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.QQ/QQAuthenticationHandler.cs
@@ -130,7 +130,7 @@ namespace AspNet.Security.OAuth.QQ
                 ["fmt"] = "json" // Return JSON instead of JSONP which is default due to historical reasons
             };
 
-            if (Options.ApplyForUnionID)
+            if (Options.ApplyForUnionId)
             {
                 queryString.Add("unionid", "1");
             }

--- a/src/AspNet.Security.OAuth.QQ/QQAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.QQ/QQAuthenticationHandler.cs
@@ -163,6 +163,6 @@ namespace AspNet.Security.OAuth.QQ
 
         protected override string FormatScope() => FormatScope(Options.Scope);
 
-        protected override string FormatScope(IEnumerable<string> scopes) => string.Join(',', scopes);
+        protected override string FormatScope([NotNull] IEnumerable<string> scopes) => string.Join(',', scopes);
     }
 }

--- a/src/AspNet.Security.OAuth.QQ/QQAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.QQ/QQAuthenticationOptions.cs
@@ -40,7 +40,7 @@ namespace AspNet.Security.OAuth.QQ
         /// <summary>
         /// Gets or sets if the union Id (the primary key of an owner for different apps of the QQ platform) should be put into the user claims.
         /// </summary>
-        public bool ApplyForUnionID { get; set; }
+        public bool ApplyForUnionId { get; set; }
 
         /// <summary>
         /// Gets or sets the URL of the user identification endpoint (a.k.a. the "OpenID endpoint").

--- a/test/AspNet.Security.OAuth.Providers.Tests/QQ/QQTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/QQ/QQTests.cs
@@ -26,7 +26,7 @@ namespace AspNet.Security.OAuth.QQ
         {
             builder.AddQQ(options =>
             {
-                options.ApplyForUnionID = true;
+                options.ApplyForUnionId = true;
                 ConfigureDefaults(builder, options);
             });
         }


### PR DESCRIPTION
  * Use `Id` rather than `ID` for consistency.
  * Fix test by adding missing `[NotNull]` attribute.
