### PR TITLE
Remove claim for Discord avatar

### DIFF
--- a/docs/discord.md
+++ b/docs/discord.md
@@ -25,7 +25,7 @@ _None._
 
 Versions of the Discord provider before version `6.0.0` would automatically map the user's avatar URL as the `urn:discord:avatar:url` claim.
 
-This functionality is no longer built-in (see #584 and #585), but can be added to your application with some extra code similar to that shown in the sample below.
+This functionality is no longer built-in (see [#584](https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/issues/584) and [#585](https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/pull/585)), but can be added to your application with some extra code similar to that shown in the sample below.
 
 ```csharp
 services.AddAuthentication(options => /* Auth configuration */)

--- a/docs/discord.md
+++ b/docs/discord.md
@@ -20,3 +20,26 @@ _None._
 | Property Name | Property Type | Description | Default Value |
 |:--|:--|:--|:--|
 | `Prompt` | `string?` | The value to use for the `prompt` query string parameter when making HTTP requests to the authorization endpoint. | `null` |
+
+## Avatars as Claims
+
+Versions of the Discord provider before version `6.0.0` would automatically map the user's avatar URL as the `urn:discord:avatar:url` claim.
+
+This functionality is no longer built-in (see #584 and #585), but can be added to your application with some extra code similar to that shown in the sample below.
+
+```csharp
+services.AddAuthentication(options => /* Auth configuration */)
+        .AddDiscord(options =>
+        {
+            options.ClientId = "my-client-id";
+            options.ClientSecret = "my-client-secret";
+
+            options.ClaimActions.MapCustomJson("urn:discord:avatar:url", user =>
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    "https://cdn.discordapp.com/avatars/{0}/{1}.{2}",
+                    user.GetString("id"),
+                    user.GetString("avatar"),
+                    user.GetString("avatar").StartsWith("a_") ? "gif" : "png"));
+        });
+```

--- a/docs/discord.md
+++ b/docs/discord.md
@@ -19,6 +19,4 @@ _None._
 
 | Property Name | Property Type | Description | Default Value |
 |:--|:--|:--|:--|
-| `DiscordAvatarFormat` | `string` | Gets or sets the URL format string to use for user avatar images. | `DiscordAuthenticationConstants.Urls.AvatarUrlFormat` |
-| `DiscordCdn` | `string` | The URL to use for the Discord CDN. | `DiscordAuthenticationConstants.Urls.DiscordCdn` |
 | `Prompt` | `string?` | The value to use for the `prompt` query string parameter when making HTTP requests to the authorization endpoint. | `null` |

--- a/src/AspNet.Security.OAuth.Discord/DiscordAuthenticationConstants.cs
+++ b/src/AspNet.Security.OAuth.Discord/DiscordAuthenticationConstants.cs
@@ -11,16 +11,9 @@ namespace AspNet.Security.OAuth.Discord
     /// </summary>
     public static class DiscordAuthenticationConstants
     {
-        public static class Urls
-        {
-            public const string DiscordCdn = "https://cdn.discordapp.com";
-            public const string AvatarUrlFormat = "{0}/avatars/{1}/{2}.png";
-        }
-
         public static class Claims
         {
             public const string AvatarHash = "urn:discord:avatar:hash";
-            public const string AvatarUrl = "urn:discord:avatar:url";
             public const string Discriminator = "urn:discord:user:discriminator";
         }
 

--- a/src/AspNet.Security.OAuth.Discord/DiscordAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Discord/DiscordAuthenticationOptions.cs
@@ -4,7 +4,6 @@
  * for more information concerning the license and the contributors participating to this project.
  */
 
-using System.Globalization;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
@@ -17,18 +16,6 @@ namespace AspNet.Security.OAuth.Discord
     /// </summary>
     public class DiscordAuthenticationOptions : OAuthOptions
     {
-        /// <summary>
-        /// Gets or sets the root Discord CDN URL path. The default value is <see cref="Urls.DiscordCdn"/>.
-        /// </summary>
-        public string DiscordCdn { get; set; } = Urls.DiscordCdn;
-
-        /// <summary>
-        /// Gets or sets the URL format string for the user avatar URL, using <see cref="string.Format(System.IFormatProvider?, string, object?[])"/>.
-        /// Substitute <c>{0}</c> for <see cref="DiscordCdn"/>, <c>{1}</c> for the user ID and <c>{2}</c> for the Avatar hash.
-        /// The default value is <see cref="Urls.AvatarUrlFormat"/>.
-        /// </summary>
-        public string DiscordAvatarFormat { get; set; } = Urls.AvatarUrlFormat;
-
         /// <summary>
         /// Gets or sets a value which controls how the authorization flow handles existing authorizations.
         /// The default value of this property is <see langword="null"/> and the <c>prompt</c> query string
@@ -52,13 +39,6 @@ namespace AspNet.Security.OAuth.Discord
             ClaimActions.MapJsonKey(ClaimTypes.Email, "email");
             ClaimActions.MapJsonKey(Claims.AvatarHash, "avatar");
             ClaimActions.MapJsonKey(Claims.Discriminator, "discriminator");
-            ClaimActions.MapCustomJson(Claims.AvatarUrl, user =>
-                string.Format(
-                    CultureInfo.InvariantCulture,
-                    DiscordAvatarFormat,
-                    DiscordCdn.TrimEnd('/'),
-                    user.GetString("id"),
-                    user.GetString("avatar")));
 
             Scope.Add("identify");
         }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Discord/DiscordTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Discord/DiscordTests.cs
@@ -37,7 +37,6 @@ namespace AspNet.Security.OAuth.Discord
         [InlineData(ClaimTypes.Email, "john@john-smith.local")]
         [InlineData(Claims.Discriminator, "1234")]
         [InlineData(Claims.AvatarHash, "dummy-avatar-hash")]
-        [InlineData(Claims.AvatarUrl, "https://cdn.discordapp.com/avatars/my-id/dummy-avatar-hash.png")]
         public async Task Can_Sign_In_Using_Discord(string claimType, string claimValue)
         {
             // Arrange


### PR DESCRIPTION
Rather than maintain logic to understand how Discord builds up avatar URLs and handles different image formats, this PR removes the computed "avatar URL" claim for the v6 release while we have the opportunity to make breaking changes.

Consumers can instead author their own `MapCustomJson(...)` on the `ClaimActions` and derive the URI based on their own requirements.

As this is pretty easy to do using the extensibility that already exists, I think this is a long-term more preferable and maintainable solution than us trying to keep in step with whatever it is that Discord is doing for their avatar image storage.

If we decide this is the route we want to go down, I'll add an example implementation that mirrors what previous versions did with a tweak to support the animated case into the Markdown document. Users can then copy-paste that into their app configuration if they need it.

We could also optionally add `[Obsolete]` to these properties in the dev branch for v5 to give some advance notice to it being removed in v6.

Relates to #584.
