### PR TITLE
Use NuGet.exe instead of dotnet nuget

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,12 +26,13 @@ jobs:
             os_name: windows
 
     steps:
-
     - name: Checkout code
       uses: actions/checkout@v2
 
-    - name: Setup .NET SDK
-      uses: actions/setup-dotnet@v1
+    - name: Setup NuGet
+      uses: nuget/setup-nuget@v1
+      with:
+        nuget-version: '5.11.0'
 
     # Arcade only allows the revision to contain up to two characters, and GitHub Actions does not roll-over
     # build numbers every day like Azure DevOps does. To balance these two requirements, set the official
@@ -88,9 +89,9 @@ jobs:
         path: ./artifacts/TestResults/Release
 
     - name: Push NuGet packages to aspnet-contrib MyGet
-      run: dotnet nuget push "artifacts\packages\Release\Shipping\*.nupkg" --api-key ${{ secrets.MYGET_API_KEY }} --skip-duplicate --source https://www.myget.org/F/aspnet-contrib/api/v3/index.json
       if: ${{ github.repository_owner == 'aspnet-contrib' && (github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/heads/rel/') || startsWith(github.ref, 'refs/tags/')) && runner.os == 'Windows' }}
+      run: nuget push "artifacts\packages\Release\Shipping\*.nupkg" -ApiKey ${{ secrets.MYGET_API_KEY }} -SkipDuplicate -Source https://www.myget.org/F/aspnet-contrib/api/v3/index.json
 
     - name: Push NuGet packages to NuGet.org
-      run: dotnet nuget push "artifacts\packages\Release\Shipping\*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate --source https://api.nuget.org/v3/index.json
       if: ${{ github.repository_owner == 'aspnet-contrib' && startsWith(github.ref, 'refs/tags/') && runner.os == 'Windows' }}
+      run: nuget push "artifacts\packages\Release\Shipping\*.nupkg" -ApiKey ${{ secrets.NUGET_API_KEY }} -SkipDuplicate -Source https://api.nuget.org/v3/index.json


### PR DESCRIPTION
Our build workflow relies on `dotnet nuget push` to push NuGet packages to MyGet.org/NuGet.org.

While the .NET SDK is generally present on most GitHub workers, `actions/setup-dotnet@v1` is called quite early to install a fixed .NET SDK version that will be exclusively used for pushing packages (since .NET Arcade takes care of installing the SDK and runtimes listed in global.json). On Windows workers, this step can take up to 50 seconds:

![image](https://user-images.githubusercontent.com/6998306/145064132-b15770bb-11e4-44e9-8fee-795f18b47842.png)

This PR replaces `actions/setup-dotnet@v1` by `nuget/setup-nuget@v1` - that typically runs in less than a second - and updates the 2 "Push NuGet packages" steps to use `NuGet.exe`:

![image](https://user-images.githubusercontent.com/6998306/145064617-cf6e5093-752d-4c66-b759-3fd9cb167e2d.png)