### PR TITLE
Bug Fix: CreatingTicket not using properly initialized event

### DIFF
--- a/src/AspNet.Security.OAuth.AdobeIO/AdobeIOAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.AdobeIO/AdobeIOAuthenticationHandler.cs
@@ -61,7 +61,7 @@ namespace AspNet.Security.OAuth.AdobeIO
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
 

--- a/src/AspNet.Security.OAuth.Alipay/AlipayAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Alipay/AlipayAuthenticationHandler.cs
@@ -155,7 +155,7 @@ namespace AspNet.Security.OAuth.Alipay
 
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
 
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }

--- a/src/AspNet.Security.OAuth.Amazon/AmazonAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Amazon/AmazonAuthenticationHandler.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
  * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
  * for more information concerning the license and the contributors participating to this project.
@@ -75,7 +75,7 @@ namespace AspNet.Security.OAuth.Amazon
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
     }

--- a/src/AspNet.Security.OAuth.AmoCrm/AmoCrmAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.AmoCrm/AmoCrmAuthenticationHandler.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
  * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
  * for more information concerning the license and the contributors participating to this project.
@@ -69,7 +69,7 @@ namespace AspNet.Security.OAuth.AmoCrm
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
     }

--- a/src/AspNet.Security.OAuth.Apple/AppleAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Apple/AppleAuthenticationHandler.cs
@@ -111,7 +111,7 @@ namespace AspNet.Security.OAuth.Apple
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, tokens.Response.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
 

--- a/src/AspNet.Security.OAuth.ArcGIS/ArcGISAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.ArcGIS/ArcGISAuthenticationHandler.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
  * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
  * for more information concerning the license and the contributors participating to this project.
@@ -67,7 +67,7 @@ namespace AspNet.Security.OAuth.ArcGIS
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
     }

--- a/src/AspNet.Security.OAuth.Asana/AsanaAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Asana/AsanaAuthenticationHandler.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
  * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
  * for more information concerning the license and the contributors participating to this project.
@@ -56,7 +56,7 @@ namespace AspNet.Security.OAuth.Asana
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions(payload.RootElement.GetProperty("data"));
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
     }

--- a/src/AspNet.Security.OAuth.Autodesk/AutodeskAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Autodesk/AutodeskAuthenticationHandler.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
  * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
  * for more information concerning the license and the contributors participating to this project.
@@ -56,7 +56,7 @@ namespace AspNet.Security.OAuth.Autodesk
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
     }

--- a/src/AspNet.Security.OAuth.Automatic/AutomaticAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Automatic/AutomaticAuthenticationHandler.cs
@@ -58,7 +58,7 @@ namespace AspNet.Security.OAuth.Automatic
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
 

--- a/src/AspNet.Security.OAuth.Baidu/BaiduAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Baidu/BaiduAuthenticationHandler.cs
@@ -58,7 +58,7 @@ namespace AspNet.Security.OAuth.Baidu
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
     }

--- a/src/AspNet.Security.OAuth.Basecamp/BasecampAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Basecamp/BasecampAuthenticationHandler.cs
@@ -56,7 +56,7 @@ namespace AspNet.Security.OAuth.Basecamp
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
     }

--- a/src/AspNet.Security.OAuth.BattleNet/BattleNetAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.BattleNet/BattleNetAuthenticationHandler.cs
@@ -58,7 +58,7 @@ namespace AspNet.Security.OAuth.BattleNet
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
     }

--- a/src/AspNet.Security.OAuth.Beam/BeamAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Beam/BeamAuthenticationHandler.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
  * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
  * for more information concerning the license and the contributors participating to this project.
@@ -56,7 +56,7 @@ namespace AspNet.Security.OAuth.Beam
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
     }

--- a/src/AspNet.Security.OAuth.Bitbucket/BitbucketAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Bitbucket/BitbucketAuthenticationHandler.cs
@@ -71,7 +71,7 @@ namespace AspNet.Security.OAuth.Bitbucket
                 }
             }
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
 

--- a/src/AspNet.Security.OAuth.Buffer/BufferAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Buffer/BufferAuthenticationHandler.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
  * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
  * for more information concerning the license and the contributors participating to this project.
@@ -56,7 +56,7 @@ namespace AspNet.Security.OAuth.Buffer
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
     }

--- a/src/AspNet.Security.OAuth.CiscoSpark/CiscoSparkAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.CiscoSpark/CiscoSparkAuthenticationHandler.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
  * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
  * for more information concerning the license and the contributors participating to this project.
