### PR TITLE
Add support for Dropbox response_type and token_access_type params

### DIFF
--- a/AspNet.Security.OAuth.Providers.sln
+++ b/AspNet.Security.OAuth.Providers.sln
@@ -189,6 +189,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{C2CA4B38-A
 		docs\battlenet.md = docs\battlenet.md
 		docs\bitbucket.md = docs\bitbucket.md
 		docs\discord.md = docs\discord.md
+		docs\dropbox.md = docs\dropbox.md
 		docs\eveonline.md = docs\eveonline.md
 		docs\foursquare.md = docs\foursquare.md
 		docs\gitee.md = docs\gitee.md

--- a/docs/dropbox.md
+++ b/docs/dropbox.md
@@ -1,0 +1,39 @@
+# Integrating the Dropbox Provider
+
+## Example
+
+```csharp
+services.AddAuthentication(options => /* Auth configuration */)
+        .AddDropbox(options =>
+        {
+            options.ClientId = "my-client-id";
+            options.ClientSecret = "my-client-secret";
+        });
+```
+
+## Required Additional Settings
+
+_None._
+
+## Optional Settings
+
+| Property Name | Property Type | Description | Default Value |
+|:--|:--|:--|:--|
+| `AccessType` | `string?` | Sets the _token_access_type_ parameter which defines the token response.  Accepted values are `online`, `offline`, `legacy` | `null` |
+| `ResponseType` | `string?` | Sets the _response_type_ parameter, signifying the grant type requested, either `token` or `code`. | `null` |
+
+### AccessType
+
+* `online` The response will contain only a short-lived _access_token_. 
+
+* `offline` The response will contain a short-lived _access_token_ and a long-lived _refresh_token_ that can be used to request a new short-lived access token as long as a user's approval remains valid. 
+
+* `legacy` The response will default to returning a long-lived _access_token_ if they are allowed in the app console. If long-lived access tokens are disabled in the app console, this parameter defaults to `online`.
+
+### ResponseType
+
+* _(Recommended)_ The `code` flow returns a code via the _redirect_uri_ callback which should then be converted into a bearer token using the /oauth2/token call. This is the recommended flow for apps that are running on a server.
+
+  The PKCE flow is an extension of the code flow that uses dynamically generated codes instead of a secret to perform an OAuth exchange from public clients. The PKCE flow is a newer, more secure alternative to the token (implicit) flow. It is the recommended flow for client-side apps, such as mobile or JavaScript apps.
+
+* _(Legacy)_ The `token` or implicit grant flow returns the bearer token via the _redirect_uri_ callback, rather than requiring your app to make a second call to a server. This is useful for pure client-side apps, such as mobile apps or JavaScript-based apps.

--- a/docs/dropbox.md
+++ b/docs/dropbox.md
@@ -20,7 +20,6 @@ _None._
 | Property Name | Property Type | Description | Default Value |
 |:--|:--|:--|:--|
 | `AccessType` | `string?` | Sets the _token_access_type_ parameter which defines the token response.  Accepted values are `online`, `offline`, `legacy` | `null` |
-| `ResponseType` | `string?` | Sets the _response_type_ parameter, signifying the grant type requested, either `token` or `code`. | `null` |
 
 ### AccessType
 
@@ -29,11 +28,3 @@ _None._
 * `offline` The response will contain a short-lived _access_token_ and a long-lived _refresh_token_ that can be used to request a new short-lived access token as long as a user's approval remains valid. 
 
 * `legacy` The response will default to returning a long-lived _access_token_ if they are allowed in the app console. If long-lived access tokens are disabled in the app console, this parameter defaults to `online`.
-
-### ResponseType
-
-* _(Recommended)_ The `code` flow returns a code via the _redirect_uri_ callback which should then be converted into a bearer token using the /oauth2/token call. This is the recommended flow for apps that are running on a server.
-
-  The PKCE flow is an extension of the code flow that uses dynamically generated codes instead of a secret to perform an OAuth exchange from public clients. The PKCE flow is a newer, more secure alternative to the token (implicit) flow. It is the recommended flow for client-side apps, such as mobile or JavaScript apps.
-
-* _(Legacy)_ The `token` or implicit grant flow returns the bearer token via the _redirect_uri_ callback, rather than requiring your app to make a second call to a server. This is useful for pure client-side apps, such as mobile apps or JavaScript-based apps.

--- a/src/AspNet.Security.OAuth.Dropbox/DropboxAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Dropbox/DropboxAuthenticationHandler.cs
@@ -42,11 +42,6 @@ namespace AspNet.Security.OAuth.Dropbox
                 challengeUrl = QueryHelpers.AddQueryString(challengeUrl, "token_access_type", Options.AccessType);
             }
 
