### PR TITLE
Add DefaultNetCoreTargetFramework property

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,6 +3,7 @@
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 
   <PropertyGroup>
+    <DefaultNetCoreTargetFramework>net5.0</DefaultNetCoreTargetFramework>
     <LangVersion>latest</LangVersion>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/samples/Mvc.Client/Mvc.Client.csproj
+++ b/samples/Mvc.Client/Mvc.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
     <UserSecretsId>AspNet.Security.OAuth.Providers.Mvc.Client</UserSecretsId>
   </PropertyGroup>
 

--- a/src/AspNet.Security.OAuth.Alipay/AspNet.Security.OAuth.Alipay.csproj
+++ b/src/AspNet.Security.OAuth.Alipay/AspNet.Security.OAuth.Alipay.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Amazon/AspNet.Security.OAuth.Amazon.csproj
+++ b/src/AspNet.Security.OAuth.Amazon/AspNet.Security.OAuth.Amazon.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.AmoCrm/AspNet.Security.OAuth.AmoCrm.csproj
+++ b/src/AspNet.Security.OAuth.AmoCrm/AspNet.Security.OAuth.AmoCrm.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Apple/AspNet.Security.OAuth.Apple.csproj
+++ b/src/AspNet.Security.OAuth.Apple/AspNet.Security.OAuth.Apple.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.ArcGIS/AspNet.Security.OAuth.ArcGIS.csproj
+++ b/src/AspNet.Security.OAuth.ArcGIS/AspNet.Security.OAuth.ArcGIS.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Asana/AspNet.Security.OAuth.Asana.csproj
+++ b/src/AspNet.Security.OAuth.Asana/AspNet.Security.OAuth.Asana.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Autodesk/AspNet.Security.OAuth.Autodesk.csproj
+++ b/src/AspNet.Security.OAuth.Autodesk/AspNet.Security.OAuth.Autodesk.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Automatic/AspNet.Security.OAuth.Automatic.csproj
+++ b/src/AspNet.Security.OAuth.Automatic/AspNet.Security.OAuth.Automatic.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Baidu/AspNet.Security.OAuth.Baidu.csproj
+++ b/src/AspNet.Security.OAuth.Baidu/AspNet.Security.OAuth.Baidu.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Basecamp/AspNet.Security.OAuth.Basecamp.csproj
+++ b/src/AspNet.Security.OAuth.Basecamp/AspNet.Security.OAuth.Basecamp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.BattleNet/AspNet.Security.OAuth.BattleNet.csproj
+++ b/src/AspNet.Security.OAuth.BattleNet/AspNet.Security.OAuth.BattleNet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Beam/AspNet.Security.OAuth.Beam.csproj
+++ b/src/AspNet.Security.OAuth.Beam/AspNet.Security.OAuth.Beam.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Bitbucket/AspNet.Security.OAuth.Bitbucket.csproj
+++ b/src/AspNet.Security.OAuth.Bitbucket/AspNet.Security.OAuth.Bitbucket.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Buffer/AspNet.Security.OAuth.Buffer.csproj
+++ b/src/AspNet.Security.OAuth.Buffer/AspNet.Security.OAuth.Buffer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.CiscoSpark/AspNet.Security.OAuth.CiscoSpark.csproj
+++ b/src/AspNet.Security.OAuth.CiscoSpark/AspNet.Security.OAuth.CiscoSpark.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Coinbase/AspNet.Security.OAuth.Coinbase.csproj
+++ b/src/AspNet.Security.OAuth.Coinbase/AspNet.Security.OAuth.Coinbase.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Deezer/AspNet.Security.OAuth.Deezer.csproj
+++ b/src/AspNet.Security.OAuth.Deezer/AspNet.Security.OAuth.Deezer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.DeviantArt/AspNet.Security.OAuth.DeviantArt.csproj
+++ b/src/AspNet.Security.OAuth.DeviantArt/AspNet.Security.OAuth.DeviantArt.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Discord/AspNet.Security.OAuth.Discord.csproj
+++ b/src/AspNet.Security.OAuth.Discord/AspNet.Security.OAuth.Discord.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Dropbox/AspNet.Security.OAuth.Dropbox.csproj
+++ b/src/AspNet.Security.OAuth.Dropbox/AspNet.Security.OAuth.Dropbox.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.EVEOnline/AspNet.Security.OAuth.EVEOnline.csproj
+++ b/src/AspNet.Security.OAuth.EVEOnline/AspNet.Security.OAuth.EVEOnline.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.ExactOnline/AspNet.Security.OAuth.ExactOnline.csproj
+++ b/src/AspNet.Security.OAuth.ExactOnline/AspNet.Security.OAuth.ExactOnline.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Fitbit/AspNet.Security.OAuth.Fitbit.csproj
+++ b/src/AspNet.Security.OAuth.Fitbit/AspNet.Security.OAuth.Fitbit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Foursquare/AspNet.Security.OAuth.Foursquare.csproj
+++ b/src/AspNet.Security.OAuth.Foursquare/AspNet.Security.OAuth.Foursquare.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.GitHub/AspNet.Security.OAuth.GitHub.csproj
+++ b/src/AspNet.Security.OAuth.GitHub/AspNet.Security.OAuth.GitHub.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.GitLab/AspNet.Security.OAuth.GitLab.csproj
+++ b/src/AspNet.Security.OAuth.GitLab/AspNet.Security.OAuth.GitLab.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Gitee/AspNet.Security.OAuth.Gitee.csproj
+++ b/src/AspNet.Security.OAuth.Gitee/AspNet.Security.OAuth.Gitee.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Gitter/AspNet.Security.OAuth.Gitter.csproj
+++ b/src/AspNet.Security.OAuth.Gitter/AspNet.Security.OAuth.Gitter.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Harvest/AspNet.Security.OAuth.Harvest.csproj
+++ b/src/AspNet.Security.OAuth.Harvest/AspNet.Security.OAuth.Harvest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.HealthGraph/AspNet.Security.OAuth.HealthGraph.csproj
+++ b/src/AspNet.Security.OAuth.HealthGraph/AspNet.Security.OAuth.HealthGraph.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Imgur/AspNet.Security.OAuth.Imgur.csproj
+++ b/src/AspNet.Security.OAuth.Imgur/AspNet.Security.OAuth.Imgur.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Instagram/AspNet.Security.OAuth.Instagram.csproj
+++ b/src/AspNet.Security.OAuth.Instagram/AspNet.Security.OAuth.Instagram.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.KakaoTalk/AspNet.Security.OAuth.KakaoTalk.csproj
+++ b/src/AspNet.Security.OAuth.KakaoTalk/AspNet.Security.OAuth.KakaoTalk.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Keycloak/AspNet.Security.OAuth.Keycloak.csproj
+++ b/src/AspNet.Security.OAuth.Keycloak/AspNet.Security.OAuth.Keycloak.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Kloudless/AspNet.Security.OAuth.Kloudless.csproj
+++ b/src/AspNet.Security.OAuth.Kloudless/AspNet.Security.OAuth.Kloudless.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Lichess/AspNet.Security.OAuth.Lichess.csproj
+++ b/src/AspNet.Security.OAuth.Lichess/AspNet.Security.OAuth.Lichess.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Line/AspNet.Security.OAuth.Line.csproj
+++ b/src/AspNet.Security.OAuth.Line/AspNet.Security.OAuth.Line.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.LinkedIn/AspNet.Security.OAuth.LinkedIn.csproj
+++ b/src/AspNet.Security.OAuth.LinkedIn/AspNet.Security.OAuth.LinkedIn.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.MailChimp/AspNet.Security.OAuth.MailChimp.csproj
+++ b/src/AspNet.Security.OAuth.MailChimp/AspNet.Security.OAuth.MailChimp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.MailRu/AspNet.Security.OAuth.MailRu.csproj
+++ b/src/AspNet.Security.OAuth.MailRu/AspNet.Security.OAuth.MailRu.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Mixcloud/AspNet.Security.OAuth.Mixcloud.csproj
+++ b/src/AspNet.Security.OAuth.Mixcloud/AspNet.Security.OAuth.Mixcloud.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Moodle/AspNet.Security.OAuth.Moodle.csproj
+++ b/src/AspNet.Security.OAuth.Moodle/AspNet.Security.OAuth.Moodle.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Myob/AspNet.Security.OAuth.Myob.csproj
+++ b/src/AspNet.Security.OAuth.Myob/AspNet.Security.OAuth.Myob.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.NetEase/AspNet.Security.OAuth.NetEase.csproj
+++ b/src/AspNet.Security.OAuth.NetEase/AspNet.Security.OAuth.NetEase.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Nextcloud/AspNet.Security.OAuth.Nextcloud.csproj
+++ b/src/AspNet.Security.OAuth.Nextcloud/AspNet.Security.OAuth.Nextcloud.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Notion/AspNet.Security.OAuth.Notion.csproj
+++ b/src/AspNet.Security.OAuth.Notion/AspNet.Security.OAuth.Notion.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Odnoklassniki/AspNet.Security.OAuth.Odnoklassniki.csproj
+++ b/src/AspNet.Security.OAuth.Odnoklassniki/AspNet.Security.OAuth.Odnoklassniki.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Okta/AspNet.Security.OAuth.Okta.csproj
+++ b/src/AspNet.Security.OAuth.Okta/AspNet.Security.OAuth.Okta.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Onshape/AspNet.Security.OAuth.Onshape.csproj
+++ b/src/AspNet.Security.OAuth.Onshape/AspNet.Security.OAuth.Onshape.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Patreon/AspNet.Security.OAuth.Patreon.csproj
+++ b/src/AspNet.Security.OAuth.Patreon/AspNet.Security.OAuth.Patreon.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Paypal/AspNet.Security.OAuth.Paypal.csproj
+++ b/src/AspNet.Security.OAuth.Paypal/AspNet.Security.OAuth.Paypal.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.QQ/AspNet.Security.OAuth.QQ.csproj
+++ b/src/AspNet.Security.OAuth.QQ/AspNet.Security.OAuth.QQ.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Reddit/AspNet.Security.OAuth.Reddit.csproj
+++ b/src/AspNet.Security.OAuth.Reddit/AspNet.Security.OAuth.Reddit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Salesforce/AspNet.Security.OAuth.Salesforce.csproj
+++ b/src/AspNet.Security.OAuth.Salesforce/AspNet.Security.OAuth.Salesforce.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Shopify/AspNet.Security.OAuth.Shopify.csproj
+++ b/src/AspNet.Security.OAuth.Shopify/AspNet.Security.OAuth.Shopify.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Slack/AspNet.Security.OAuth.Slack.csproj
+++ b/src/AspNet.Security.OAuth.Slack/AspNet.Security.OAuth.Slack.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.SoundCloud/AspNet.Security.OAuth.SoundCloud.csproj
+++ b/src/AspNet.Security.OAuth.SoundCloud/AspNet.Security.OAuth.SoundCloud.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Spotify/AspNet.Security.OAuth.Spotify.csproj
+++ b/src/AspNet.Security.OAuth.Spotify/AspNet.Security.OAuth.Spotify.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.StackExchange/AspNet.Security.OAuth.StackExchange.csproj
+++ b/src/AspNet.Security.OAuth.StackExchange/AspNet.Security.OAuth.StackExchange.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Strava/AspNet.Security.OAuth.Strava.csproj
+++ b/src/AspNet.Security.OAuth.Strava/AspNet.Security.OAuth.Strava.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Streamlabs/AspNet.Security.OAuth.Streamlabs.csproj
+++ b/src/AspNet.Security.OAuth.Streamlabs/AspNet.Security.OAuth.Streamlabs.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
 

