### PR TITLE
Updated LiChess to use required pkce authentication

### DIFF
--- a/src/AspNet.Security.OAuth.Lichess/LichessAuthenticationDefaults.cs
+++ b/src/AspNet.Security.OAuth.Lichess/LichessAuthenticationDefaults.cs
@@ -42,7 +42,7 @@ namespace AspNet.Security.OAuth.Lichess
         /// <summary>
         /// Default value for <see cref="OAuthOptions.TokenEndpoint"/>.
         /// </summary>
-        public const string TokenEndpoint = "https://oauth.lichess.org/oauth";
+        public const string TokenEndpoint = "https://lichess.org/api/token";
 
         /// <summary>
         /// Default value for <see cref="OAuthOptions.UserInformationEndpoint"/>.

--- a/src/AspNet.Security.OAuth.Lichess/LichessAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Lichess/LichessAuthenticationHandler.cs
@@ -4,11 +4,8 @@
  * for more information concerning the license and the contributors participating to this project.
  */
 
-using System;
-using System.Collections.Generic;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Net.Mime;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
 using System.Text.Json;

--- a/src/AspNet.Security.OAuth.Lichess/LichessAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Lichess/LichessAuthenticationHandler.cs
@@ -4,8 +4,11 @@
  * for more information concerning the license and the contributors participating to this project.
  */
 
+using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Net.Mime;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
 using System.Text.Json;
@@ -37,6 +40,48 @@ namespace AspNet.Security.OAuth.Lichess
             [NotNull] ISystemClock clock)
             : base(options, logger, encoder, clock)
         {
+        }
+
+        protected override async Task<OAuthTokenResponse> ExchangeCodeAsync([NotNull] OAuthCodeExchangeContext context)
+        {
+            var tokenRequestParameters = new Dictionary<string, string?>()
+            {
+                ["grant_type"] = "authorization_code",
+                ["client_id"] = Options.ClientId,
+                ["code"] = context.Code,
+                ["redirect_uri"] = context.RedirectUri
+            };
+
+            // PKCE https://tools.ietf.org/html/rfc7636#section-4.5, see BuildChallengeUrl
+            if (context.Properties.Items.TryGetValue(OAuthConstants.CodeVerifierKey, out string? codeVerifier))
+            {
+                tokenRequestParameters.Add(OAuthConstants.CodeVerifierKey, codeVerifier);
+                context.Properties.Items.Remove(OAuthConstants.CodeVerifierKey);
+            }
+
+            using var requestContent = new FormUrlEncodedContent(tokenRequestParameters!);
+            using var requestMessage = new HttpRequestMessage(HttpMethod.Post, Options.TokenEndpoint);
+
+            requestMessage.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(MediaTypeNames.Application.Json));
+            requestMessage.Content = requestContent;
+
+            using var response = await Backchannel.SendAsync(requestMessage, Context.RequestAborted);
+            if (!response.IsSuccessStatusCode)
+            {
+                const string Error = "An error occurred while retrieving an OAuth token";
+
+                Logger.LogError("{Error}: the remote server " +
+                                "returned a {Status} response with the following payload: {Headers} {Body}.",
+                                /* Error: */  Error,
+                                /* Status: */ response.StatusCode,
+                                /* Headers: */ response.Headers.ToString(),
+                                /* Body: */ await response.Content.ReadAsStringAsync(Context.RequestAborted));
+
+                return OAuthTokenResponse.Failed(new Exception(Error));
+            }
+
+            var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+            return OAuthTokenResponse.Success(payload);
         }
 
         /// <inheritdoc />

--- a/src/AspNet.Security.OAuth.Lichess/LichessAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Lichess/LichessAuthenticationOptions.cs
@@ -17,6 +17,9 @@ namespace AspNet.Security.OAuth.Lichess
     {
         public LichessAuthenticationOptions()
         {
+            // Pkce is now mandatory for LiChess
+            UsePkce = true;
+
             ClaimsIssuer = LichessAuthenticationDefaults.Issuer;
             CallbackPath = LichessAuthenticationDefaults.CallbackPath;
 

--- a/test/AspNet.Security.OAuth.Providers.Tests/Lichess/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Lichess/bundle.json
@@ -4,13 +4,17 @@
     {
       "comment": "https://lichess.org/api#section/Authentication",
       "uri": "https://oauth.lichess.org/oauth",
+      "method": "GET"
+    },
+    {
+      "comment": "https://lichess.org/api#tag/OAuth",
+      "uri": "https://lichess.org/api/token",
       "method": "POST",
       "contentFormat": "json",
       "contentJson": {
+        "token_type": "Bearer",
         "access_token": "secret-access-token",
-        "token_type": "bearer",
-        "refresh_token": "secret-refresh-token",
-        "expires_in": "600"
+        "expires_in": 31536000
       }
     },
     {


### PR DESCRIPTION
LiChess updated their OAuth requirements to require PKCE.  This revision sets the default options to use PKCE, updates the TokenEndPoint in defaults, and adds an override for ExchangeCodeAsync that follows their required mechanism for authentication.

[https://lichess.org/api#tag/OAuth](https://lichess.org/api#tag/OAuth)