-            if (!string.IsNullOrEmpty(Options.ResponseType))
-            {
-                challengeUrl = QueryHelpers.AddQueryString(challengeUrl, "response_type", Options.ResponseType);
-            }
-
             return challengeUrl;
         }
 

--- a/src/AspNet.Security.OAuth.Dropbox/DropboxAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Dropbox/DropboxAuthenticationHandler.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
  * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
  * for more information concerning the license and the contributors participating to this project.
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
+using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -27,6 +28,26 @@ namespace AspNet.Security.OAuth.Dropbox
             [NotNull] ISystemClock clock)
             : base(options, logger, encoder, clock)
         {
+        }
+
+        /// <inheritdoc />
+        protected override string BuildChallengeUrl(
+            [NotNull] AuthenticationProperties properties,
+            [NotNull] string redirectUri)
+        {
+            string challengeUrl = base.BuildChallengeUrl(properties, redirectUri);
+
+            if (!string.IsNullOrEmpty(Options.AccessType))
+            {
+                challengeUrl = QueryHelpers.AddQueryString(challengeUrl, "token_access_type", Options.AccessType);
+            }
+
+            if (!string.IsNullOrEmpty(Options.ResponseType))
+            {
+                challengeUrl = QueryHelpers.AddQueryString(challengeUrl, "response_type", Options.ResponseType);
+            }
+
+            return challengeUrl;
         }
 
         protected override async Task<AuthenticationTicket> CreateTicketAsync(

--- a/src/AspNet.Security.OAuth.Dropbox/DropboxAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Dropbox/DropboxAuthenticationOptions.cs
@@ -20,11 +20,6 @@ namespace AspNet.Security.OAuth.Dropbox
         /// </summary>
         public string? AccessType { get; set; }
 
-        /// <summary>
-        /// Gets or sets the Response Type requested from Dropbox:  Token or Code
-        /// </summary>
-        public string? ResponseType { get; set; }
-
         public DropboxAuthenticationOptions()
         {
             ClaimsIssuer = DropboxAuthenticationDefaults.Issuer;

--- a/src/AspNet.Security.OAuth.Dropbox/DropboxAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Dropbox/DropboxAuthenticationOptions.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
  * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
  * for more information concerning the license and the contributors participating to this project.
@@ -15,6 +15,16 @@ namespace AspNet.Security.OAuth.Dropbox
     /// </summary>
     public class DropboxAuthenticationOptions : OAuthOptions
     {
+        /// <summary>
+        /// Gets or sets what the response type from Dropbox should be:  Online, Offline or Legacy
+        /// </summary>
+        public string? AccessType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Response Type requested from Dropbox:  Token or Code
+        /// </summary>
+        public string? ResponseType { get; set; }
+
         public DropboxAuthenticationOptions()
         {
             ClaimsIssuer = DropboxAuthenticationDefaults.Issuer;

--- a/src/AspNet.Security.OAuth.Dropbox/DropboxAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Dropbox/DropboxAuthenticationOptions.cs
@@ -16,7 +16,7 @@ namespace AspNet.Security.OAuth.Dropbox
     public class DropboxAuthenticationOptions : OAuthOptions
     {
         /// <summary>
-        /// Gets or sets what the response type from Dropbox should be:  Online, Offline or Legacy
+        /// Gets or sets what the response type from Dropbox should be: Online, Offline or Legacy.
         /// </summary>
         public string? AccessType { get; set; }
 

--- a/src/AspNet.Security.OAuth.Dropbox/DropboxAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Dropbox/DropboxAuthenticationOptions.cs
@@ -16,7 +16,7 @@ namespace AspNet.Security.OAuth.Dropbox
     public class DropboxAuthenticationOptions : OAuthOptions
     {
         /// <summary>
-        /// Gets or sets what the response type from Dropbox should be: Online, Offline or Legacy.
+        /// Gets or sets what the response type from Dropbox should be: online, offline or legacy.
         /// </summary>
         public string? AccessType { get; set; }
 

--- a/test/AspNet.Security.OAuth.Providers.Tests/Dropbox/DropboxTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Dropbox/DropboxTests.cs
@@ -63,7 +63,7 @@ namespace AspNet.Security.OAuth.Dropbox
                     {
                         OnRedirectToAuthorizationEndpoint = ctx =>
                         {
-                            accessTypeIsSet = ctx.RedirectUri.Contains($"token_access_type={value}", StringComparison.InvariantCulture);
+                            accessTypeIsSet = ctx.RedirectUri.Contains($"token_access_type={value}", StringComparison.OrdinalIgnoreCase);
                             ctx.Response.Redirect(ctx.RedirectUri);
                             return Task.CompletedTask;
                         }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Dropbox/DropboxTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Dropbox/DropboxTests.cs
@@ -4,10 +4,13 @@
  * for more information concerning the license and the contributors participating to this project.
  */
 
+using System;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.OAuth;
 using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -41,6 +44,72 @@ namespace AspNet.Security.OAuth.Dropbox
 
             // Assert
             AssertClaim(claims, claimType, claimValue);
+        }
+
+        [Theory]
+        [InlineData("offline")]
+        [InlineData("online")]
+        [InlineData("legacy")]
+        public async Task RedirectUri_Contains_Access_Type(string value)
+        {
+            bool accessTypeIsSet = false;
+
+            void ConfigureServices(IServiceCollection services)
+            {
+                services.PostConfigureAll<DropboxAuthenticationOptions>((options) =>
+                {
+                    options.AccessType = value;
+                    options.Events = new OAuthEvents
+                    {
+                        OnRedirectToAuthorizationEndpoint = ctx =>
+                        {
+                            accessTypeIsSet = ctx.RedirectUri.Contains($"token_access_type={value}", StringComparison.InvariantCulture);
+                            ctx.Response.Redirect(ctx.RedirectUri);
+                            return Task.CompletedTask;
+                        }
+                    };
+                });
+            }
+
+            // Arrange
+            using var server = CreateTestServer(ConfigureServices);
+
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            accessTypeIsSet.ShouldBeTrue();
+        }
+
+        [Fact]
+        public async Task Response_Contains_Refresh_Token()
+        {
+            bool refreshTokenIsPresent = false;
+
+            void ConfigureServices(IServiceCollection services)
+            {
+                services.PostConfigureAll<DropboxAuthenticationOptions>((options) =>
+                {
+                    options.AccessType = "offline";
+                    options.Events = new OAuthEvents
+                    {
+                        OnCreatingTicket = ctx =>
+                        {
+                            refreshTokenIsPresent = !string.IsNullOrEmpty(ctx.RefreshToken);
+                            return Task.CompletedTask;
+                        }
+                    };
+                });
+            }
+
+            // Arrange
+            using var server = CreateTestServer(ConfigureServices);
+
+            // Act
+            var claims = await AuthenticateUserAsync(server);
+
+            // Assert
+            refreshTokenIsPresent.ShouldBeTrue();
         }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Dropbox/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Dropbox/bundle.json
@@ -9,6 +9,7 @@
       "contentJson": {
         "access_token": "ABCDEFG",
         "token_type": "bearer",
+        "refresh_token": "secret-refresh-token",
         "account_id": "dbid:AAH4f99T0taONIb-OurWxbNQ6ywGRopQngc",
         "uid": "12345"
       }


### PR DESCRIPTION
<!--

Summarize the changes this Pull Request makes.

Please include a reference to a GitHub issue if appropriate.
It is not necessary to create a new issue just to open a Pull Request.

If adding a new provider, please ensure you have included appropriate test(s).

For new providers, a package with the same ID must not already exist in NuGet.org.
If it does, you must be the owner of the package and agree to transfer ownership
of the package to the [aspnet-contrib](https://www.nuget.org/profiles/aspnet-contrib)
organisation after the Pull Request is merged so we can take over publishing of
the provider from our Continuous Integration.

-->

This pull request address Feature Request #578 and adds support for the Dropbox token_access_type and response_type parameters:

**ResponseType** allows specification of the grant type. Per the [documentation](https://www.dropbox.com/developers/documentation/http/documentation):

> The grant type requested, either token or code. 

**AccessType** allows for the ability to request offline access and receive refresh_tokens with authentication tokens.   Per the [documentation](https://www.dropbox.com/developers/documentation/http/documentation):

>  If this parameter is set to offline, then the access token payload returned by a successful /oauth2/token call will contain a short-lived access_token and a long-lived refresh_token that can be used to request a new short-lived access token as long as a user's approval remains valid. If set to online then only a short-lived access_token will be returned. If omitted, the response will default to returning a long-lived access_token if they are allowed in the app console. If long-lived access tokens are disabled in the app console, this parameter defaults to online