--- a/src/AspNet.Security.OAuth.SuperOffice/AspNet.Security.OAuth.SuperOffice.csproj
+++ b/src/AspNet.Security.OAuth.SuperOffice/AspNet.Security.OAuth.SuperOffice.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Trakt/AspNet.Security.OAuth.Trakt.csproj
+++ b/src/AspNet.Security.OAuth.Trakt/AspNet.Security.OAuth.Trakt.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Twitch/AspNet.Security.OAuth.Twitch.csproj
+++ b/src/AspNet.Security.OAuth.Twitch/AspNet.Security.OAuth.Twitch.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Untappd/AspNet.Security.OAuth.Untappd.csproj
+++ b/src/AspNet.Security.OAuth.Untappd/AspNet.Security.OAuth.Untappd.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Vimeo/AspNet.Security.OAuth.Vimeo.csproj
+++ b/src/AspNet.Security.OAuth.Vimeo/AspNet.Security.OAuth.Vimeo.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.VisualStudio/AspNet.Security.OAuth.VisualStudio.csproj
+++ b/src/AspNet.Security.OAuth.VisualStudio/AspNet.Security.OAuth.VisualStudio.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Vkontakte/AspNet.Security.OAuth.Vkontakte.csproj
+++ b/src/AspNet.Security.OAuth.Vkontakte/AspNet.Security.OAuth.Vkontakte.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Weibo/AspNet.Security.OAuth.Weibo.csproj
+++ b/src/AspNet.Security.OAuth.Weibo/AspNet.Security.OAuth.Weibo.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Weixin/AspNet.Security.OAuth.Weixin.csproj
+++ b/src/AspNet.Security.OAuth.Weixin/AspNet.Security.OAuth.Weixin.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.WordPress/AspNet.Security.OAuth.WordPress.csproj
+++ b/src/AspNet.Security.OAuth.WordPress/AspNet.Security.OAuth.WordPress.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.WorkWeixin/AspNet.Security.OAuth.WorkWeixin.csproj
+++ b/src/AspNet.Security.OAuth.WorkWeixin/AspNet.Security.OAuth.WorkWeixin.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Yahoo/AspNet.Security.OAuth.Yahoo.csproj
+++ b/src/AspNet.Security.OAuth.Yahoo/AspNet.Security.OAuth.Yahoo.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Yammer/AspNet.Security.OAuth.Yammer.csproj
+++ b/src/AspNet.Security.OAuth.Yammer/AspNet.Security.OAuth.Yammer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Yandex/AspNet.Security.OAuth.Yandex.csproj
+++ b/src/AspNet.Security.OAuth.Yandex/AspNet.Security.OAuth.Yandex.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AspNet.Security.OAuth.Zalo/AspNet.Security.OAuth.Zalo.csproj
+++ b/src/AspNet.Security.OAuth.Zalo/AspNet.Security.OAuth.Zalo.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/AspNet.Security.OAuth.Providers.Tests/AspNet.Security.OAuth.Providers.Tests.csproj
+++ b/test/AspNet.Security.OAuth.Providers.Tests/AspNet.Security.OAuth.Providers.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <RootNamespace>AspNet.Security.OAuth</RootNamespace>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <NoWarn>$(NoWarn);CA1707;CA2227</NoWarn>
@@ -37,5 +37,5 @@
       <_Parameter2>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)../../'))</_Parameter2>
     </AssemblyAttribute>
   </ItemGroup>
-  
+
 </Project>


### PR DESCRIPTION
Inspired by the ASP.NET Core repo, add a new `DefaultNetCoreTargetFramework` MSBuild property and use that to specify the target framework in each project.

This should make future changes for .NET 6 and beyond easier as we won't necessarily need to touch every project file to perform the update.
