### PR TITLE
Minor refactors

### DIFF
--- a/AspNet.Security.OAuth.Providers.sln
+++ b/AspNet.Security.OAuth.Providers.sln
@@ -184,7 +184,37 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNet.Security.OAuth.NetEa
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{C2CA4B38-AA21-4CA4-8799-2E8C8C06754F}"
 	ProjectSection(SolutionItems) = preProject
+		docs\amazon.md = docs\amazon.md
+		docs\amocrm.md = docs\amocrm.md
+		docs\battlenet.md = docs\battlenet.md
+		docs\bitbucket.md = docs\bitbucket.md
+		docs\discord.md = docs\discord.md
+		docs\eveonline.md = docs\eveonline.md
+		docs\foursquare.md = docs\foursquare.md
+		docs\gitee.md = docs\gitee.md
+		docs\github.md = docs\github.md
+		docs\instagram.md = docs\instagram.md
+		docs\keycloak.md = docs\keycloak.md
+		docs\kloudless.md = docs\kloudless.md
+		docs\lichess.md = docs\lichess.md
+		docs\line.md = docs\line.md
+		docs\linkedin.md = docs\linkedin.md
+		docs\moodle.md = docs\moodle.md
+		docs\odnoklassniki.md = docs\odnoklassniki.md
+		docs\okta.md = docs\okta.md
+		docs\patreon.md = docs\patreon.md
+		docs\qq.md = docs\qq.md
+		docs\README.md = docs\README.md
+		docs\reddit.md = docs\reddit.md
+		docs\salesforce.md = docs\salesforce.md
 		docs\sign-in-with-apple.md = docs\sign-in-with-apple.md