@@ -56,7 +56,7 @@ namespace AspNet.Security.OAuth.CiscoSpark
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
     }

--- a/src/AspNet.Security.OAuth.Coinbase/CoinbaseAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Coinbase/CoinbaseAuthenticationHandler.cs
@@ -56,7 +56,7 @@ namespace AspNet.Security.OAuth.Coinbase
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement.GetProperty("data"));
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
     }

--- a/src/AspNet.Security.OAuth.Deezer/DeezerAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Deezer/DeezerAuthenticationHandler.cs
@@ -103,7 +103,7 @@ namespace AspNet.Security.OAuth.Deezer
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
 

--- a/src/AspNet.Security.OAuth.DeviantArt/DeviantArtAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.DeviantArt/DeviantArtAuthenticationHandler.cs
@@ -56,7 +56,7 @@ namespace AspNet.Security.OAuth.DeviantArt
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
     }

--- a/src/AspNet.Security.OAuth.Discord/DiscordAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Discord/DiscordAuthenticationHandler.cs
@@ -73,7 +73,7 @@ namespace AspNet.Security.OAuth.Discord
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
     }

--- a/src/AspNet.Security.OAuth.Dropbox/DropboxAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Dropbox/DropboxAuthenticationHandler.cs
@@ -72,7 +72,7 @@ namespace AspNet.Security.OAuth.Dropbox
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
     }

--- a/src/AspNet.Security.OAuth.EVEOnline/EVEOnlineAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.EVEOnline/EVEOnlineAuthenticationHandler.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
  * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
  * for more information concerning the license and the contributors participating to this project.
@@ -56,7 +56,7 @@ namespace AspNet.Security.OAuth.EVEOnline
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
     }

--- a/src/AspNet.Security.OAuth.ExactOnline/ExactOnlineAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.ExactOnline/ExactOnlineAuthenticationHandler.cs
@@ -63,7 +63,7 @@ namespace AspNet.Security.OAuth.ExactOnline
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions(user);
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
     }

--- a/src/AspNet.Security.OAuth.Fitbit/FitbitAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Fitbit/FitbitAuthenticationHandler.cs
@@ -59,7 +59,7 @@ namespace AspNet.Security.OAuth.Fitbit
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions(payload.RootElement.GetProperty("user"));
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
 

--- a/src/AspNet.Security.OAuth.Foursquare/FoursquareAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Foursquare/FoursquareAuthenticationHandler.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
  * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
  * for more information concerning the license and the contributors participating to this project.
@@ -72,7 +72,7 @@ namespace AspNet.Security.OAuth.Foursquare
                 context.RunClaimActions();
             }
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
     }

--- a/src/AspNet.Security.OAuth.GitHub/GitHubAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.GitHub/GitHubAuthenticationHandler.cs
@@ -71,7 +71,7 @@ namespace AspNet.Security.OAuth.GitHub
                 }
             }
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
 

--- a/src/AspNet.Security.OAuth.GitLab/GitLabAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.GitLab/GitLabAuthenticationHandler.cs
@@ -57,7 +57,7 @@ namespace AspNet.Security.OAuth.GitLab
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
     }

--- a/src/AspNet.Security.OAuth.Gitee/GiteeAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Gitee/GiteeAuthenticationHandler.cs
@@ -71,7 +71,7 @@ namespace AspNet.Security.OAuth.Gitee
                 }
             }
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
 

--- a/src/AspNet.Security.OAuth.Gitter/GitterAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Gitter/GitterAuthenticationHandler.cs
@@ -56,7 +56,7 @@ namespace AspNet.Security.OAuth.Gitter
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
     }

--- a/src/AspNet.Security.OAuth.Harvest/HarvestAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Harvest/HarvestAuthenticationHandler.cs
@@ -56,7 +56,7 @@ namespace AspNet.Security.OAuth.Harvest
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
     }

--- a/src/AspNet.Security.OAuth.HealthGraph/HealthGraphAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.HealthGraph/HealthGraphAuthenticationHandler.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
  * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
  * for more information concerning the license and the contributors participating to this project.
@@ -56,7 +56,7 @@ namespace AspNet.Security.OAuth.HealthGraph
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
     }

--- a/src/AspNet.Security.OAuth.Imgur/ImgurAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Imgur/ImgurAuthenticationHandler.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
  * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
  * for more information concerning the license and the contributors participating to this project.
