### PR TITLE
Use CancellationTokens more and bump SDK and packages

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -4,12 +4,12 @@
     <PackageReference Update="JetBrains.Annotations" Version="2020.3.0" />
     <PackageReference Update="JustEat.HttpClientInterception" Version="3.1.0" />
     <PackageReference Update="MartinCostello.Logging.XUnit" Version="0.1.0" />
-    <PackageReference Update="Microsoft.AspNetCore.Authentication.Google" Version="5.0.2" />
-    <PackageReference Update="Microsoft.AspNetCore.Authentication.Twitter" Version="5.0.2" />
-    <PackageReference Update="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.2" />
-    <PackageReference Update="Microsoft.AspNetCore.TestHost" Version="5.0.2" />
+    <PackageReference Update="Microsoft.AspNetCore.Authentication.Google" Version="5.0.4" />
+    <PackageReference Update="Microsoft.AspNetCore.Authentication.Twitter" Version="5.0.4" />
+    <PackageReference Update="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.4" />
+    <PackageReference Update="Microsoft.AspNetCore.TestHost" Version="5.0.4" />
     <PackageReference Update="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.6.0" />
-    <PackageReference Update="Moq" Version="4.16.0" />
+    <PackageReference Update="Moq" Version="4.16.1" />
     <PackageReference Update="Shouldly" Version="4.0.3" />
     <PackageReference Update="StyleCop.Analyzers" Version="1.1.118" />
     <PackageReference Update="System.IdentityModel.Tokens.Jwt" Version="6.6.0" />

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "5.0.102"
+    "dotnet": "5.0.201"
   },
 
   "msbuild-sdks": {

--- a/src/AspNet.Security.OAuth.Alipay/AlipayAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Alipay/AlipayAuthenticationHandler.cs
@@ -81,7 +81,7 @@ namespace AspNet.Security.OAuth.Alipay
                                 "returned a {Status} response with the following payload: {Headers} {Body}.",
                                 /* Status: */ response.StatusCode,
                                 /* Headers: */ response.Headers.ToString(),
-                                /* Body: */ await response.Content.ReadAsStringAsync());
+                                /* Body: */ await response.Content.ReadAsStringAsync(Context.RequestAborted));
 
                 return OAuthTokenResponse.Failed(new Exception("An error occurred while retrieving an access token."));
             }
@@ -128,7 +128,7 @@ namespace AspNet.Security.OAuth.Alipay
                                 "returned a {Status} response with the following payload: {Headers} {Body}.",
                                 /* Status: */ response.StatusCode,
                                 /* Headers: */ response.Headers.ToString(),
-                                /* Body: */ await response.Content.ReadAsStringAsync());
+                                /* Body: */ await response.Content.ReadAsStringAsync(Context.RequestAborted));
 
                 throw new HttpRequestException("An error occurred while retrieving user information.");
             }

--- a/src/AspNet.Security.OAuth.Line/LineAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Line/LineAuthenticationHandler.cs
@@ -65,12 +65,12 @@ namespace AspNet.Security.OAuth.Line
                                 "returned a {Status} response with the following payload: {Headers} {Body}.",
                                 /* Status: */ response.StatusCode,
                                 /* Headers: */ response.Headers.ToString(),
-                                /* Body: */ await response.Content.ReadAsStringAsync());
+                                /* Body: */ await response.Content.ReadAsStringAsync(Context.RequestAborted));
 
                 return OAuthTokenResponse.Failed(new Exception("An error occurred while retrieving an access token."));
             }
 
-            var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+            var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
             return OAuthTokenResponse.Success(payload);
         }
 
@@ -90,12 +90,12 @@ namespace AspNet.Security.OAuth.Line
                                 "returned a {Status} response with the following payload: {Headers} {Body}.",
                                 /* Status: */ response.StatusCode,
                                 /* Headers: */ response.Headers.ToString(),
-                                /* Body: */ await response.Content.ReadAsStringAsync());
+                                /* Body: */ await response.Content.ReadAsStringAsync(Context.RequestAborted));
 
                 throw new HttpRequestException("An error occurred while retrieving user information.");
             }
 
-            using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+            using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
             var principal = new ClaimsPrincipal(identity);
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
@@ -134,12 +134,12 @@ namespace AspNet.Security.OAuth.Line
                                   "the remote server returned a {Status} response with the following payload: {Headers} {Body}.",
                                   /* Status: */ response.StatusCode,
                                   /* Headers: */ response.Headers.ToString(),
-                                  /* Body: */ await response.Content.ReadAsStringAsync());
+                                  /* Body: */ await response.Content.ReadAsStringAsync(Context.RequestAborted));
 
                 throw new HttpRequestException("An error occurred while retrieving the email address associated to the user profile.");
             }
 
-            using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+            using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
             return payload.RootElement.GetString("email");
         }
     }


### PR DESCRIPTION
  * Pass through the `CancellationToken` for the request into `ReadAsStringAsync()` calls in the Alipay and Line providers to match usage in the other providers since #515.
  * Update to the latest .NET 5.0 SDK.
  * Update test/sample NuGet packages to their latest versions.
