### PR TITLE
Allow package baseline override

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,7 +5,7 @@
     <MinorVersion>0</MinorVersion>
     <PatchVersion>2</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
-    <PackageValidationBaselineVersion>6.0.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion Condition="'$(PackageValidationBaselineVersion)' == ''">6.0.0</PackageValidationBaselineVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <PreReleaseVersionIteration></PreReleaseVersionIteration>
     <PreReleaseBrandingLabel>Preview $(PreReleaseVersionIteration)</PreReleaseBrandingLabel>


### PR DESCRIPTION
Allow individual packages to override the baseline for any new providers added since the last major release.

For example, a new provider added tomorrow could specify a baseline of 6.0.2, but disable baseline validation until it was published.

```xml
  <PropertyGroup>
    <PackageValidationBaselineVersion>6.0.2</PackageValidationBaselineVersion>
    <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
  </PropertyGroup>
```

Otherwise, a new provider wouldn't build because the package validation analyzer would fail because it wouldn't be able to find it in NuGet.org.

In another PR I'll look at adding a list of released providers so that this doesn't need any thought by contributors and "just works", becoming a small piece of extra release process admin for new providers instead.