@@ -56,7 +56,7 @@ namespace AspNet.Security.OAuth.Imgur
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions(payload.RootElement.GetProperty("data"));
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
     }

--- a/src/AspNet.Security.OAuth.Instagram/InstagramAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Instagram/InstagramAuthenticationHandler.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
  * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
  * for more information concerning the license and the contributors participating to this project.
@@ -64,7 +64,7 @@ namespace AspNet.Security.OAuth.Instagram
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
     }

--- a/src/AspNet.Security.OAuth.KakaoTalk/KakaoTalkAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.KakaoTalk/KakaoTalkAuthenticationHandler.cs
@@ -39,7 +39,7 @@ namespace AspNet.Security.OAuth.KakaoTalk
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, userProfile.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
 

--- a/src/AspNet.Security.OAuth.Keycloak/KeycloakAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Keycloak/KeycloakAuthenticationHandler.cs
@@ -71,7 +71,7 @@ namespace AspNet.Security.OAuth.Keycloak
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
     }

--- a/src/AspNet.Security.OAuth.Kloudless/KloudlessAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Kloudless/KloudlessAuthenticationHandler.cs
@@ -70,7 +70,7 @@ namespace AspNet.Security.OAuth.Kloudless
 
             context.RunClaimActions(accounts[0]);
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
     }

--- a/src/AspNet.Security.OAuth.Lichess/LichessAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Lichess/LichessAuthenticationHandler.cs
@@ -62,7 +62,7 @@ namespace AspNet.Security.OAuth.Lichess
                 context.RunClaimActions(emailPayload.RootElement);
             }
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
 

--- a/src/AspNet.Security.OAuth.Line/LineAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Line/LineAuthenticationHandler.cs
@@ -111,7 +111,7 @@ namespace AspNet.Security.OAuth.Line
                 }
             }
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
 

--- a/src/AspNet.Security.OAuth.LinkedIn/LinkedInAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.LinkedIn/LinkedInAuthenticationHandler.cs
@@ -81,7 +81,7 @@ namespace AspNet.Security.OAuth.LinkedIn
                 }
             }
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
 

--- a/src/AspNet.Security.OAuth.MailChimp/MailChimpAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.MailChimp/MailChimpAuthenticationHandler.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
  * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
  * for more information concerning the license and the contributors participating to this project.
@@ -56,7 +56,7 @@ namespace AspNet.Security.OAuth.MailChimp
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
     }

--- a/src/AspNet.Security.OAuth.MailRu/MailRuAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.MailRu/MailRuAuthenticationHandler.cs
@@ -58,7 +58,7 @@ namespace AspNet.Security.OAuth.MailRu
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
     }

--- a/src/AspNet.Security.OAuth.Mixcloud/MixcloudAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Mixcloud/MixcloudAuthenticationHandler.cs
@@ -235,7 +235,7 @@ namespace AspNet.Security.OAuth.Mixcloud
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
     }

--- a/src/AspNet.Security.OAuth.Moodle/MoodleAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Moodle/MoodleAuthenticationHandler.cs
@@ -56,7 +56,7 @@ namespace AspNet.Security.OAuth.Moodle
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
     }

--- a/src/AspNet.Security.OAuth.Myob/MyobAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Myob/MyobAuthenticationHandler.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
  * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
  * for more information concerning the license and the contributors participating to this project.
@@ -39,7 +39,7 @@ namespace AspNet.Security.OAuth.Myob
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, user);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
     }

--- a/src/AspNet.Security.OAuth.NetEase/NetEaseAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.NetEase/NetEaseAuthenticationHandler.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
  * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
  * for more information concerning the license and the contributors participating to this project.
@@ -56,7 +56,7 @@ namespace AspNet.Security.OAuth.NetEase
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
     }

--- a/src/AspNet.Security.OAuth.Nextcloud/NextcloudAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Nextcloud/NextcloudAuthenticationHandler.cs
@@ -61,7 +61,7 @@ namespace AspNet.Security.OAuth.Nextcloud
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
     }

--- a/src/AspNet.Security.OAuth.Notion/NotionAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Notion/NotionAuthenticationHandler.cs
@@ -90,7 +90,7 @@ namespace AspNet.Security.OAuth.Notion
                 tokens.Response.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
 

--- a/src/AspNet.Security.OAuth.Odnoklassniki/OdnoklassnikiAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Odnoklassniki/OdnoklassnikiAuthenticationHandler.cs
@@ -72,7 +72,7 @@ namespace AspNet.Security.OAuth.Odnoklassniki
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
 

