### PR TITLE
updating the out-of-date EveOnline provider

### DIFF
--- a/src/AspNet.Security.OAuth.EVEOnline/AspNet.Security.OAuth.EVEOnline.csproj
+++ b/src/AspNet.Security.OAuth.EVEOnline/AspNet.Security.OAuth.EVEOnline.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <Description>ASP.NET Core security middleware enabling EVEOnline authentication.</Description>
-    <Authors>Mariusz Zieliński;Chino Chang</Authors>
+    <Authors>Mariusz Zieliński;Chino Chang;Psianna Archeia</Authors>
     <PackageTags>aspnetcore;authentication;eveonline;oauth;security</PackageTags>
   </PropertyGroup>
 

--- a/src/AspNet.Security.OAuth.EVEOnline/EVEOnlineAuthenticationDefaults.cs
+++ b/src/AspNet.Security.OAuth.EVEOnline/EVEOnlineAuthenticationDefaults.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
  * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
  * for more information concerning the license and the contributors participating to this project.
@@ -35,45 +35,10 @@ namespace AspNet.Security.OAuth.EVEOnline
         public const string CallbackPath = "/signin-eveonline";
 
         /// <summary>
-        /// Default values for the Tranquility (live) server.
+        /// Default value for <see cref="EVEOnlineAuthenticationOptions.Server"/>.
         /// </summary>
-        public static class Tranquility
-        {
-            /// <summary>
-            /// Default value for <see cref="OAuthOptions.AuthorizationEndpoint"/>.
-            /// </summary>
-            public const string AuthorizationEndpoint = "https://login.eveonline.com/oauth/authorize";
+        public const string TranquilityUrl = "https://login.eveonline.com";
 
-            /// <summary>
-            /// Default value for <see cref="OAuthOptions.TokenEndpoint"/>.
-            /// </summary>
-            public const string TokenEndpoint = "https://login.eveonline.com/oauth/token";
-
-            /// <summary>
-            /// Default value for <see cref="OAuthOptions.UserInformationEndpoint"/>.
-            /// </summary>
-            public const string UserInformationEndpoint = "https://login.eveonline.com/oauth/verify";
-        }
-
-        /// <summary>
-        /// Default values for the Singularity (test) server.
-        /// </summary>
-        public static class Singularity
-        {
-            /// <summary>
-            /// Default value for <see cref="OAuthOptions.AuthorizationEndpoint"/>.
-            /// </summary>
-            public const string AuthorizationEndpoint = "https://sisilogin.testeveonline.com/oauth/authorize";
-
-            /// <summary>
-            /// Default value for <see cref="OAuthOptions.TokenEndpoint"/>.
-            /// </summary>
-            public const string TokenEndpoint = "https://sisilogin.testeveonline.com/oauth/token";
-
-            /// <summary>
-            /// Default value for <see cref="OAuthOptions.UserInformationEndpoint"/>.
-            /// </summary>
-            public const string UserInformationEndpoint = "https://sisilogin.testeveonline.com/oauth/verify";
-        }
+        public const string SerenityUrl = "https://login.evepc.163.com";
     }
 }

--- a/src/AspNet.Security.OAuth.EVEOnline/EVEOnlineAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.EVEOnline/EVEOnlineAuthenticationOptions.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
  * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
  * for more information concerning the license and the contributors participating to this project.
@@ -30,6 +30,8 @@ namespace AspNet.Security.OAuth.EVEOnline
             ClaimActions.MapJsonKey(Claims.Scopes, "Scopes");
         }
 
+        public EVEOnlineOauthVersion Version { get; set; }
+
         /// <summary>
         /// Sets the server used when communicating with EVE Online
         /// (by default, <see cref="EVEOnlineAuthenticationServer.Tranquility"/>).
@@ -38,23 +40,30 @@ namespace AspNet.Security.OAuth.EVEOnline
         {
             set
             {
+                var baseUrl = string.Empty;
                 switch (value)
                 {
                     case EVEOnlineAuthenticationServer.Tranquility:
-                        AuthorizationEndpoint = EVEOnlineAuthenticationDefaults.Tranquility.AuthorizationEndpoint;
-                        TokenEndpoint = EVEOnlineAuthenticationDefaults.Tranquility.TokenEndpoint;
-                        UserInformationEndpoint = EVEOnlineAuthenticationDefaults.Tranquility.UserInformationEndpoint;
+                        baseUrl = EVEOnlineAuthenticationDefaults.TranquilityUrl;
                         break;
 
-                    case EVEOnlineAuthenticationServer.Singularity:
-                        AuthorizationEndpoint = EVEOnlineAuthenticationDefaults.Singularity.AuthorizationEndpoint;
-                        TokenEndpoint = EVEOnlineAuthenticationDefaults.Singularity.TokenEndpoint;
-                        UserInformationEndpoint = EVEOnlineAuthenticationDefaults.Singularity.UserInformationEndpoint;
+                    case EVEOnlineAuthenticationServer.Serenity:
+                        baseUrl = EVEOnlineAuthenticationDefaults.SerenityUrl;
                         break;
 
                     default:
                         throw new ArgumentException($"Server '{value}' is unsupported.", nameof(value));
                 }
+
+                var version = string.Empty;
+                if (Version == EVEOnlineOauthVersion.V2)
+                {
+                    version = "/v2";
+                }
+
+                AuthorizationEndpoint = $"{baseUrl}{version}/oauth/authorize";
+                TokenEndpoint = $"{baseUrl}{version}/oauth/token";
+                UserInformationEndpoint = $"{baseUrl}/oauth/verify";
             }
         }
     }

--- a/src/AspNet.Security.OAuth.EVEOnline/EVEOnlineOauthVersion.cs
+++ b/src/AspNet.Security.OAuth.EVEOnline/EVEOnlineOauthVersion.cs
@@ -7,19 +7,19 @@
 namespace AspNet.Security.OAuth
 {
     /// <summary>
-    /// Defines a list of servers used to determine the appropriate
+    /// Defines a list of versions used to help determine the appropriate
     /// API endpoints when communicating with EVEOnline.
     /// </summary>
-    public enum EVEOnlineAuthenticationServer
+    public enum EVEOnlineOauthVersion
     {
         /// <summary>
-        /// Everyone else server.
+        /// Version 1 Oauth Server.
         /// </summary>
-        Tranquility = 0,
+        V1,
 
         /// <summary>
-        /// Chinese server.
+        /// Version 2 Oauth Server.
         /// </summary>
-        Serenity = 1
+        V2
     }
 }


### PR DESCRIPTION
The Eve Online provider is woefully out of date. It no longer supports Singularity server and also has a v2 option for OAuth provider.
I have removed Singularity as an option and added in Serenity. Also added an enum option to support choosing between versions of Oauth.

Both v1 and v2 options have been tested and verified that the built-in Microsoft External Login Provider will acknowledge both versions of OAuth and it knows the user is the same, even switching between versions within the same project's authorization scheme.

Please consider updating this because whoever originally added this has not been keeping up with it and several changes have obviously been made by the SSO owners (CCP) and this would be most useful to the Eve Online community.