### PR TITLE
Fix Keycloak throwing exception for Secret Key if we are using public access type

### DIFF
--- a/src/AspNet.Security.OAuth.Keycloak/KeycloakAuthenticationAccessType.cs
+++ b/src/AspNet.Security.OAuth.Keycloak/KeycloakAuthenticationAccessType.cs
@@ -1,0 +1,13 @@
+﻿// Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+// See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+// for more information concerning the license and the contributors participating to this project.
+
+namespace AspNet.Security.OAuth.Keycloak
+{
+    public enum KeycloakAuthenticationAccessType
+    {
+        Confidential,
+        Public,
+        BearerOnly
+    }
+}


### PR DESCRIPTION
This is a fix for #610 

I added a new property for Keycloak's access type. It will swallow the exception thrown for missing Secret Key if the access type is public, otherwise everything stays the same.