--- a/src/AspNet.Security.OAuth.Okta/OktaAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Okta/OktaAuthenticationHandler.cs
@@ -69,7 +69,7 @@ namespace AspNet.Security.OAuth.Okta
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
     }

--- a/src/AspNet.Security.OAuth.Onshape/OnshapeAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Onshape/OnshapeAuthenticationHandler.cs
@@ -56,7 +56,7 @@ namespace AspNet.Security.OAuth.Onshape
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
     }

--- a/src/AspNet.Security.OAuth.Patreon/PatreonAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Patreon/PatreonAuthenticationHandler.cs
@@ -69,7 +69,7 @@ namespace AspNet.Security.OAuth.Patreon
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions(payload.RootElement.GetProperty("data"));
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
     }

--- a/src/AspNet.Security.OAuth.Paypal/PaypalAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Paypal/PaypalAuthenticationHandler.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
  * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
  * for more information concerning the license and the contributors participating to this project.
@@ -56,7 +56,7 @@ namespace AspNet.Security.OAuth.Paypal
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
     }

--- a/src/AspNet.Security.OAuth.QQ/QQAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.QQ/QQAuthenticationHandler.cs
@@ -87,7 +87,7 @@ namespace AspNet.Security.OAuth.QQ
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
 

--- a/src/AspNet.Security.OAuth.QuickBooks/QuickBooksAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.QuickBooks/QuickBooksAuthenticationHandler.cs
@@ -60,7 +60,7 @@ namespace AspNet.Security.OAuth.QuickBooks
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
     }

--- a/src/AspNet.Security.OAuth.Reddit/RedditAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Reddit/RedditAuthenticationHandler.cs
@@ -67,7 +67,7 @@ namespace AspNet.Security.OAuth.Reddit
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
 

--- a/src/AspNet.Security.OAuth.Salesforce/SalesforceAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Salesforce/SalesforceAuthenticationHandler.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
  * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
  * for more information concerning the license and the contributors participating to this project.
@@ -59,7 +59,7 @@ namespace AspNet.Security.OAuth.Salesforce
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
     }

--- a/src/AspNet.Security.OAuth.Shopify/ShopifyAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Shopify/ShopifyAuthenticationHandler.cs
@@ -88,7 +88,7 @@ namespace AspNet.Security.OAuth.Shopify
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
 

--- a/src/AspNet.Security.OAuth.Slack/SlackAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Slack/SlackAuthenticationHandler.cs
@@ -58,7 +58,7 @@ namespace AspNet.Security.OAuth.Slack
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
     }

--- a/src/AspNet.Security.OAuth.SoundCloud/SoundCloudAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.SoundCloud/SoundCloudAuthenticationHandler.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
  * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
  * for more information concerning the license and the contributors participating to this project.
@@ -58,7 +58,7 @@ namespace AspNet.Security.OAuth.SoundCloud
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
     }

--- a/src/AspNet.Security.OAuth.Spotify/SpotifyAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Spotify/SpotifyAuthenticationHandler.cs
@@ -56,7 +56,7 @@ namespace AspNet.Security.OAuth.Spotify
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
     }

--- a/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationHandler.cs
@@ -80,7 +80,7 @@ namespace AspNet.Security.OAuth.StackExchange
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions(payload.RootElement.GetProperty("items").EnumerateArray().First());
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
 

--- a/src/AspNet.Security.OAuth.Strava/StravaAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Strava/StravaAuthenticationHandler.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
  * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
  * for more information concerning the license and the contributors participating to this project.
@@ -59,7 +59,7 @@ namespace AspNet.Security.OAuth.Strava
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
 

--- a/src/AspNet.Security.OAuth.Streamlabs/StreamlabsAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Streamlabs/StreamlabsAuthenticationHandler.cs
@@ -68,7 +68,7 @@ namespace AspNet.Security.OAuth.Streamlabs
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
     }

--- a/src/AspNet.Security.OAuth.Trakt/TraktAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Trakt/TraktAuthenticationHandler.cs
@@ -59,7 +59,7 @@ namespace AspNet.Security.OAuth.Trakt
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
     }

--- a/src/AspNet.Security.OAuth.Twitch/TwitchAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Twitch/TwitchAuthenticationHandler.cs
@@ -70,7 +70,7 @@ namespace AspNet.Security.OAuth.Twitch
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
     }

