### PR TITLE
Simplify PEM loading

### DIFF
--- a/docs/sign-in-with-apple.md
+++ b/docs/sign-in-with-apple.md
@@ -10,7 +10,7 @@ This document provides some additional information and context to help you confi
 
 Unlike other providers, the `ClientSecret` property is not used as _Sign in with Apple_ does not use a static client secret value. Instead the client secret has to be generated using a private key file provided by Apple from the Developer Portal that is used with the Key ID and Team ID to create a signed JSON Web Token (JWT).
 
-The provider comes with a built-in extension method ([`UsePrivateKey(string)`](https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/blob/8e4c19008f518f3730bab90a980e01347ba6f3d3/src/AspNet.Security.OAuth.Apple/AppleAuthenticationOptionsExtensions.cs#L20-L33 "UsePrivateKey() extension method")) to generate they secret from a `.p8` certificate file on disk that you provide. Here's a [code example](https://github.com/martincostello/SignInWithAppleSample/blob/245bb70a164b66ec98ea3c2040a7387b0a3e8f0e/src/SignInWithApple/Startup.cs#L37-L46 "Example code to configure the Apple provider"):
+The provider comes with a built-in extension method ([`UsePrivateKey(string)`](https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/blob/8e4c19008f518f3730bab90a980e01347ba6f3d3/src/AspNet.Security.OAuth.Apple/AppleAuthenticationOptionsExtensions.cs#L20-L33 "UsePrivateKey() extension method")) to generate they secret from a `.p8` certificate file on disk that you provide. Here's a code example:
 
 ```csharp
 services.AddAuthentication(options => /* Auth configuration */)
@@ -25,7 +25,45 @@ services.AddAuthentication(options => /* Auth configuration */)
         });
 ```
 
-Alternatively you can use the [`Func<string, Task<byte[]>> PrivateKeyBytes`](https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/blob/8e4c19008f518f3730bab90a980e01347ba6f3d3/src/AspNet.Security.OAuth.Apple/AppleAuthenticationOptions.cs#L78-L85 "Definition of PrivateKeyBytes property") property of the `AppleAuthenticationOptions` class to provide a delegate to a custom method of your own that loads the private key's bytes from another location, such as Azure Key Vault, Kubernetes secrets etc.
+Alternatively you can use the `Func<string, Task<ReadOnlyMemory<char>>> PrivateKey` property of the `AppleAuthenticationOptions` class to provide a delegate to a custom method of your own that loads the private key's bytes from another location, such as Azure Key Vault, Kubernetes secrets etc.
+
+Below are two examples of this approach.
+
+#### Loading from an Environment Variable
+
+```csharp
+services.AddAuthentication(options => /* Auth configuration */)
+        .AddApple(options =>
+        {
+            options.ClientId = Configuration["Apple:ClientId"];
+            options.KeyId = Configuration["Apple:KeyId"];
+            options.TeamId = Configuration["Apple:TeamId"];
+            options.PrivateKey = (keyId, _) =>
+            {
+                return Task.FromResult(Configuration[$"Apple:Key:{keyId}"].AsMemory());
+            };
+        });
+```
+
+#### Loading from Azure Key Vault
+
+```csharp
+services.AddAuthentication(options => /* Auth configuration */)
+        .AddApple()
+        .Services
+        .AddOptions<AppleAuthenticationOptions>(AppleAuthenticationDefaults.AuthenticationScheme)
+        .Configure<IConfiguration, SecretClient>((options, configuration, client) =>
+        {
+            options.ClientId = configuration["Apple:ClientId"];
+            options.KeyId = configuration["Apple:KeyId"];
+            options.TeamId = configuration["Apple:TeamId"];
+            options.PrivateKey = async (keyId, cancellationToken) =>
+            {
+                var secret = await client.GetSecretAsync($"AuthKey-{keyId}", cancellationToken: cancellationToken);
+                return secret.Value.Value.AsMemory();
+            };
+        });
+```
 
 ### Issues Loading Private Key
 
@@ -63,7 +101,7 @@ Below are links to some issues raised against this repository that were related 
 
 ## Sign in with Apple on iOS
 
-When using _Sign In with Apple_ on an iOS 13+ Device, [Apple provides a different authentication workflow](https://developer.apple.com/documentation/authenticationservices) that returns the validation response to the app instead of in a server callback. Using that response to authenticate a user against your own backend requires sending the response to your servers and [communicating with the Apple authentication endpoint from there](https://developer.apple.com/documentation/sign_in_with_apple/generate_and_validate_tokens). 
+When using _Sign In with Apple_ on an iOS 13+ Device, [Apple provides a different authentication workflow](https://developer.apple.com/documentation/authenticationservices) that returns the validation response to the app instead of in a server callback. Using that response to authenticate a user against your own backend requires sending the response to your servers and [communicating with the Apple authentication endpoint from there](https://developer.apple.com/documentation/sign_in_with_apple/generate_and_validate_tokens).
 
 This workflow is out of the scope of this package but client secret generation and token validation can provide a starting point for an ASP.NET.Core integration. Note that the `ClientId` in this case is the App Id where the authentication was requested, not your Services Id.
 

--- a/docs/sign-in-with-apple.md
+++ b/docs/sign-in-with-apple.md
@@ -10,7 +10,7 @@ This document provides some additional information and context to help you confi
 
 Unlike other providers, the `ClientSecret` property is not used as _Sign in with Apple_ does not use a static client secret value. Instead the client secret has to be generated using a private key file provided by Apple from the Developer Portal that is used with the Key ID and Team ID to create a signed JSON Web Token (JWT).
 
-The provider comes with a built-in extension method ([`UsePrivateKey(string)`](https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/blob/8e4c19008f518f3730bab90a980e01347ba6f3d3/src/AspNet.Security.OAuth.Apple/AppleAuthenticationOptionsExtensions.cs#L20-L33 "UsePrivateKey() extension method")) to generate they secret from a `.p8` certificate file on disk that you provide. Here's a code example:
+The provider comes with a built-in extension method `UsePrivateKey(string)` to generate they secret from a `.p8` certificate file on disk that you provide. Here's a code example:
 
 ```csharp
 services.AddAuthentication(options => /* Auth configuration */)
@@ -125,7 +125,7 @@ Below are links to a number of other documentation sources, blog posts and sampl
 | `ConfigurationManager` | `IConfigurationManager<OpenIdConnectConfiguration>?` | The configuration manager to use for the OpenID configuration. | `null` |
 | `GenerateClientSecret` | `bool` | Whether to automatically generate a client secret. | `false` |
 | `KeyId` | `string?` | The optional ID for your Sign in with Apple private key. | `null` |
-| `PrivateKeyBytes` | `Func<string, Task<byte[]>>?` | An optional delegate to use to get the raw bytes of the client's private key in PKCS #8 format. | `null` |
+| `PrivateKeyBytes` | `Func<string, Task<ReadOnlyMemory<char>>>?` | An optional delegate to use to get the characters of the client's private key in PKCS #8 format. | `null` |
 | `TeamId` | `string` | The Team ID for your Apple Developer account. | `""` |
 | `TokenAudience` | `string` | The audience used for tokens. | `AppleAuthenticationConstants.Audience` |
 | `TokenValidator` | `AppleIdTokenValidator` | A service that validates Apple ID tokens. | `An internal implementation` |

--- a/docs/sign-in-with-apple.md
+++ b/docs/sign-in-with-apple.md
@@ -67,16 +67,7 @@ services.AddAuthentication(options => /* Auth configuration */)
 
 ### Issues Loading Private Key
 
-If you encounter issues loading the private key of the certificate, the reasons could include one of the two scenarios:
-
-  1. Using .NET Core 2.x on Linux or macOS
-  1. Using Windows Server with IIS
-
-#### .NET Core 2.x on Linux or macOS
-
-For the first scenario, before .NET Core 3.0 non-Windows platforms did not support loading `.p8` (PKCS #8) files. If you cannot use .NET Core 3.1 or later, it is recommended that you create a `.pfx` certificate file from your `.p8` file and use that instead.
-
-Further information can be found in this GitHub issue: https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/issues/390
+If you encounter issues loading the private key of the certificate, the reasons could include one of the following scenarios.
 
 #### Windows Server with IIS
 

--- a/src/AspNet.Security.OAuth.Apple/AppleAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Apple/AppleAuthenticationOptions.cs
@@ -92,7 +92,7 @@ namespace AspNet.Security.OAuth.Apple
         /// <remarks>
         /// The private key should be in PKCS #8 (<c>.p8</c>) format.
         /// </remarks>
-        public Func<string, CancellationToken, Task<string>>? PrivateKey { get; set; }
+        public Func<string, CancellationToken, Task<ReadOnlyMemory<char>>>? PrivateKey { get; set; }
 
         /// <summary>
         /// Gets or sets the Team ID for your Apple Developer account.

--- a/src/AspNet.Security.OAuth.Apple/AppleAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Apple/AppleAuthenticationOptions.cs
@@ -85,14 +85,14 @@ namespace AspNet.Security.OAuth.Apple
         public string MetadataEndpoint { get; set; } = AppleAuthenticationDefaults.MetadataEndpoint;
 
         /// <summary>
-        /// Gets or sets an optional delegate to get the raw bytes of the client's private key
-        /// which is passed the value of the <see cref="KeyId"/> property and the <see cref="CancellationToken"/>
+        /// Gets or sets an optional delegate to get the client's private key which is passed
+        /// the value of the <see cref="KeyId"/> property and the <see cref="CancellationToken"/>
         /// associated with the current HTTP request.
         /// </summary>
         /// <remarks>
         /// The private key should be in PKCS #8 (<c>.p8</c>) format.
         /// </remarks>
-        public Func<string, CancellationToken, Task<byte[]>>? PrivateKeyBytes { get; set; }
+        public Func<string, CancellationToken, Task<string>>? PrivateKey { get; set; }
 
         /// <summary>
         /// Gets or sets the Team ID for your Apple Developer account.

--- a/src/AspNet.Security.OAuth.Apple/AppleAuthenticationOptionsExtensions.cs
+++ b/src/AspNet.Security.OAuth.Apple/AppleAuthenticationOptionsExtensions.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 using var stream = fileInfo.CreateReadStream();
                 using var reader = new StreamReader(stream);
 
-                return await reader.ReadToEndAsync();
+                return (await reader.ReadToEndAsync()).AsMemory();
             };
 
             return options;

--- a/src/AspNet.Security.OAuth.Apple/AppleAuthenticationOptionsExtensions.cs
+++ b/src/AspNet.Security.OAuth.Apple/AppleAuthenticationOptionsExtensions.cs
@@ -33,22 +33,14 @@ namespace Microsoft.Extensions.DependencyInjection
             [NotNull] Func<string, IFileInfo> privateKeyFile)
         {
             options.GenerateClientSecret = true;
-            options.PrivateKeyBytes = async (keyId, _) =>
+            options.PrivateKey = async (keyId, _) =>
             {
                 var fileInfo = privateKeyFile(keyId);
 
                 using var stream = fileInfo.CreateReadStream();
                 using var reader = new StreamReader(stream);
 
-                string privateKey = await reader.ReadToEndAsync();
-
-                if (privateKey.StartsWith("-----BEGIN PRIVATE KEY-----", StringComparison.Ordinal))
-                {
-                    string[] lines = privateKey.Split('\n');
-                    privateKey = string.Join(string.Empty, lines[1..^1]);
-                }
-
-                return Convert.FromBase64String(privateKey);
+                return await reader.ReadToEndAsync();
             };
 
             return options;

--- a/src/AspNet.Security.OAuth.Apple/Internal/DefaultAppleClientSecretGenerator.cs
+++ b/src/AspNet.Security.OAuth.Apple/Internal/DefaultAppleClientSecretGenerator.cs
@@ -93,7 +93,7 @@ namespace AspNet.Security.OAuth.Apple.Internal
                 Subject = new ClaimsIdentity(new[] { subject }),
             };
 
-            string pem = await context.Options.PrivateKey!(context.Options.KeyId!, context.HttpContext.RequestAborted);
+            var pem = await context.Options.PrivateKey!(context.Options.KeyId!, context.HttpContext.RequestAborted);
             string clientSecret;
 
             using (var algorithm = CreateAlgorithm(pem))
@@ -108,13 +108,13 @@ namespace AspNet.Security.OAuth.Apple.Internal
             return (clientSecret, expiresAt);
         }
 
-        private static ECDsa CreateAlgorithm(ReadOnlySpan<char> pem)
+        private static ECDsa CreateAlgorithm(ReadOnlyMemory<char> pem)
         {
             var algorithm = ECDsa.Create();
 
             try
             {
-                algorithm.ImportFromPem(pem);
+                algorithm.ImportFromPem(pem.Span);
                 return algorithm;
             }
             catch (Exception)

--- a/src/AspNet.Security.OAuth.Apple/Internal/DefaultAppleClientSecretGenerator.cs
+++ b/src/AspNet.Security.OAuth.Apple/Internal/DefaultAppleClientSecretGenerator.cs
@@ -93,10 +93,10 @@ namespace AspNet.Security.OAuth.Apple.Internal
                 Subject = new ClaimsIdentity(new[] { subject }),
             };
 
-            byte[] keyBlob = await context.Options.PrivateKeyBytes!(context.Options.KeyId!, context.HttpContext.RequestAborted);
+            string pem = await context.Options.PrivateKey!(context.Options.KeyId!, context.HttpContext.RequestAborted);
             string clientSecret;
 
-            using (var algorithm = CreateAlgorithm(keyBlob))
+            using (var algorithm = CreateAlgorithm(pem))
             {
                 tokenDescriptor.SigningCredentials = CreateSigningCredentials(context.Options.KeyId!, algorithm);
 
@@ -108,13 +108,13 @@ namespace AspNet.Security.OAuth.Apple.Internal
             return (clientSecret, expiresAt);
         }
 
-        private static ECDsa CreateAlgorithm(byte[] keyBlob)
+        private static ECDsa CreateAlgorithm(ReadOnlySpan<char> pem)
         {
             var algorithm = ECDsa.Create();
 
             try
             {
-                algorithm.ImportPkcs8PrivateKey(keyBlob, out _);
+                algorithm.ImportFromPem(pem);
                 return algorithm;
             }
             catch (Exception)

--- a/test/AspNet.Security.OAuth.Providers.Tests/Apple/AppleClientSecretGeneratorTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Apple/AppleClientSecretGeneratorTests.cs
@@ -41,7 +41,7 @@ namespace AspNet.Security.OAuth.Apple
                 options.ClientSecretExpiresAfter = TimeSpan.FromMinutes(1);
                 options.KeyId = "my-key-id";
                 options.TeamId = "my-team-id";
-                options.PrivateKeyBytes = (_, _) => TestKeys.GetPrivateKeyBytesAsync();
+                options.PrivateKey = (_, cancellationToken) => TestKeys.GetPrivateKeyAsync(cancellationToken);
             }
 
             await GenerateTokenAsync(Configure, async (context) =>
@@ -92,7 +92,7 @@ namespace AspNet.Security.OAuth.Apple
                 options.ClientSecretExpiresAfter = TimeSpan.FromSeconds(2);
                 options.KeyId = "my-key-id";
                 options.TeamId = "my-team-id";
-                options.PrivateKeyBytes = (_, _) => TestKeys.GetPrivateKeyBytesAsync();
+                options.PrivateKey = (_, cancellationToken) => TestKeys.GetPrivateKeyAsync(cancellationToken);
             }
 
             await GenerateTokenAsync(Configure, async (context) =>
@@ -127,7 +127,7 @@ namespace AspNet.Security.OAuth.Apple
                 options.ClientSecretExpiresAfter = clientSecretExpiresAfter;
                 options.KeyId = "my-key-id";
                 options.TeamId = "my-team-id";
-                options.PrivateKeyBytes = (_, _) => TestKeys.GetPrivateKeyBytesAsync();
+                options.PrivateKey = (_, cancellationToken) => TestKeys.GetPrivateKeyAsync(cancellationToken);
             }
 
             var optionsB = new AppleAuthenticationOptions()
@@ -137,7 +137,7 @@ namespace AspNet.Security.OAuth.Apple
                 SecurityTokenHandler = new JsonWebTokenHandler(),
                 KeyId = "my-other-key-id",
                 TeamId = "my-other-team-id",
-                PrivateKeyBytes = (_, _) => TestKeys.GetPrivateKeyBytesAsync(),
+                PrivateKey = (_, cancellationToken) => TestKeys.GetPrivateKeyAsync(cancellationToken),
             };
 
             await GenerateTokenAsync(ConfigureA, async (contextA) =>

--- a/test/AspNet.Security.OAuth.Providers.Tests/Apple/AppleTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Apple/AppleTests.cs
@@ -92,10 +92,10 @@ namespace AspNet.Security.OAuth.Apple
                     options.TeamId = "my-team-id";
                     options.TokenValidationParameters.ValidateLifetime = false;
                     options.ValidateTokens = true;
-                    options.PrivateKeyBytes = async (keyId, _) =>
+                    options.PrivateKey = async (keyId, cancellationToken) =>
                     {
                         Assert.Equal("my-key-id", keyId);
-                        return await TestKeys.GetPrivateKeyBytesAsync();
+                        return await TestKeys.GetPrivateKeyAsync(cancellationToken);
                     };
                 });
             }
@@ -265,7 +265,6 @@ namespace AspNet.Security.OAuth.Apple
             // Assert
             exception.InnerException.ShouldNotBeNull();
             exception.InnerException.ShouldBeOfType<InvalidOperationException>();
-            exception.InnerException!.Message.ShouldNotBeNull();
             exception.InnerException.Message.ShouldBe("No Apple ID token was returned in the OAuth token response.");
         }
 

--- a/test/AspNet.Security.OAuth.Providers.Tests/Apple/TestKeys.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Apple/TestKeys.cs
@@ -4,6 +4,7 @@
  * for more information concerning the license and the contributors participating to this project.
  */
 
+using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -12,7 +13,7 @@ namespace AspNet.Security.OAuth.Apple
 {
     internal static class TestKeys
     {
-        internal static async Task<string> GetPrivateKeyAsync(CancellationToken cancellationToken = default)
-            => await File.ReadAllTextAsync(Path.Combine("Apple", "test.p8"), cancellationToken);
+        internal static async Task<ReadOnlyMemory<char>> GetPrivateKeyAsync(CancellationToken cancellationToken = default)
+            => (await File.ReadAllTextAsync(Path.Combine("Apple", "test.p8"), cancellationToken)).AsMemory();
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Apple/TestKeys.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Apple/TestKeys.cs
@@ -4,26 +4,15 @@
  * for more information concerning the license and the contributors participating to this project.
  */
 
-using System;
 using System.IO;
-using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace AspNet.Security.OAuth.Apple
 {
     internal static class TestKeys
     {
-        internal static async Task<byte[]> GetPrivateKeyBytesAsync()
-        {
-            string content = await File.ReadAllTextAsync(Path.Combine("Apple", "test.p8"));
-
-            if (content.StartsWith("-----BEGIN PRIVATE KEY-----", StringComparison.Ordinal))
-            {
-                string[] keyLines = content.Split('\n');
-                content = string.Join(string.Empty, keyLines.Skip(1).Take(keyLines.Length - 2));
-            }
-
-            return Convert.FromBase64String(content);
-        }
+        internal static async Task<string> GetPrivateKeyAsync(CancellationToken cancellationToken = default)
+            => await File.ReadAllTextAsync(Path.Combine("Apple", "test.p8"), cancellationToken);
     }
 }


### PR DESCRIPTION
Simplify the code to load the PEM file for Sign in with Apple after feedback on https://github.com/dotnet/runtime/issues/53807.

The Apple provider already has some breaking changes for .NET 6, so would be a good time to try and simplify it as well to leverage the new PEM support added in .NET 5.

~Leaving as draft for now, as if we make this change it might be worth seeing if it can leverage the forthcoming `Secret<T>` type as it's a key (https://github.com/dotnet/designs/pull/147#issuecomment-844392771, if this is a good use case) which would make it something like this instead:~

```csharp
public Func<string, CancellationToken, Task<Secret<char>>>? PrivateKey { get; set; }
```

~which would then be used at the last-minute like this:~

```csharp
using var pem = await context.Options.PrivateKey!(context.Options.KeyId!, context.HttpContext.RequestAborted);
// ...
algorithm.ImportFromPem(pem.RevealToString());
```

~Might be overkill as it needs to read off disk as a string anyway to use the `ImportFromPem()` method.~
