### PR TITLE
Save id_token in Apple provider

### DIFF
--- a/src/AspNet.Security.OAuth.Apple/AppleAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Apple/AppleAuthenticationHandler.cs
@@ -339,6 +339,13 @@ namespace AspNet.Security.OAuth.Apple
                     }
                 }
 
+                string? idToken = tokens.Response.RootElement.GetString("id_token");
+
+                if (!string.IsNullOrEmpty(idToken))
+                {
+                    authTokens.Add(new AuthenticationToken() { Name = "id_token", Value = idToken });
+                }
+
                 properties.StoreTokens(authTokens);
             }
 

--- a/test/AspNet.Security.OAuth.Providers.Tests/Apple/AppleTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Apple/AppleTests.cs
@@ -45,6 +45,7 @@ namespace AspNet.Security.OAuth.Apple
             {
                 ConfigureDefaults(builder, options);
                 options.ClientId = "com.martincostello.signinwithapple.test.client";
+                options.SaveTokens = true;
             });
         }
 

--- a/test/AspNet.Security.OAuth.Providers.Tests/SuperOffice/SuperOfficeTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/SuperOffice/SuperOfficeTests.cs
@@ -35,6 +35,7 @@ namespace AspNet.Security.OAuth.SuperOffice
                 ConfigureDefaults(builder, options);
 
                 options.ClientId = "gg454918d75b1b53101065c16ee51123";
+                options.SaveTokens = true;
                 options.TokenValidationParameters.ValidAudience = options.ClientId;
                 options.TokenValidationParameters.ValidIssuer = "https://sod.superoffice.com";
             });


### PR DESCRIPTION
If `SaveTokens` is set to true, save the `id_token` in the Apple provider like the [SuperOffice provider does](https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/blob/fcbd67a723e7f6b708424cb8f03d5b298c8aa485/src/AspNet.Security.OAuth.SuperOffice/SuperOfficeAuthenticationHandler.cs#L142).

Addresses #556.

