### PR TITLE
Update SDK and packages

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -1,19 +1,18 @@
 <Project>
 
   <ItemGroup>
-    <PackageReference Update="JetBrains.Annotations" Version="2020.1.0" />
-    <PackageReference Update="JustEat.HttpClientInterception" Version="3.0.0" />
+    <PackageReference Update="JetBrains.Annotations" Version="2020.3.0" />
+    <PackageReference Update="JustEat.HttpClientInterception" Version="3.1.0" />
     <PackageReference Update="MartinCostello.Logging.XUnit" Version="0.1.0" />
-    <PackageReference Update="Microsoft.AspNetCore.Authentication.Google" Version="3.1.7" />
-    <PackageReference Update="Microsoft.AspNetCore.Authentication.Twitter" Version="3.1.7" />
-    <PackageReference Update="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.7" />
-    <PackageReference Update="Microsoft.AspNetCore.TestHost" Version="3.1.7" />
-    <PackageReference Update="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0" />
-    <PackageReference Update="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="5.5.0" />
-    <PackageReference Update="Moq" Version="4.14.5" />
-    <PackageReference Update="Shouldly" Version="3.0.2" />
+    <PackageReference Update="Microsoft.AspNetCore.Authentication.Google" Version="5.0.2" />
+    <PackageReference Update="Microsoft.AspNetCore.Authentication.Twitter" Version="5.0.2" />
+    <PackageReference Update="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.2" />
+    <PackageReference Update="Microsoft.AspNetCore.TestHost" Version="5.0.2" />
+    <PackageReference Update="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.6.0" />
+    <PackageReference Update="Moq" Version="4.16.0" />
+    <PackageReference Update="Shouldly" Version="4.0.3" />
     <PackageReference Update="StyleCop.Analyzers" Version="1.1.118" />
-    <PackageReference Update="System.IdentityModel.Tokens.Jwt" Version="5.5.0" />
+    <PackageReference Update="System.IdentityModel.Tokens.Jwt" Version="6.6.0" />
   </ItemGroup>
 
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "5.0.100"
+    "dotnet": "5.0.102"
   },
 
   "msbuild-sdks": {


### PR DESCRIPTION
* Update to the 5.0.102 SDK.
* Fix package versions that drifted in change from `Directory.Packages.props` in `rel/5.0.0` back to `Packages.props` in `dev`.
* Update NuGet packages used by the tests and sample app to their latest versions.