--- a/src/AspNet.Security.OAuth.Untappd/UntappdAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Untappd/UntappdAuthenticationHandler.cs
@@ -114,7 +114,7 @@ namespace AspNet.Security.OAuth.Untappd
 
             context.RunClaimActions(payload.RootElement.GetProperty("response").GetProperty("user"));
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
     }

--- a/src/AspNet.Security.OAuth.Vimeo/VimeoAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Vimeo/VimeoAuthenticationHandler.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
  * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
  * for more information concerning the license and the contributors participating to this project.
@@ -56,7 +56,7 @@ namespace AspNet.Security.OAuth.Vimeo
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
     }

--- a/src/AspNet.Security.OAuth.VisualStudio/VisualStudioAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.VisualStudio/VisualStudioAuthenticationHandler.cs
@@ -59,7 +59,7 @@ namespace AspNet.Security.OAuth.VisualStudio
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
 

--- a/src/AspNet.Security.OAuth.Vkontakte/VkontakteAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Vkontakte/VkontakteAuthenticationHandler.cs
@@ -70,7 +70,7 @@ namespace AspNet.Security.OAuth.Vkontakte
             // Re-run to get the email claim from the tokens response
             context.RunClaimActions(tokens.Response.RootElement);
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
     }

--- a/src/AspNet.Security.OAuth.Weibo/WeiboAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Weibo/WeiboAuthenticationHandler.cs
@@ -78,7 +78,7 @@ namespace AspNet.Security.OAuth.Weibo
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
 

--- a/src/AspNet.Security.OAuth.Weixin/WeixinAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Weixin/WeixinAuthenticationHandler.cs
@@ -93,7 +93,7 @@ namespace AspNet.Security.OAuth.Weixin
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
 

--- a/src/AspNet.Security.OAuth.WordPress/WordPressAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.WordPress/WordPressAuthenticationHandler.cs
@@ -56,7 +56,7 @@ namespace AspNet.Security.OAuth.WordPress
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
     }

--- a/src/AspNet.Security.OAuth.WorkWeixin/WorkWeixinAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.WorkWeixin/WorkWeixinAuthenticationHandler.cs
@@ -80,7 +80,7 @@ namespace AspNet.Security.OAuth.WorkWeixin
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
 

--- a/src/AspNet.Security.OAuth.Yahoo/YahooAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Yahoo/YahooAuthenticationHandler.cs
@@ -59,7 +59,7 @@ namespace AspNet.Security.OAuth.Yahoo
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions(payload.RootElement);
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
 

--- a/src/AspNet.Security.OAuth.Yammer/YammerAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Yammer/YammerAuthenticationHandler.cs
@@ -58,7 +58,7 @@ namespace AspNet.Security.OAuth.Yammer
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
 
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }

--- a/src/AspNet.Security.OAuth.Yandex/YandexAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Yandex/YandexAuthenticationHandler.cs
@@ -59,7 +59,7 @@ namespace AspNet.Security.OAuth.Yandex
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
 

--- a/src/AspNet.Security.OAuth.Zalo/ZaloAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Zalo/ZaloAuthenticationHandler.cs
@@ -62,7 +62,7 @@ namespace AspNet.Security.OAuth.Zalo
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
 

--- a/src/AspNet.Security.OAuth.Zendesk/ZendeskAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Zendesk/ZendeskAuthenticationHandler.cs
@@ -56,7 +56,7 @@ namespace AspNet.Security.OAuth.Zendesk
             var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement.GetProperty("user"));
             context.RunClaimActions();
 
-            await Options.Events.CreatingTicket(context);
+            await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
         }
     }


### PR DESCRIPTION
## The bug
Today as I was working on my own project, I noticed that after assigning `DiscordAuthenticationOptions.EventsType`, the custom events class gets properly initialized with a scope, but `CreatingTicket` method is not triggered - while `DiscordAuthenticationOptions.Events.OnCreatingTicket` delegate is.

## Cause
After some investigation I noticed that the cause for this is the fact that each of the providers in the library calls `Options.Events.CreatingTicket` directly. Doing it that way completely ignores the instance generated from `EventsType` property.

## Solution
Looking into source code of base class [AuhenticationHandler<TOptions>](https://github.com/aspnet/Security/blob/master/src/Microsoft.AspNetCore.Authentication/AuthenticationHandler.cs), I noticed that `InitializeEventsAsync` async method properly creates an instance and assigns it to `Events` property. Therefore, using `Events.OnCreatingTicket` instead of `Options.Events.OnCreatingTicket` in the Provider solves the issue.

### Unit Tests
Unit tests all ran successfully.