+		docs\stackexchange.md = docs\stackexchange.md
+		docs\superoffice.md = docs\superoffice.md
+		docs\trakt.md = docs\trakt.md
+		docs\twitch.md = docs\twitch.md
+		docs\vkontakte.md = docs\vkontakte.md
+		docs\weibo.md = docs\weibo.md
+		docs\workweixin.md = docs\workweixin.md
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNet.Security.OAuth.Basecamp", "src\AspNet.Security.OAuth.Basecamp\AspNet.Security.OAuth.Basecamp.csproj", "{42306484-B2BF-4B52-B950-E0CDFA58B02A}"
@@ -220,7 +250,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNet.Security.OAuth.Keycl
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNet.Security.OAuth.WorkWeixin", "src\AspNet.Security.OAuth.WorkWeixin\AspNet.Security.OAuth.WorkWeixin.csproj", "{C40ED377-E365-45FB-8B42-27BE82CC7BE3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AspNet.Security.OAuth.Notion", "src\AspNet.Security.OAuth.Notion\AspNet.Security.OAuth.Notion.csproj", "{DF2786DF-234D-4A8C-B166-0B8F8B7D527B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNet.Security.OAuth.Notion", "src\AspNet.Security.OAuth.Notion\AspNet.Security.OAuth.Notion.csproj", "{DF2786DF-234D-4A8C-B166-0B8F8B7D527B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -524,10 +554,6 @@ Global
 		{514D2D1E-E72F-4998-9DF3-D841F399AB37}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{514D2D1E-E72F-4998-9DF3-D841F399AB37}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{514D2D1E-E72F-4998-9DF3-D841F399AB37}.Release|Any CPU.Build.0 = Release|Any CPU
-		{DF2786DF-234D-4A8C-B166-0B8F8B7D527B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{DF2786DF-234D-4A8C-B166-0B8F8B7D527B}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{DF2786DF-234D-4A8C-B166-0B8F8B7D527B}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{DF2786DF-234D-4A8C-B166-0B8F8B7D527B}.Release|Any CPU.Build.0 = Release|Any CPU
 		{01C2AC98-B615-49F8-80A5-475A2B75A8FD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{01C2AC98-B615-49F8-80A5-475A2B75A8FD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{01C2AC98-B615-49F8-80A5-475A2B75A8FD}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -536,6 +562,10 @@ Global
 		{C40ED377-E365-45FB-8B42-27BE82CC7BE3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C40ED377-E365-45FB-8B42-27BE82CC7BE3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C40ED377-E365-45FB-8B42-27BE82CC7BE3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DF2786DF-234D-4A8C-B166-0B8F8B7D527B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DF2786DF-234D-4A8C-B166-0B8F8B7D527B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DF2786DF-234D-4A8C-B166-0B8F8B7D527B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DF2786DF-234D-4A8C-B166-0B8F8B7D527B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -621,9 +651,9 @@ Global
 		{1745B11F-F700-4604-B61F-54B962A6BE9A} = {C1352FD3-AE8B-43EE-B45B-F6E0B3FBAC6D}
 		{839267B9-492D-47B6-A6AF-454282142123} = {C1352FD3-AE8B-43EE-B45B-F6E0B3FBAC6D}
 		{514D2D1E-E72F-4998-9DF3-D841F399AB37} = {C1352FD3-AE8B-43EE-B45B-F6E0B3FBAC6D}
-		{DF2786DF-234D-4A8C-B166-0B8F8B7D527B} = {C1352FD3-AE8B-43EE-B45B-F6E0B3FBAC6D}
 		{01C2AC98-B615-49F8-80A5-475A2B75A8FD} = {C1352FD3-AE8B-43EE-B45B-F6E0B3FBAC6D}
 		{C40ED377-E365-45FB-8B42-27BE82CC7BE3} = {C1352FD3-AE8B-43EE-B45B-F6E0B3FBAC6D}
+		{DF2786DF-234D-4A8C-B166-0B8F8B7D527B} = {C1352FD3-AE8B-43EE-B45B-F6E0B3FBAC6D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C7B54DE2-6407-4802-AD9C-CE54BF414C8C}

--- a/src/AspNet.Security.OAuth.Alipay/AlipayAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Alipay/AlipayAuthenticationHandler.cs
@@ -207,7 +207,7 @@ namespace AspNet.Security.OAuth.Alipay
             byte[] privateKeyBytes = Convert.FromBase64String(Options.ClientSecret);
 
             using var rsa = RSA.Create();
-            rsa.ImportRSAPrivateKey(privateKeyBytes, out int _);
+            rsa.ImportRSAPrivateKey(privateKeyBytes, out _);
 
             byte[] encryptedBytes = rsa.SignData(plainBytes, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
 

--- a/src/AspNet.Security.OAuth.Amazon/AmazonAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Amazon/AmazonAuthenticationHandler.cs
@@ -50,7 +50,7 @@ namespace AspNet.Security.OAuth.Amazon
 
             if (Options.Fields.Count > 0)
             {
-                endpoint = QueryHelpers.AddQueryString(endpoint, "fields", string.Join(",", Options.Fields));
+                endpoint = QueryHelpers.AddQueryString(endpoint, "fields", string.Join(',', Options.Fields));
             }
 
             using var request = new HttpRequestMessage(HttpMethod.Get, endpoint);

--- a/src/AspNet.Security.OAuth.Apple/Internal/DefaultAppleClientSecretGenerator.cs
+++ b/src/AspNet.Security.OAuth.Apple/Internal/DefaultAppleClientSecretGenerator.cs
@@ -74,7 +74,7 @@ namespace AspNet.Security.OAuth.Apple.Internal
                 options.KeyId
             };
 
-            return string.Join("+", segments);
+            return string.Join('+', segments);
         }
 
         private async Task<(string clientSecret, DateTimeOffset expiresAt)> GenerateNewSecretAsync(

--- a/src/AspNet.Security.OAuth.Apple/Internal/DefaultAppleClientSecretGenerator.cs
+++ b/src/AspNet.Security.OAuth.Apple/Internal/DefaultAppleClientSecretGenerator.cs
@@ -117,7 +117,7 @@ namespace AspNet.Security.OAuth.Apple.Internal
 
             try
             {
-                algorithm.ImportPkcs8PrivateKey(keyBlob, out int _);
+                algorithm.ImportPkcs8PrivateKey(keyBlob, out _);
                 return algorithm;
             }
             catch (Exception)

--- a/src/AspNet.Security.OAuth.Apple/Internal/DefaultAppleIdTokenValidator.cs
+++ b/src/AspNet.Security.OAuth.Apple/Internal/DefaultAppleIdTokenValidator.cs
@@ -52,7 +52,7 @@ namespace AspNet.Security.OAuth.Apple.Internal
 
             try
             {
-                context.Options.JwtSecurityTokenHandler.ValidateToken(context.IdToken, parameters, out var _);
+                context.Options.JwtSecurityTokenHandler.ValidateToken(context.IdToken, parameters, out _);
             }
             catch (Exception ex)
             {

--- a/src/AspNet.Security.OAuth.Deezer/DeezerAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Deezer/DeezerAuthenticationHandler.cs
@@ -140,6 +140,6 @@ namespace AspNet.Security.OAuth.Deezer
 
         /// <inheritdoc/>
         protected override string FormatScope([NotNull] IEnumerable<string> scopes)
-            => string.Join(",", scopes);
+            => string.Join(',', scopes);
     }
 }

--- a/src/AspNet.Security.OAuth.Instagram/InstagramAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Instagram/InstagramAuthenticationHandler.cs
@@ -40,7 +40,7 @@ namespace AspNet.Security.OAuth.Instagram
 
             if (Options.Fields.Count > 0)
             {
-                address = QueryHelpers.AddQueryString(address, "fields", string.Join(",", Options.Fields));
+                address = QueryHelpers.AddQueryString(address, "fields", string.Join(',', Options.Fields));
             }
 
             using var request = new HttpRequestMessage(HttpMethod.Get, address);

--- a/src/AspNet.Security.OAuth.LinkedIn/LinkedInAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.LinkedIn/LinkedInAuthenticationHandler.cs
@@ -46,7 +46,7 @@ namespace AspNet.Security.OAuth.LinkedIn
             // If at least one field is specified, append the fields to the endpoint URL.
             if (fields.Count > 0)
             {
-                requestUri = QueryHelpers.AddQueryString(requestUri, "projection", $"({string.Join(",", fields)})");
+                requestUri = QueryHelpers.AddQueryString(requestUri, "projection", $"({string.Join(',', fields)})");
             }
 
             using var request = new HttpRequestMessage(HttpMethod.Get, requestUri);

--- a/src/AspNet.Security.OAuth.LinkedIn/LinkedInAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.LinkedIn/LinkedInAuthenticationOptions.cs
@@ -42,7 +42,7 @@ namespace AspNet.Security.OAuth.LinkedIn
             ClaimActions.MapCustomJson(Claims.PictureUrls, user =>
             {
                 var urls = GetPictureUrls(user);
-                return urls == null ? null : string.Join(",", urls);
+                return urls == null ? null : string.Join(',', urls);
             });
         }
 
@@ -118,7 +118,7 @@ namespace AspNet.Security.OAuth.LinkedIn
                 GetMultiLocaleString(user, ProfileFields.LastName),
             };
 
-            return string.Join(" ", nameParts.Where(s => !string.IsNullOrWhiteSpace(s)));
+            return string.Join(' ', nameParts.Where(s => !string.IsNullOrWhiteSpace(s)));
         }
 
         private static IEnumerable<string> GetPictureUrls(JsonElement user)

--- a/src/AspNet.Security.OAuth.Moodle/MoodleAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Moodle/MoodleAuthenticationOptions.cs
@@ -56,21 +56,21 @@ namespace AspNet.Security.OAuth.Moodle
         {
             base.Validate();
 
-            if (!Uri.TryCreate(AuthorizationEndpoint, UriKind.Absolute, out var _))
+            if (!Uri.TryCreate(AuthorizationEndpoint, UriKind.Absolute, out _))
             {
                 throw new ArgumentException(
                     $"The '{nameof(AuthorizationEndpoint)}' option must be set to a valid URI.",
                     nameof(AuthorizationEndpoint));
             }
 
-            if (!Uri.TryCreate(TokenEndpoint, UriKind.Absolute, out var _))
+            if (!Uri.TryCreate(TokenEndpoint, UriKind.Absolute, out _))
             {
                 throw new ArgumentException(
                     $"The '{nameof(TokenEndpoint)}' option must be set to a valid URI.",
                     nameof(TokenEndpoint));
             }
 
-            if (!Uri.TryCreate(UserInformationEndpoint, UriKind.Absolute, out var _))
+            if (!Uri.TryCreate(UserInformationEndpoint, UriKind.Absolute, out _))
             {
                 throw new ArgumentException(
                     $"The '{nameof(UserInformationEndpoint)}' option must be set to a valid URI.",

--- a/src/AspNet.Security.OAuth.Nextcloud/NextcloudAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Nextcloud/NextcloudAuthenticationOptions.cs
@@ -35,7 +35,7 @@ namespace AspNet.Security.OAuth.Nextcloud
                     if (TryGetData(user, out var data) &&
                         data.TryGetProperty("groups", out var groups))
                     {
-                        return string.Join(",", groups.EnumerateArray().Select((p) => p.GetString()));
+                        return string.Join(',', groups.EnumerateArray().Select((p) => p.GetString()));
                     }
 
                     return null;

--- a/src/AspNet.Security.OAuth.Okta/OktaAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Okta/OktaAuthenticationOptions.cs
@@ -45,21 +45,21 @@ namespace AspNet.Security.OAuth.Okta
         {
             base.Validate();
 
-            if (!Uri.TryCreate(AuthorizationEndpoint, UriKind.Absolute, out var _))
+            if (!Uri.TryCreate(AuthorizationEndpoint, UriKind.Absolute, out _))
             {
                 throw new ArgumentException(
                     $"The '{nameof(AuthorizationEndpoint)}' option must be set to a valid URI.",
                     nameof(AuthorizationEndpoint));
             }
 
-            if (!Uri.TryCreate(TokenEndpoint, UriKind.Absolute, out var _))
+            if (!Uri.TryCreate(TokenEndpoint, UriKind.Absolute, out _))
             {
                 throw new ArgumentException(
                     $"The '{nameof(TokenEndpoint)}' option must be set to a valid URI.",
                     nameof(TokenEndpoint));
             }
 
-            if (!Uri.TryCreate(UserInformationEndpoint, UriKind.Absolute, out var _))
+            if (!Uri.TryCreate(UserInformationEndpoint, UriKind.Absolute, out _))
             {
                 throw new ArgumentException(
                     $"The '{nameof(UserInformationEndpoint)}' option must be set to a valid URI.",

--- a/src/AspNet.Security.OAuth.Patreon/PatreonAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Patreon/PatreonAuthenticationHandler.cs
@@ -39,12 +39,12 @@ namespace AspNet.Security.OAuth.Patreon
 
             if (Options.Fields.Count > 0)
             {
-                endpoint = QueryHelpers.AddQueryString(endpoint, "fields[user]", string.Join(",", Options.Fields));
+                endpoint = QueryHelpers.AddQueryString(endpoint, "fields[user]", string.Join(',', Options.Fields));
             }
 
             if (Options.Includes.Count > 0)
             {
-                endpoint = QueryHelpers.AddQueryString(endpoint, "include", string.Join(",", Options.Includes));
+                endpoint = QueryHelpers.AddQueryString(endpoint, "include", string.Join(',', Options.Includes));
             }
 
             using var request = new HttpRequestMessage(HttpMethod.Get, endpoint);

--- a/src/AspNet.Security.OAuth.Reddit/RedditAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Reddit/RedditAuthenticationHandler.cs
@@ -85,7 +85,7 @@ namespace AspNet.Security.OAuth.Reddit
             // Note: Reddit requires a non-standard comma-separated scope.
             // See https://github.com/reddit/reddit/wiki/OAuth2#authorization
             // and http://tools.ietf.org/html/rfc6749#section-3.3.
-            return string.Join(",", Options.Scope);
+            return string.Join(',', Options.Scope);
         }
 
         protected override async Task<OAuthTokenResponse> ExchangeCodeAsync([NotNull] OAuthCodeExchangeContext context)

--- a/src/AspNet.Security.OAuth.Shopify/ShopifyAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Shopify/ShopifyAuthenticationHandler.cs
@@ -95,7 +95,7 @@ namespace AspNet.Security.OAuth.Shopify
         /// <inheritdoc />
         protected override string FormatScope()
         {
-            return string.Join(",", Options.Scope);
+            return string.Join(',', Options.Scope);
         }
 
         /// <inheritdoc />

--- a/src/AspNet.Security.OAuth.Strava/StravaAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Strava/StravaAuthenticationHandler.cs
@@ -63,6 +63,6 @@ namespace AspNet.Security.OAuth.Strava
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
 
-        protected override string FormatScope() => string.Join(",", Options.Scope);
+        protected override string FormatScope() => string.Join(',', Options.Scope);
     }
 }

--- a/src/AspNet.Security.OAuth.Vkontakte/VkontakteAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Vkontakte/VkontakteAuthenticationHandler.cs
@@ -44,7 +44,7 @@ namespace AspNet.Security.OAuth.Vkontakte
 
             if (Options.Fields.Count != 0)
             {
-                address = QueryHelpers.AddQueryString(address, "fields", string.Join(",", Options.Fields));
+                address = QueryHelpers.AddQueryString(address, "fields", string.Join(',', Options.Fields));
             }
 
             using var response = await Backchannel.GetAsync(address, Context.RequestAborted);

--- a/src/AspNet.Security.OAuth.Weibo/WeiboAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Weibo/WeiboAuthenticationHandler.cs
@@ -82,7 +82,7 @@ namespace AspNet.Security.OAuth.Weibo
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
 
-        protected override string FormatScope() => string.Join(",", Options.Scope);
+        protected override string FormatScope() => string.Join(',', Options.Scope);
 
         protected virtual async Task<string?> GetEmailAsync([NotNull] OAuthTokenResponse tokens)
         {

--- a/src/AspNet.Security.OAuth.Weixin/WeixinAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Weixin/WeixinAuthenticationHandler.cs
@@ -164,7 +164,7 @@ namespace AspNet.Security.OAuth.Weixin
             return redirectUri;
         }
 
-        protected override string FormatScope() => string.Join(",", Options.Scope);
+        protected override string FormatScope() => string.Join(',', Options.Scope);
 
         private bool IsWeixinAuthorizationEndpointInUse()
         {

--- a/src/AspNet.Security.OAuth.Weixin/WeixinAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Weixin/WeixinAuthenticationHandler.cs
@@ -43,7 +43,7 @@ namespace AspNet.Security.OAuth.Weixin
                 if (Request.Query.TryGetValue(OauthState, out var stateValue))
                 {
                     var query = Request.Query.ToDictionary(c => c.Key, c => c.Value, StringComparer.OrdinalIgnoreCase);
-                    if (query.TryGetValue(State, out var _))
+                    if (query.TryGetValue(State, out _))
                     {
                         query[State] = stateValue;
                         Request.QueryString = QueryString.Create(query);

--- a/src/AspNet.Security.OAuth.Weixin/WeixinAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Weixin/WeixinAuthenticationOptions.cs
@@ -44,7 +44,7 @@ namespace AspNet.Security.OAuth.Weixin
                     return null;
                 }
 
-                return string.Join(",", value.EnumerateArray().Select(element => element.GetString()));
+                return string.Join(',', value.EnumerateArray().Select(element => element.GetString()));
             });
         }
     }

--- a/test/AspNet.Security.OAuth.Providers.Tests/GitHub/GitHubPostConfigureOptionsTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/GitHub/GitHubPostConfigureOptionsTests.cs
@@ -34,16 +34,16 @@ namespace AspNet.Security.OAuth.GitHub
 
             // Assert
             options.AuthorizationEndpoint.ShouldStartWith("https://github.local/");
-            Uri.TryCreate(options.AuthorizationEndpoint, UriKind.Absolute, out var _).ShouldBeTrue();
+            Uri.TryCreate(options.AuthorizationEndpoint, UriKind.Absolute, out _).ShouldBeTrue();
 
             options.TokenEndpoint.ShouldStartWith("https://github.local/");
-            Uri.TryCreate(options.TokenEndpoint, UriKind.Absolute, out var _).ShouldBeTrue();
+            Uri.TryCreate(options.TokenEndpoint, UriKind.Absolute, out _).ShouldBeTrue();
 
             options.UserEmailsEndpoint.ShouldStartWith("https://github.local/api/v3/");
-            Uri.TryCreate(options.UserEmailsEndpoint, UriKind.Absolute, out var _).ShouldBeTrue();
+            Uri.TryCreate(options.UserEmailsEndpoint, UriKind.Absolute, out _).ShouldBeTrue();
 
             options.UserInformationEndpoint.ShouldStartWith("https://github.local/api/v3/");
-            Uri.TryCreate(options.UserInformationEndpoint, UriKind.Absolute, out var _).ShouldBeTrue();
+            Uri.TryCreate(options.UserInformationEndpoint, UriKind.Absolute, out _).ShouldBeTrue();
         }
 
         [Theory]
@@ -66,16 +66,16 @@ namespace AspNet.Security.OAuth.GitHub
 
             // Assert
             options.AuthorizationEndpoint.ShouldStartWith("https://github.com/");
-            Uri.TryCreate(options.AuthorizationEndpoint, UriKind.Absolute, out var _).ShouldBeTrue();
+            Uri.TryCreate(options.AuthorizationEndpoint, UriKind.Absolute, out _).ShouldBeTrue();
 
             options.TokenEndpoint.ShouldStartWith("https://github.com/");
-            Uri.TryCreate(options.TokenEndpoint, UriKind.Absolute, out var _).ShouldBeTrue();
+            Uri.TryCreate(options.TokenEndpoint, UriKind.Absolute, out _).ShouldBeTrue();
 
             options.UserEmailsEndpoint.ShouldStartWith("https://api.github.com/");
-            Uri.TryCreate(options.UserEmailsEndpoint, UriKind.Absolute, out var _).ShouldBeTrue();
+            Uri.TryCreate(options.UserEmailsEndpoint, UriKind.Absolute, out _).ShouldBeTrue();
 
             options.UserInformationEndpoint.ShouldStartWith("https://api.github.com/");
-            Uri.TryCreate(options.UserInformationEndpoint, UriKind.Absolute, out var _).ShouldBeTrue();
+            Uri.TryCreate(options.UserInformationEndpoint, UriKind.Absolute, out _).ShouldBeTrue();
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Moodle/MoodlePostConfigureOptionsTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Moodle/MoodlePostConfigureOptionsTests.cs
@@ -34,13 +34,13 @@ namespace AspNet.Security.OAuth.Moodle
 
             // Assert
             options.AuthorizationEndpoint.ShouldStartWith("https://moodle.local/local/oauth/login.php");
-            Uri.TryCreate(options.AuthorizationEndpoint, UriKind.Absolute, out var _).ShouldBeTrue();
+            Uri.TryCreate(options.AuthorizationEndpoint, UriKind.Absolute, out _).ShouldBeTrue();
 
             options.TokenEndpoint.ShouldStartWith("https://moodle.local/local/oauth/token.php");
-            Uri.TryCreate(options.TokenEndpoint, UriKind.Absolute, out var _).ShouldBeTrue();
+            Uri.TryCreate(options.TokenEndpoint, UriKind.Absolute, out _).ShouldBeTrue();
 
             options.UserInformationEndpoint.ShouldStartWith("https://moodle.local/local/oauth/user_info.php");
-            Uri.TryCreate(options.UserInformationEndpoint, UriKind.Absolute, out var _).ShouldBeTrue();
+            Uri.TryCreate(options.UserInformationEndpoint, UriKind.Absolute, out _).ShouldBeTrue();
         }
 
         [Theory]

--- a/test/AspNet.Security.OAuth.Providers.Tests/Okta/OktaPostConfigureOptionsTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Okta/OktaPostConfigureOptionsTests.cs
@@ -34,13 +34,13 @@ namespace AspNet.Security.OAuth.Okta
 
             // Assert
             options.AuthorizationEndpoint.ShouldStartWith("https://okta.local/oauth2/default/v1/");
-            Uri.TryCreate(options.AuthorizationEndpoint, UriKind.Absolute, out var _).ShouldBeTrue();
+            Uri.TryCreate(options.AuthorizationEndpoint, UriKind.Absolute, out _).ShouldBeTrue();
 
             options.TokenEndpoint.ShouldStartWith("https://okta.local/oauth2/default/v1/");
-            Uri.TryCreate(options.TokenEndpoint, UriKind.Absolute, out var _).ShouldBeTrue();
+            Uri.TryCreate(options.TokenEndpoint, UriKind.Absolute, out _).ShouldBeTrue();
 
             options.UserInformationEndpoint.ShouldStartWith("https://okta.local/oauth2/default/v1/");
-            Uri.TryCreate(options.UserInformationEndpoint, UriKind.Absolute, out var _).ShouldBeTrue();
+            Uri.TryCreate(options.UserInformationEndpoint, UriKind.Absolute, out _).ShouldBeTrue();
         }
 
         [Theory]


### PR DESCRIPTION
* Use the `char` overload for `string.Join()` where it's only being joined for one character.
* Remove the need to declare the type when an out parameter isn't used.
* Add all the provider documentation files to the Solution Item's docs folder.
