### PR TITLE
Refactor BuildChallengeUrl overrides

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -85,7 +85,7 @@ dotnet_naming_symbols.constant_fields.required_modifiers          = const
 [*.cs]
 
 # var preferences
-csharp_style_var_for_built_in_types = false:suggestion
+csharp_style_var_for_built_in_types = true:suggestion
 csharp_style_var_when_type_is_apparent = true:silent
 csharp_style_var_elsewhere = true:silent
 

--- a/global.json
+++ b/global.json
@@ -1,10 +1,10 @@
 {
   "sdk": {
-    "version": "6.0.100"
+    "version": "6.0.101"
   },
   
   "tools": {
-    "dotnet": "6.0.100"
+    "dotnet": "6.0.101"
   },
 
   "msbuild-sdks": {

--- a/src/AspNet.Security.OAuth.Alipay/AlipayAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Alipay/AlipayAuthenticationHandler.cs
@@ -221,7 +221,7 @@ public partial class AlipayAuthenticationHandler : OAuthHandler<AlipayAuthentica
         if (Options.UsePkce)
         {
             byte[] bytes = RandomNumberGenerator.GetBytes(32);
-            string codeVerifier = Microsoft.AspNetCore.WebUtilities.Base64UrlTextEncoder.Encode(bytes);
+            string codeVerifier = WebEncoders.Base64UrlEncode(bytes);
 
             // Store this for use during the code redemption.
             properties.Items.Add(OAuthConstants.CodeVerifierKey, codeVerifier);

--- a/src/AspNet.Security.OAuth.Alipay/AlipayAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Alipay/AlipayAuthenticationHandler.cs
@@ -220,7 +220,7 @@ public partial class AlipayAuthenticationHandler : OAuthHandler<AlipayAuthentica
 
         if (Options.UsePkce)
         {
-            byte[] bytes = RandomNumberGenerator.GetBytes(32);
+            byte[] bytes = RandomNumberGenerator.GetBytes(256 / 8);
             string codeVerifier = WebEncoders.Base64UrlEncode(bytes);
 
             // Store this for use during the code redemption.

--- a/src/AspNet.Security.OAuth.ArcGIS/ArcGISAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.ArcGIS/ArcGISAuthenticationHandler.cs
@@ -31,11 +31,13 @@ public partial class ArcGISAuthenticationHandler : OAuthHandler<ArcGISAuthentica
         [NotNull] OAuthTokenResponse tokens)
     {
         // Note: the ArcGIS API doesn't support content negotiation via headers.
-        string address = QueryHelpers.AddQueryString(Options.UserInformationEndpoint, new Dictionary<string, string?>
+        var parameters = new Dictionary<string, string?>
         {
             ["f"] = "json",
-            ["token"] = tokens.AccessToken
-        });
+            ["token"] = tokens.AccessToken,
+        };
+
+        var address = QueryHelpers.AddQueryString(Options.UserInformationEndpoint, parameters!);
 
         using var request = new HttpRequestMessage(HttpMethod.Get, address);
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));

--- a/src/AspNet.Security.OAuth.Automatic/AutomaticAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Automatic/AutomaticAuthenticationHandler.cs
@@ -56,7 +56,7 @@ public partial class AutomaticAuthenticationHandler : OAuthHandler<AutomaticAuth
         var challengeUrl = base.BuildChallengeUrl(properties, redirectUri);
 
         // The redirect_uri parameter is not allowed by Automatic and MUST NOT be sent.
-        var challengeUri = new Uri(challengeUrl);
+        var challengeUri = new Uri(challengeUrl, UriKind.Absolute);
         var query = QueryHelpers.ParseQuery(challengeUri.Query);
 
         query.Remove("redirect_uri");

--- a/src/AspNet.Security.OAuth.Automatic/AutomaticAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Automatic/AutomaticAuthenticationHandler.cs
@@ -53,14 +53,15 @@ public partial class AutomaticAuthenticationHandler : OAuthHandler<AutomaticAuth
 
     protected override string BuildChallengeUrl([NotNull] AuthenticationProperties properties, [NotNull] string redirectUri)
     {
-        // Note: the redirect_uri parameter is not allowed by Automatic and MUST NOT be sent.
-        return QueryHelpers.AddQueryString(Options.AuthorizationEndpoint, new Dictionary<string, string?>
-        {
-            ["client_id"] = Options.ClientId,
-            ["response_type"] = "code",
-            ["scope"] = FormatScope(),
-            ["state"] = Options.StateDataFormat.Protect(properties)
-        });
+        var challengeUrl = base.BuildChallengeUrl(properties, redirectUri);
+
+        // The redirect_uri parameter is not allowed by Automatic and MUST NOT be sent.
+        var challengeUri = new Uri(challengeUrl);
+        var query = QueryHelpers.ParseQuery(challengeUri.Query);
+
+        query.Remove("redirect_uri");
+
+        return QueryHelpers.AddQueryString(Options.AuthorizationEndpoint, query);
     }
 
     private static partial class Log

--- a/src/AspNet.Security.OAuth.Deezer/DeezerAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Deezer/DeezerAuthenticationHandler.cs
@@ -101,7 +101,7 @@ public partial class DeezerAuthenticationHandler : OAuthHandler<DeezerAuthentica
 
         if (Options.UsePkce)
         {
-            byte[] bytes = RandomNumberGenerator.GetBytes(32);
+            byte[] bytes = RandomNumberGenerator.GetBytes(256 / 8);
             string codeVerifier = WebEncoders.Base64UrlEncode(bytes);
 
             // Store this for use during the code redemption.

--- a/src/AspNet.Security.OAuth.Deezer/DeezerAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Deezer/DeezerAuthenticationHandler.cs
@@ -39,13 +39,13 @@ public partial class DeezerAuthenticationHandler : OAuthHandler<DeezerAuthentica
         };
 
         // PKCE https://tools.ietf.org/html/rfc7636#section-4.5, see BuildChallengeUrl
-        if (context.Properties.Items.TryGetValue(OAuthConstants.CodeVerifierKey, out string? codeVerifier))
+        if (context.Properties.Items.TryGetValue(OAuthConstants.CodeVerifierKey, out var codeVerifier))
         {
             tokenRequestParameters.Add(OAuthConstants.CodeVerifierKey, codeVerifier);
             context.Properties.Items.Remove(OAuthConstants.CodeVerifierKey);
         }
 
-        string endpoint = QueryHelpers.AddQueryString(Options.TokenEndpoint, tokenRequestParameters);
+        var endpoint = QueryHelpers.AddQueryString(Options.TokenEndpoint, tokenRequestParameters);
 
         using var requestMessage = new HttpRequestMessage(HttpMethod.Get, endpoint);
         requestMessage.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(MediaTypeNames.Application.Json));
@@ -65,7 +65,7 @@ public partial class DeezerAuthenticationHandler : OAuthHandler<DeezerAuthentica
         [NotNull] AuthenticationProperties properties,
         [NotNull] OAuthTokenResponse tokens)
     {
-        string address = QueryHelpers.AddQueryString(Options.UserInformationEndpoint, "access_token", tokens.AccessToken!);
+        var address = QueryHelpers.AddQueryString(Options.UserInformationEndpoint, "access_token", tokens.AccessToken!);
 
         using var request = new HttpRequestMessage(HttpMethod.Get, address);
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(MediaTypeNames.Application.Json));
@@ -90,7 +90,7 @@ public partial class DeezerAuthenticationHandler : OAuthHandler<DeezerAuthentica
     protected override string BuildChallengeUrl([NotNull] AuthenticationProperties properties, [NotNull] string redirectUri)
     {
         var scopeParameter = properties.GetParameter<ICollection<string>>(OAuthChallengeProperties.ScopeKey);
-        string scopes = scopeParameter != null ? FormatScope(scopeParameter) : FormatScope();
+        var scopes = scopeParameter != null ? FormatScope(scopeParameter) : FormatScope();
 
         var parameters = new Dictionary<string, string?>
         {
@@ -101,13 +101,13 @@ public partial class DeezerAuthenticationHandler : OAuthHandler<DeezerAuthentica
 
         if (Options.UsePkce)
         {
-            byte[] bytes = RandomNumberGenerator.GetBytes(256 / 8);
-            string codeVerifier = WebEncoders.Base64UrlEncode(bytes);
+            var bytes = RandomNumberGenerator.GetBytes(256 / 8);
+            var codeVerifier = WebEncoders.Base64UrlEncode(bytes);
 
             // Store this for use during the code redemption.
             properties.Items.Add(OAuthConstants.CodeVerifierKey, codeVerifier);
 
-            byte[] challengeBytes = SHA256.HashData(Encoding.UTF8.GetBytes(codeVerifier));
+            var challengeBytes = SHA256.HashData(Encoding.UTF8.GetBytes(codeVerifier));
             parameters[OAuthConstants.CodeChallengeKey] = WebEncoders.Base64UrlEncode(challengeBytes);
             parameters[OAuthConstants.CodeChallengeMethodKey] = OAuthConstants.CodeChallengeMethodS256;
         }

--- a/src/AspNet.Security.OAuth.Deezer/DeezerAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Deezer/DeezerAuthenticationHandler.cs
@@ -102,7 +102,7 @@ public partial class DeezerAuthenticationHandler : OAuthHandler<DeezerAuthentica
         if (Options.UsePkce)
         {
             byte[] bytes = RandomNumberGenerator.GetBytes(32);
-            string codeVerifier = Microsoft.AspNetCore.WebUtilities.Base64UrlTextEncoder.Encode(bytes);
+            string codeVerifier = WebEncoders.Base64UrlEncode(bytes);
 
             // Store this for use during the code redemption.
             properties.Items.Add(OAuthConstants.CodeVerifierKey, codeVerifier);

--- a/src/AspNet.Security.OAuth.Ebay/EbayAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Ebay/EbayAuthenticationHandler.cs
@@ -60,7 +60,7 @@ public partial class EbayAuthenticationHandler : OAuthHandler<EbayAuthentication
         {
             ["grant_type"] = "authorization_code",
             ["code"] = context.Code,
-            ["redirect_uri"] = Options.RuName!
+            ["redirect_uri"] = Options.RuName!,
         };
 
         // PKCE https://tools.ietf.org/html/rfc7636#section-4.5, see BuildChallengeUrl
@@ -90,7 +90,7 @@ public partial class EbayAuthenticationHandler : OAuthHandler<EbayAuthentication
 
     private AuthenticationHeaderValue CreateAuthorizationHeader()
     {
-        string credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes(
+        var credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes(
             string.Concat(
                 EscapeDataString(Options.ClientId),
                 ":",

--- a/src/AspNet.Security.OAuth.Ebay/EbayAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Ebay/EbayAuthenticationHandler.cs
@@ -9,7 +9,6 @@ using System.Security.Claims;
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
-using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -51,16 +50,8 @@ public partial class EbayAuthenticationHandler : OAuthHandler<EbayAuthentication
 
     protected override string BuildChallengeUrl([NotNull] AuthenticationProperties properties, [NotNull] string redirectUri)
     {
-        var parameters = new Dictionary<string, string>
-        {
-            ["client_id"] = Options.ClientId,
-            ["redirect_uri"] = Options.RuName!,
-            ["response_type"] = "code",
-            ["scope"] = FormatScope(Options.Scope)
-        };
-        parameters["state"] = Options.StateDataFormat.Protect(properties);
-
-        return QueryHelpers.AddQueryString(Options.AuthorizationEndpoint, parameters!);
+        // eBay uses the RuName for the redirect_uri
+        return base.BuildChallengeUrl(properties, Options.RuName);
     }
 
     protected override async Task<OAuthTokenResponse> ExchangeCodeAsync([NotNull] OAuthCodeExchangeContext context)

--- a/src/AspNet.Security.OAuth.Fitbit/FitbitAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Fitbit/FitbitAuthenticationHandler.cs
@@ -57,7 +57,7 @@ public partial class FitbitAuthenticationHandler : OAuthHandler<FitbitAuthentica
         {
             ["grant_type"] = "authorization_code",
             ["redirect_uri"] = context.RedirectUri,
-            ["code"] = context.Code
+            ["code"] = context.Code,
         };
 
         // PKCE https://tools.ietf.org/html/rfc7636#section-4.5, see BuildChallengeUrl
@@ -97,7 +97,7 @@ public partial class FitbitAuthenticationHandler : OAuthHandler<FitbitAuthentica
             return Uri.EscapeDataString(value).Replace("%20", "+", StringComparison.Ordinal);
         }
 
-        string credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes(
+        var credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes(
             string.Concat(
                 EscapeDataString(Options.ClientId),
                 ":",

--- a/src/AspNet.Security.OAuth.Fitbit/FitbitAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Fitbit/FitbitAuthenticationHandler.cs
@@ -53,18 +53,25 @@ public partial class FitbitAuthenticationHandler : OAuthHandler<FitbitAuthentica
 
     protected override async Task<OAuthTokenResponse> ExchangeCodeAsync([NotNull] OAuthCodeExchangeContext context)
     {
-        using var request = new HttpRequestMessage(HttpMethod.Post, Options.TokenEndpoint);
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-        request.Headers.Authorization = CreateAuthorizationHeader();
-
-        var parameters = new Dictionary<string, string>
+        var tokenRequestParameters = new Dictionary<string, string>
         {
             ["grant_type"] = "authorization_code",
             ["redirect_uri"] = context.RedirectUri,
             ["code"] = context.Code
         };
 
-        request.Content = new FormUrlEncodedContent(parameters!);
+        // PKCE https://tools.ietf.org/html/rfc7636#section-4.5, see BuildChallengeUrl
+        if (context.Properties.Items.TryGetValue(OAuthConstants.CodeVerifierKey, out var codeVerifier))
+        {
+            tokenRequestParameters.Add(OAuthConstants.CodeVerifierKey, codeVerifier!);
+            context.Properties.Items.Remove(OAuthConstants.CodeVerifierKey);
+        }
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, Options.TokenEndpoint);
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        request.Headers.Authorization = CreateAuthorizationHeader();
+
+        request.Content = new FormUrlEncodedContent(tokenRequestParameters);
 
         using var response = await Backchannel.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, Context.RequestAborted);
         if (!response.IsSuccessStatusCode)

--- a/src/AspNet.Security.OAuth.Foursquare/FoursquareAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Foursquare/FoursquareAuthenticationHandler.cs
@@ -31,12 +31,14 @@ public partial class FoursquareAuthenticationHandler : OAuthHandler<FoursquareAu
     {
         // See https://developer.foursquare.com/overview/versioning
         // for more information about the mandatory "v" and "m" parameters.
-        string address = QueryHelpers.AddQueryString(Options.UserInformationEndpoint, new Dictionary<string, string?>
+        var parameters = new Dictionary<string, string?>
         {
             ["m"] = "foursquare",
             ["v"] = !string.IsNullOrEmpty(Options.ApiVersion) ? Options.ApiVersion : FoursquareAuthenticationDefaults.ApiVersion,
             ["oauth_token"] = tokens.AccessToken,
-        });
+        };
+
+        var address = QueryHelpers.AddQueryString(Options.UserInformationEndpoint, parameters);
 
         using var request = new HttpRequestMessage(HttpMethod.Get, address);
 

--- a/src/AspNet.Security.OAuth.Line/LineAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Line/LineAuthenticationHandler.cs
@@ -40,7 +40,7 @@ public partial class LineAuthenticationHandler : OAuthHandler<LineAuthentication
             ["code"] = context.Code,
             ["redirect_uri"] = context.RedirectUri,
             ["client_id"] = Options.ClientId,
-            ["client_secret"] = Options.ClientSecret
+            ["client_secret"] = Options.ClientSecret,
         };
 
         // PKCE https://tools.ietf.org/html/rfc7636#section-4.5, see BuildChallengeUrl
@@ -89,7 +89,7 @@ public partial class LineAuthenticationHandler : OAuthHandler<LineAuthentication
         // When the email address is not public, retrieve it from the emails endpoint if the user:email scope is specified.
         if (!string.IsNullOrEmpty(Options.UserEmailsEndpoint) && Options.Scope.Contains("email"))
         {
-            string? email = await GetEmailAsync(tokens);
+            var email = await GetEmailAsync(tokens);
 
             if (!string.IsNullOrEmpty(email))
             {
@@ -103,14 +103,14 @@ public partial class LineAuthenticationHandler : OAuthHandler<LineAuthentication
 
     protected virtual async Task<string?> GetEmailAsync([NotNull] OAuthTokenResponse tokens)
     {
-        using var request = new HttpRequestMessage(HttpMethod.Post, Options.UserEmailsEndpoint);
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-
         var parameters = new Dictionary<string, string?>
         {
             ["id_token"] = tokens.Response?.RootElement.GetString("id_token") ?? string.Empty,
-            ["client_id"] = Options.ClientId
+            ["client_id"] = Options.ClientId,
         };
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, Options.UserEmailsEndpoint);
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
         request.Content = new FormUrlEncodedContent(parameters);
 
         using var response = await Backchannel.SendAsync(request, Context.RequestAborted);

--- a/src/AspNet.Security.OAuth.Line/LineAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Line/LineAuthenticationHandler.cs
@@ -27,15 +27,10 @@ public partial class LineAuthenticationHandler : OAuthHandler<LineAuthentication
     }
 
     protected override string BuildChallengeUrl([NotNull] AuthenticationProperties properties, [NotNull] string redirectUri)
-        => QueryHelpers.AddQueryString(Options.AuthorizationEndpoint, new Dictionary<string, string?>
-        {
-            ["response_type"] = "code",
-            ["client_id"] = Options.ClientId,
-            ["redirect_uri"] = redirectUri,
-            ["state"] = Options.StateDataFormat.Protect(properties),
-            ["scope"] = FormatScope(),
-            ["prompt"] = Options.Prompt ? "consent" : string.Empty
-        });
+    {
+        var challengeUrl = base.BuildChallengeUrl(properties, redirectUri);
+        return QueryHelpers.AddQueryString(challengeUrl, "prompt", Options.Prompt ? "consent" : string.Empty);
+    }
 
     protected override async Task<OAuthTokenResponse> ExchangeCodeAsync([NotNull] OAuthCodeExchangeContext context)
     {

--- a/src/AspNet.Security.OAuth.LinkedIn/LinkedInAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.LinkedIn/LinkedInAuthenticationOptions.cs
@@ -106,7 +106,7 @@ public class LinkedInAuthenticationOptions : OAuthOptions
 
     private string GetFullName(JsonElement user)
     {
-        string?[] nameParts = new string?[]
+        var nameParts = new string?[]
         {
                 GetMultiLocaleString(user, ProfileFields.FirstName),
                 GetMultiLocaleString(user, ProfileFields.LastName),
@@ -134,7 +134,7 @@ public class LinkedInAuthenticationOptions : OAuthOptions
                 continue;
             }
 
-            string? pictureUrl = imageIdentifier
+            var pictureUrl = imageIdentifier
                 .EnumerateArray()
                 .FirstOrDefault()
                 .GetString("identifier");
@@ -161,13 +161,13 @@ public class LinkedInAuthenticationOptions : OAuthOptions
     private static string? DefaultMultiLocaleStringResolver(IReadOnlyDictionary<string, string?> localizedValues, string? preferredLocale)
     {
         if (!string.IsNullOrEmpty(preferredLocale) &&
-            localizedValues.TryGetValue(preferredLocale, out string? preferredLocaleValue))
+            localizedValues.TryGetValue(preferredLocale, out var preferredLocaleValue))
         {
             return preferredLocaleValue;
         }
 
-        string currentUIKey = Thread.CurrentThread.CurrentUICulture.ToString().Replace('-', '_');
-        if (localizedValues.TryGetValue(currentUIKey, out string? currentUIValue))
+        var currentUIKey = Thread.CurrentThread.CurrentUICulture.ToString().Replace('-', '_');
+        if (localizedValues.TryGetValue(currentUIKey, out var currentUIValue))
         {
             return currentUIValue;
         }

--- a/src/AspNet.Security.OAuth.Mixcloud/MixcloudAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Mixcloud/MixcloudAuthenticationHandler.cs
@@ -41,7 +41,7 @@ public partial class MixcloudAuthenticationHandler : OAuthHandler<MixcloudAuthen
 
         if (Options.UsePkce)
         {
-            var bytes = RandomNumberGenerator.GetBytes(32);
+            var bytes = RandomNumberGenerator.GetBytes(256 / 8);
             var codeVerifier = WebEncoders.Base64UrlEncode(bytes);
 
             // Store this for use during the code redemption.

--- a/src/AspNet.Security.OAuth.Mixcloud/MixcloudAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Mixcloud/MixcloudAuthenticationHandler.cs
@@ -76,10 +76,8 @@ public partial class MixcloudAuthenticationHandler : OAuthHandler<MixcloudAuthen
         return await base.ExchangeCodeAsync(context);
     }
 
-    protected override async Task<HandleRequestResult> HandleRemoteAuthenticateAsync()
-    {
-        return await base.HandleRemoteAuthenticateAsync();
-    }
+    protected override Task<HandleRequestResult> HandleRemoteAuthenticateAsync()
+        => base.HandleRemoteAuthenticateAsync(); // TODO This override is the same as the base class' and can be removed in the next major version
 
     protected override async Task<AuthenticationTicket> CreateTicketAsync(
         [NotNull] ClaimsIdentity identity,

--- a/src/AspNet.Security.OAuth.Mixcloud/MixcloudAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Mixcloud/MixcloudAuthenticationHandler.cs
@@ -4,7 +4,6 @@
  * for more information concerning the license and the contributors participating to this project.
  */
 
-using System.Globalization;
 using System.Net.Http.Headers;
 using System.Security.Claims;
 using System.Security.Cryptography;
@@ -14,7 +13,6 @@ using System.Text.Json;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Microsoft.Extensions.Primitives;
 using Base64UrlTextEncoder = Microsoft.AspNetCore.Authentication.Base64UrlTextEncoder;
 
 namespace AspNet.Security.OAuth.Mixcloud;
@@ -66,137 +64,21 @@ public partial class MixcloudAuthenticationHandler : OAuthHandler<MixcloudAuthen
         return QueryHelpers.AddQueryString(Options.AuthorizationEndpoint, parameters);
     }
 
+    protected override async Task<OAuthTokenResponse> ExchangeCodeAsync([NotNull] OAuthCodeExchangeContext context)
+    {
+        // Mixcloud does not appear to support the `state` parameter, so instead add it
+        // to the redirect URI before calling the base ExchangeCodeAsync() implementation.
+        var state = Request.Query["state"];
+
+        var redirectUri = QueryHelpers.AddQueryString(context.RedirectUri, "state", state);
+        context = new OAuthCodeExchangeContext(context.Properties, context.Code, redirectUri);
+
+        return await base.ExchangeCodeAsync(context);
+    }
+
     protected override async Task<HandleRequestResult> HandleRemoteAuthenticateAsync()
     {
-        var query = Request.Query;
-
-        var state = query["state"];
-        var properties = Options.StateDataFormat.Unprotect(state);
-
-        if (properties == null)
-        {
-            return HandleRequestResult.Fail("The oauth state was missing or invalid.");
-        }
-
-        // OAuth2 10.12 CSRF
-        if (!ValidateCorrelationId(properties))
-        {
-            return HandleRequestResult.Fail("Correlation failed.", properties);
-        }
-
-        var error = query["error"];
-        if (!StringValues.IsNullOrEmpty(error))
-        {
-            // Note: access_denied errors are special protocol errors indicating the user didn't
-            // approve the authorization demand requested by the remote authorization server.
-            // Since it's a frequent scenario (that is not caused by incorrect configuration),
-            // denied errors are handled differently using HandleAccessDeniedErrorAsync().
-            // Visit https://tools.ietf.org/html/rfc6749#section-4.1.2.1 for more information.
-            var errorDescription = query["error_description"];
-            var errorUri = query["error_uri"];
-            if (StringValues.Equals(error, "access_denied"))
-            {
-                var result = await HandleAccessDeniedErrorAsync(properties);
-                if (!result.None)
-                {
-                    return result;
-                }
-
-                var deniedEx = new Exception("Access was denied by the resource owner or by the remote server.");
-                deniedEx.Data["error"] = error.ToString();
-                deniedEx.Data["error_description"] = errorDescription.ToString();
-                deniedEx.Data["error_uri"] = errorUri.ToString();
-
-                return HandleRequestResult.Fail(deniedEx, properties);
-            }
-
-            var failureMessage = new StringBuilder();
-            failureMessage.Append(error);
-            if (!StringValues.IsNullOrEmpty(errorDescription))
-            {
-                failureMessage.Append(";Description=").Append(errorDescription);
-            }
-
-            if (!StringValues.IsNullOrEmpty(errorUri))
-            {
-                failureMessage.Append(";Uri=").Append(errorUri);
-            }
-
-            var ex = new Exception(failureMessage.ToString());
-            ex.Data["error"] = error.ToString();
-            ex.Data["error_description"] = errorDescription.ToString();
-            ex.Data["error_uri"] = errorUri.ToString();
-
-            return HandleRequestResult.Fail(ex, properties);
-        }
-
-        var code = query["code"];
-
-        if (StringValues.IsNullOrEmpty(code))
-        {
-            return HandleRequestResult.Fail("Code was not found.", properties);
-        }
-
-        // Mixcloud does not appear to support the `state` parameter, so have to unbundle it here:
-        var redirectUri = QueryHelpers.AddQueryString(BuildRedirectUri(Options.CallbackPath), "state", state);
-        var codeExchangeContext = new OAuthCodeExchangeContext(properties, code, redirectUri);
-        using var tokens = await ExchangeCodeAsync(codeExchangeContext);
-
-        if (tokens.Error != null)
-        {
-            return HandleRequestResult.Fail(tokens.Error, properties);
-        }
-
-        if (string.IsNullOrEmpty(tokens.AccessToken))
-        {
-            return HandleRequestResult.Fail("Failed to retrieve access token.", properties);
-        }
-
-        var identity = new ClaimsIdentity(ClaimsIssuer);
-
-        if (Options.SaveTokens)
-        {
-            var authTokens = new List<AuthenticationToken>();
-
-            authTokens.Add(new AuthenticationToken { Name = "access_token", Value = tokens.AccessToken });
-            if (!string.IsNullOrEmpty(tokens.RefreshToken))
-            {
-                authTokens.Add(new AuthenticationToken { Name = "refresh_token", Value = tokens.RefreshToken });
-            }
-
-            if (!string.IsNullOrEmpty(tokens.TokenType))
-            {
-                authTokens.Add(new AuthenticationToken { Name = "token_type", Value = tokens.TokenType });
-            }
-
-            if (!string.IsNullOrEmpty(tokens.ExpiresIn))
-            {
-                int value;
-                if (int.TryParse(tokens.ExpiresIn, NumberStyles.Integer, CultureInfo.InvariantCulture, out value))
-                {
-                    // https://www.w3.org/TR/xmlschema-2/#dateTime
-                    // https://msdn.microsoft.com/en-us/library/az4se3k1(v=vs.110).aspx
-                    var expiresAt = Clock.UtcNow + TimeSpan.FromSeconds(value);
-                    authTokens.Add(new AuthenticationToken
-                    {
-                        Name = "expires_at",
-                        Value = expiresAt.ToString("o", CultureInfo.InvariantCulture)
-                    });
-                }
-            }
-
-            properties.StoreTokens(authTokens);
-        }
-
-        var ticket = await CreateTicketAsync(identity, properties, tokens);
-        if (ticket != null)
-        {
-            return HandleRequestResult.Success(ticket);
-        }
-        else
-        {
-            return HandleRequestResult.Fail("Failed to retrieve user information from remote server.", properties);
-        }
+        return await base.HandleRemoteAuthenticateAsync();
     }
 
     protected override async Task<AuthenticationTicket> CreateTicketAsync(

--- a/src/AspNet.Security.OAuth.Mixcloud/MixcloudAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Mixcloud/MixcloudAuthenticationHandler.cs
@@ -13,7 +13,6 @@ using System.Text.Json;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Base64UrlTextEncoder = Microsoft.AspNetCore.Authentication.Base64UrlTextEncoder;
 
 namespace AspNet.Security.OAuth.Mixcloud;
 
@@ -43,7 +42,7 @@ public partial class MixcloudAuthenticationHandler : OAuthHandler<MixcloudAuthen
         if (Options.UsePkce)
         {
             var bytes = RandomNumberGenerator.GetBytes(32);
-            var codeVerifier = Base64UrlTextEncoder.Encode(bytes);
+            var codeVerifier = WebEncoders.Base64UrlEncode(bytes);
 
             // Store this for use during the code redemption.
             properties.Items.Add(OAuthConstants.CodeVerifierKey, codeVerifier);

--- a/src/AspNet.Security.OAuth.Mixcloud/MixcloudAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Mixcloud/MixcloudAuthenticationHandler.cs
@@ -83,7 +83,7 @@ public partial class MixcloudAuthenticationHandler : OAuthHandler<MixcloudAuthen
         [NotNull] AuthenticationProperties properties,
         [NotNull] OAuthTokenResponse tokens)
     {
-        string address = QueryHelpers.AddQueryString(Options.UserInformationEndpoint, "access_token", tokens.AccessToken!);
+        var address = QueryHelpers.AddQueryString(Options.UserInformationEndpoint, "access_token", tokens.AccessToken!);
 
         using var request = new HttpRequestMessage(HttpMethod.Get, address);
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));

--- a/src/AspNet.Security.OAuth.Mixcloud/MixcloudAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Mixcloud/MixcloudAuthenticationHandler.cs
@@ -36,7 +36,7 @@ public partial class MixcloudAuthenticationHandler : OAuthHandler<MixcloudAuthen
         {
             ["client_id"] = Options.ClientId,
             ["scope"] = scope,
-            ["response_type"] = "code"
+            ["response_type"] = "code",
         };
 
         if (Options.UsePkce)

--- a/src/AspNet.Security.OAuth.Notion/NotionAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Notion/NotionAuthenticationHandler.cs
@@ -44,7 +44,7 @@ public class NotionAuthenticationHandler : OAuthHandler<NotionAuthenticationOpti
             context.Properties.Items.Remove(OAuthConstants.CodeVerifierKey);
         }
 
-        using var requestContent = new FormUrlEncodedContent(tokenRequestParameters!);
+        using var requestContent = new FormUrlEncodedContent(tokenRequestParameters);
 
         using var requestMessage = new HttpRequestMessage(HttpMethod.Post, Options.TokenEndpoint);
         requestMessage.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));

--- a/src/AspNet.Security.OAuth.Notion/NotionAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Notion/NotionAuthenticationHandler.cs
@@ -49,7 +49,7 @@ public class NotionAuthenticationHandler : OAuthHandler<NotionAuthenticationOpti
         using var requestMessage = new HttpRequestMessage(HttpMethod.Post, Options.TokenEndpoint);
         requestMessage.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
 
-        byte[] byteArray = Encoding.ASCII.GetBytes(Options.ClientId + ":" + Options.ClientSecret);
+        var byteArray = Encoding.ASCII.GetBytes(Options.ClientId + ":" + Options.ClientSecret);
         requestMessage.Headers.Authorization =
             new AuthenticationHeaderValue("Basic", Convert.ToBase64String(byteArray));
         requestMessage.Content = requestContent;

--- a/src/AspNet.Security.OAuth.Odnoklassniki/OdnoklassnikiAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Odnoklassniki/OdnoklassnikiAuthenticationHandler.cs
@@ -32,17 +32,19 @@ public partial class OdnoklassnikiAuthenticationHandler : OAuthHandler<Odnoklass
         [NotNull] AuthenticationProperties properties,
         [NotNull] OAuthTokenResponse tokens)
     {
-        string accessSecret = GetMD5Hash(tokens.AccessToken + Options.ClientSecret);
-        string sign = GetMD5Hash($"application_key={Options.PublicSecret}format=jsonmethod=users.getCurrentUser{accessSecret}");
+        var accessSecret = GetMD5Hash(tokens.AccessToken + Options.ClientSecret);
+        var sign = GetMD5Hash($"application_key={Options.PublicSecret}format=jsonmethod=users.getCurrentUser{accessSecret}");
 
-        string address = QueryHelpers.AddQueryString(Options.UserInformationEndpoint, new Dictionary<string, string?>
+        var parameters = new Dictionary<string, string?>
         {
             ["application_key"] = Options.PublicSecret ?? string.Empty,
             ["format"] = "json",
             ["method"] = "users.getCurrentUser",
             ["sig"] = sign,
             ["access_token"] = tokens.AccessToken,
-        });
+        };
+
+        var address = QueryHelpers.AddQueryString(Options.UserInformationEndpoint, parameters);
 
         using var request = new HttpRequestMessage(HttpMethod.Get, address);
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
@@ -70,7 +72,7 @@ public partial class OdnoklassnikiAuthenticationHandler : OAuthHandler<Odnoklass
     private static string GetMD5Hash(string input)
     {
 #pragma warning disable CA5351
-        byte[] hash = MD5.HashData(Encoding.UTF8.GetBytes(input));
+        var hash = MD5.HashData(Encoding.UTF8.GetBytes(input));
 #pragma warning restore CA5351
 
         return Convert.ToHexString(hash).ToLowerInvariant();

--- a/src/AspNet.Security.OAuth.QQ/QQAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.QQ/QQAuthenticationHandler.cs
@@ -141,9 +141,11 @@ public partial class QQAuthenticationHandler : OAuthHandler<QQAuthenticationOpti
         return (errorCode, payloadRoot.GetString("openid"), payloadRoot.GetString("unionid"));
     }
 
-    protected override string FormatScope() => FormatScope(Options.Scope);
+    protected override string FormatScope()
+        => FormatScope(Options.Scope); // TODO This override is the same as the base class' and can be removed in the next major version
 
-    protected override string FormatScope([NotNull] IEnumerable<string> scopes) => string.Join(',', scopes);
+    protected override string FormatScope([NotNull] IEnumerable<string> scopes)
+        => string.Join(',', scopes);
 
     private static partial class Log
     {

--- a/src/AspNet.Security.OAuth.Reddit/RedditAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Reddit/RedditAuthenticationHandler.cs
@@ -68,12 +68,17 @@ public partial class RedditAuthenticationHandler : OAuthHandler<RedditAuthentica
         return QueryHelpers.AddQueryString(challengeUrl, "duration", "permanent");
     }
 
+    /// <inheritdoc />
     protected override string FormatScope()
+        => FormatScope(Options.Scope); // TODO This override is the same as the base class' and can be removed in the next major version
+
+    /// <inheritdoc />
+    protected override string FormatScope([NotNull] IEnumerable<string> scopes)
     {
         // Note: Reddit requires a non-standard comma-separated scope.
         // See https://github.com/reddit/reddit/wiki/OAuth2#authorization
         // and http://tools.ietf.org/html/rfc6749#section-3.3.
-        return string.Join(',', Options.Scope);
+        return string.Join(',', scopes);
     }
 
     protected override async Task<OAuthTokenResponse> ExchangeCodeAsync([NotNull] OAuthCodeExchangeContext context)

--- a/src/AspNet.Security.OAuth.Reddit/RedditAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Reddit/RedditAuthenticationHandler.cs
@@ -61,11 +61,11 @@ public partial class RedditAuthenticationHandler : OAuthHandler<RedditAuthentica
 
     protected override string BuildChallengeUrl([NotNull] AuthenticationProperties properties, [NotNull] string redirectUri)
     {
-        string address = base.BuildChallengeUrl(properties, redirectUri);
+        string challengeUrl = base.BuildChallengeUrl(properties, redirectUri);
 
         // Add duration=permanent to the authorization request to get an access token that doesn't expire after 1 hour.
         // See https://github.com/reddit/reddit/wiki/OAuth2#authorization for more information.
-        return QueryHelpers.AddQueryString(address, name: "duration", value: "permanent");
+        return QueryHelpers.AddQueryString(challengeUrl, "duration", "permanent");
     }
 
     protected override string FormatScope()

--- a/src/AspNet.Security.OAuth.Reddit/RedditAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Reddit/RedditAuthenticationHandler.cs
@@ -61,7 +61,7 @@ public partial class RedditAuthenticationHandler : OAuthHandler<RedditAuthentica
 
     protected override string BuildChallengeUrl([NotNull] AuthenticationProperties properties, [NotNull] string redirectUri)
     {
-        string challengeUrl = base.BuildChallengeUrl(properties, redirectUri);
+        var challengeUrl = base.BuildChallengeUrl(properties, redirectUri);
 
         // Add duration=permanent to the authorization request to get an access token that doesn't expire after 1 hour.
         // See https://github.com/reddit/reddit/wiki/OAuth2#authorization for more information.
@@ -87,7 +87,7 @@ public partial class RedditAuthenticationHandler : OAuthHandler<RedditAuthentica
         {
             ["grant_type"] = "authorization_code",
             ["redirect_uri"] = context.RedirectUri,
-            ["code"] = context.Code
+            ["code"] = context.Code,
         };
 
         // PKCE https://tools.ietf.org/html/rfc7636#section-4.5, see BuildChallengeUrl
@@ -134,7 +134,7 @@ public partial class RedditAuthenticationHandler : OAuthHandler<RedditAuthentica
             return Uri.EscapeDataString(value).Replace("%20", "+", StringComparison.Ordinal);
         }
 
-        string credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes(
+        var credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes(
             string.Concat(
                 EscapeDataString(Options.ClientId),
                 ":",

--- a/src/AspNet.Security.OAuth.Reddit/RedditAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Reddit/RedditAuthenticationHandler.cs
@@ -83,6 +83,20 @@ public partial class RedditAuthenticationHandler : OAuthHandler<RedditAuthentica
 
     protected override async Task<OAuthTokenResponse> ExchangeCodeAsync([NotNull] OAuthCodeExchangeContext context)
     {
+        var tokenRequestParameters = new Dictionary<string, string>
+        {
+            ["grant_type"] = "authorization_code",
+            ["redirect_uri"] = context.RedirectUri,
+            ["code"] = context.Code
+        };
+
+        // PKCE https://tools.ietf.org/html/rfc7636#section-4.5, see BuildChallengeUrl
+        if (context.Properties.Items.TryGetValue(OAuthConstants.CodeVerifierKey, out var codeVerifier))
+        {
+            tokenRequestParameters.Add(OAuthConstants.CodeVerifierKey, codeVerifier!);
+            context.Properties.Items.Remove(OAuthConstants.CodeVerifierKey);
+        }
+
         using var request = new HttpRequestMessage(HttpMethod.Post, Options.TokenEndpoint);
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
         request.Headers.Authorization = CreateAuthorizationHeader();
@@ -94,14 +108,7 @@ public partial class RedditAuthenticationHandler : OAuthHandler<RedditAuthentica
             request.Headers.UserAgent.ParseAdd(Options.UserAgent);
         }
 
-        var parameters = new Dictionary<string, string>
-        {
-            ["grant_type"] = "authorization_code",
-            ["redirect_uri"] = context.RedirectUri,
-            ["code"] = context.Code
-        };
-
-        request.Content = new FormUrlEncodedContent(parameters!);
+        request.Content = new FormUrlEncodedContent(tokenRequestParameters);
 
         using var response = await Backchannel.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, Context.RequestAborted);
         if (!response.IsSuccessStatusCode)

--- a/src/AspNet.Security.OAuth.Shopify/ShopifyAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Shopify/ShopifyAuthenticationHandler.cs
@@ -105,7 +105,8 @@ public partial class ShopifyAuthenticationHandler : OAuthHandler<ShopifyAuthenti
         // Get the permission scope, which can either be set in options or overridden in AuthenticationProperties.
         if (!properties.Items.TryGetValue(ShopifyAuthenticationDefaults.ShopScopeAuthenticationProperty, out string? scope))
         {
-            scope = FormatScope();
+            var scopeParameter = properties.GetParameter<ICollection<string>>(OAuthChallengeProperties.ScopeKey);
+            scope = scopeParameter != null ? FormatScope(scopeParameter) : FormatScope();
         }
 
         var parameters = new Dictionary<string, string?>()

--- a/src/AspNet.Security.OAuth.Shopify/ShopifyAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Shopify/ShopifyAuthenticationHandler.cs
@@ -119,7 +119,7 @@ public partial class ShopifyAuthenticationHandler : OAuthHandler<ShopifyAuthenti
         if (Options.UsePkce)
         {
             byte[] bytes = RandomNumberGenerator.GetBytes(32);
-            string codeVerifier = Microsoft.AspNetCore.WebUtilities.Base64UrlTextEncoder.Encode(bytes);
+            string codeVerifier = WebEncoders.Base64UrlEncode(bytes);
 
             // Store this for use during the code redemption.
             properties.Items.Add(OAuthConstants.CodeVerifierKey, codeVerifier);

--- a/src/AspNet.Security.OAuth.Shopify/ShopifyAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Shopify/ShopifyAuthenticationHandler.cs
@@ -83,9 +83,7 @@ public partial class ShopifyAuthenticationHandler : OAuthHandler<ShopifyAuthenti
 
     /// <inheritdoc />
     protected override string FormatScope()
-    {
-        return string.Join(',', Options.Scope);
-    }
+        => string.Join(',', Options.Scope);
 
     /// <inheritdoc />
     protected override string BuildChallengeUrl([NotNull] AuthenticationProperties properties, [NotNull] string redirectUri)

--- a/src/AspNet.Security.OAuth.Shopify/ShopifyAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Shopify/ShopifyAuthenticationHandler.cs
@@ -118,7 +118,7 @@ public partial class ShopifyAuthenticationHandler : OAuthHandler<ShopifyAuthenti
 
         if (Options.UsePkce)
         {
-            byte[] bytes = RandomNumberGenerator.GetBytes(32);
+            byte[] bytes = RandomNumberGenerator.GetBytes(256 / 8);
             string codeVerifier = WebEncoders.Base64UrlEncode(bytes);
 
             // Store this for use during the code redemption.

--- a/src/AspNet.Security.OAuth.Shopify/ShopifyAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Shopify/ShopifyAuthenticationHandler.cs
@@ -83,7 +83,11 @@ public partial class ShopifyAuthenticationHandler : OAuthHandler<ShopifyAuthenti
 
     /// <inheritdoc />
     protected override string FormatScope()
-        => string.Join(',', Options.Scope);
+        => FormatScope(Options.Scope); // TODO This override is the same as the base class' and can be removed in the next major version
+
+    /// <inheritdoc />
+    protected override string FormatScope([NotNull] IEnumerable<string> scopes)
+        => string.Join(',', scopes);
 
     /// <inheritdoc />
     protected override string BuildChallengeUrl([NotNull] AuthenticationProperties properties, [NotNull] string redirectUri)

--- a/src/AspNet.Security.OAuth.Shopify/ShopifyAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Shopify/ShopifyAuthenticationHandler.cs
@@ -153,7 +153,7 @@ public partial class ShopifyAuthenticationHandler : OAuthHandler<ShopifyAuthenti
         {
             ["client_id"] = Options.ClientId,
             ["client_secret"] = Options.ClientSecret,
-            ["code"] = context.Code
+            ["code"] = context.Code,
         };
 
         // PKCE https://tools.ietf.org/html/rfc7636#section-4.5, see BuildChallengeUrl

--- a/src/AspNet.Security.OAuth.Shopify/ShopifyAuthenticationProperties.cs
+++ b/src/AspNet.Security.OAuth.Shopify/ShopifyAuthenticationProperties.cs
@@ -55,7 +55,7 @@ public class ShopifyAuthenticationProperties : AuthenticationProperties
     {
         get
         {
-            string? prop = GetProperty(ShopifyAuthenticationDefaults.GrantOptionsAuthenticationProperty);
+            var prop = GetProperty(ShopifyAuthenticationDefaults.GrantOptionsAuthenticationProperty);
             return string.Equals(prop, ShopifyAuthenticationDefaults.PerUserAuthenticationPropertyValue, StringComparison.OrdinalIgnoreCase);
         }
 
@@ -77,6 +77,6 @@ public class ShopifyAuthenticationProperties : AuthenticationProperties
 
     private string? GetProperty(string propName)
     {
-        return Items.TryGetValue(propName, out string? val) ? val : null;
+        return Items.TryGetValue(propName, out var val) ? val : null;
     }
 }

--- a/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationHandler.cs
@@ -49,7 +49,7 @@ public partial class StackExchangeAuthenticationHandler : OAuthHandler<StackExch
             queryArguments["key"] = Options.RequestKey;
         }
 
-        string address = QueryHelpers.AddQueryString(Options.UserInformationEndpoint, queryArguments);
+        var address = QueryHelpers.AddQueryString(Options.UserInformationEndpoint, queryArguments);
 
         using var request = new HttpRequestMessage(HttpMethod.Get, address);
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
@@ -79,7 +79,7 @@ public partial class StackExchangeAuthenticationHandler : OAuthHandler<StackExch
             ["redirect_uri"] = context.RedirectUri,
             ["client_secret"] = Options.ClientSecret,
             ["code"] = context.Code,
-            ["grant_type"] = "authorization_code"
+            ["grant_type"] = "authorization_code",
         };
 
         // PKCE https://tools.ietf.org/html/rfc7636#section-4.5, see BuildChallengeUrl
@@ -107,7 +107,7 @@ public partial class StackExchangeAuthenticationHandler : OAuthHandler<StackExch
 
         var token = new JsonObject();
 
-        foreach ((string key, StringValues value) in content)
+        foreach ((var key, var value) in content)
         {
             token[key] = value.ToString();
         }

--- a/src/AspNet.Security.OAuth.Strava/StravaAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Strava/StravaAuthenticationHandler.cs
@@ -53,7 +53,13 @@ public partial class StravaAuthenticationHandler : OAuthHandler<StravaAuthentica
         return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
     }
 
-    protected override string FormatScope() => string.Join(',', Options.Scope);
+    /// <inheritdoc/>
+    protected override string FormatScope()
+        => FormatScope(Options.Scope); // TODO This override is the same as the base class' and can be removed in the next major version
+
+    /// <inheritdoc/>
+    protected override string FormatScope([NotNull] IEnumerable<string> scopes)
+        => string.Join(',', scopes);
 
     private static partial class Log
     {

--- a/src/AspNet.Security.OAuth.Streamlabs/StreamlabsAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Streamlabs/StreamlabsAuthenticationHandler.cs
@@ -25,11 +25,7 @@ public partial class StreamlabsAuthenticationHandler : OAuthHandler<StreamlabsAu
     }
 
     protected override string BuildChallengeUrl([NotNull] AuthenticationProperties properties, [NotNull] string redirectUri)
-    {
-        // TODO Removing this overload is technically a breaking change, so just delegate
-        // to the base implementation until a new major version when this can be removed.
-        return base.BuildChallengeUrl(properties, redirectUri);
-    }
+        => base.BuildChallengeUrl(properties, redirectUri); // TODO This override is the same as the base class' and can be removed in the next major version
 
     protected override async Task<AuthenticationTicket> CreateTicketAsync(
         [NotNull] ClaimsIdentity identity,

--- a/src/AspNet.Security.OAuth.Streamlabs/StreamlabsAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Streamlabs/StreamlabsAuthenticationHandler.cs
@@ -8,7 +8,6 @@ using System.Net.Http.Headers;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
 using System.Text.Json;
-using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -26,14 +25,11 @@ public partial class StreamlabsAuthenticationHandler : OAuthHandler<StreamlabsAu
     }
 
     protected override string BuildChallengeUrl([NotNull] AuthenticationProperties properties, [NotNull] string redirectUri)
-        => QueryHelpers.AddQueryString(Options.AuthorizationEndpoint, new Dictionary<string, string?>
-        {
-            ["client_id"] = Options.ClientId,
-            ["scope"] = FormatScope(),
-            ["response_type"] = "code",
-            ["redirect_uri"] = redirectUri,
-            ["state"] = Options.StateDataFormat.Protect(properties)
-        });
+    {
+        // Removing this overload is technically a breaking change, so just delegate
+        // to the base implementation until a new major version when this can be removed.
+        return base.BuildChallengeUrl(properties, redirectUri);
+    }
 
     protected override async Task<AuthenticationTicket> CreateTicketAsync(
         [NotNull] ClaimsIdentity identity,

--- a/src/AspNet.Security.OAuth.Streamlabs/StreamlabsAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Streamlabs/StreamlabsAuthenticationHandler.cs
@@ -26,7 +26,7 @@ public partial class StreamlabsAuthenticationHandler : OAuthHandler<StreamlabsAu
 
     protected override string BuildChallengeUrl([NotNull] AuthenticationProperties properties, [NotNull] string redirectUri)
     {
-        // Removing this overload is technically a breaking change, so just delegate
+        // TODO Removing this overload is technically a breaking change, so just delegate
         // to the base implementation until a new major version when this can be removed.
         return base.BuildChallengeUrl(properties, redirectUri);
     }

--- a/src/AspNet.Security.OAuth.Twitch/TwitchAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Twitch/TwitchAuthenticationHandler.cs
@@ -27,8 +27,8 @@ public partial class TwitchAuthenticationHandler : OAuthHandler<TwitchAuthentica
 
     protected override string BuildChallengeUrl([NotNull] AuthenticationProperties properties, [NotNull] string redirectUri)
     {
-        var redirectUrl = base.BuildChallengeUrl(properties, redirectUri);
-        return QueryHelpers.AddQueryString(redirectUrl, "force_verify", Options.ForceVerify ? "true" : "false");
+        var challengeUrl = base.BuildChallengeUrl(properties, redirectUri);
+        return QueryHelpers.AddQueryString(challengeUrl, "force_verify", Options.ForceVerify ? "true" : "false");
     }
 
     protected override async Task<AuthenticationTicket> CreateTicketAsync(

--- a/src/AspNet.Security.OAuth.Twitch/TwitchAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Twitch/TwitchAuthenticationHandler.cs
@@ -26,15 +26,10 @@ public partial class TwitchAuthenticationHandler : OAuthHandler<TwitchAuthentica
     }
 
     protected override string BuildChallengeUrl([NotNull] AuthenticationProperties properties, [NotNull] string redirectUri)
-        => QueryHelpers.AddQueryString(Options.AuthorizationEndpoint, new Dictionary<string, string?>
-        {
-            ["client_id"] = Options.ClientId,
-            ["scope"] = FormatScope(),
-            ["response_type"] = "code",
-            ["redirect_uri"] = redirectUri,
-            ["state"] = Options.StateDataFormat.Protect(properties),
-            ["force_verify"] = Options.ForceVerify ? "true" : "false"
-        });
+    {
+        var redirectUrl = base.BuildChallengeUrl(properties, redirectUri);
+        return QueryHelpers.AddQueryString(redirectUrl, "force_verify", Options.ForceVerify ? "true" : "false");
+    }
 
     protected override async Task<AuthenticationTicket> CreateTicketAsync(
         [NotNull] ClaimsIdentity identity,

--- a/src/AspNet.Security.OAuth.Untappd/UntappdAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Untappd/UntappdAuthenticationHandler.cs
@@ -44,7 +44,7 @@ public partial class UntappdAuthenticationHandler : OAuthHandler<UntappdAuthenti
             context.Properties.Items.Remove(OAuthConstants.CodeVerifierKey);
         }
 
-        using var requestContent = new FormUrlEncodedContent(tokenRequestParameters!);
+        using var requestContent = new FormUrlEncodedContent(tokenRequestParameters);
 
         string address = QueryHelpers.AddQueryString(Options.TokenEndpoint,
             new Dictionary<string, string?>

--- a/src/AspNet.Security.OAuth.Untappd/UntappdAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Untappd/UntappdAuthenticationHandler.cs
@@ -44,17 +44,17 @@ public partial class UntappdAuthenticationHandler : OAuthHandler<UntappdAuthenti
             context.Properties.Items.Remove(OAuthConstants.CodeVerifierKey);
         }
 
+        var parameters = new Dictionary<string, string?>
+        {
+            ["client_id"] = Options.ClientId,
+            ["redirect_uri"] = context.RedirectUri,
+            ["client_secret"] = Options.ClientSecret,
+            ["code"] = context.Code,
+        };
+
+        var address = QueryHelpers.AddQueryString(Options.TokenEndpoint, parameters);
+
         using var requestContent = new FormUrlEncodedContent(tokenRequestParameters);
-
-        string address = QueryHelpers.AddQueryString(Options.TokenEndpoint,
-            new Dictionary<string, string?>
-            {
-                ["client_id"] = Options.ClientId,
-                ["redirect_uri"] = context.RedirectUri,
-                ["client_secret"] = Options.ClientSecret,
-                ["code"] = context.Code
-            });
-
         using var requestMessage = new HttpRequestMessage(HttpMethod.Get, address);
         requestMessage.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
         requestMessage.Content = requestContent;

--- a/src/AspNet.Security.OAuth.VisualStudio/VisualStudioAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.VisualStudio/VisualStudioAuthenticationHandler.cs
@@ -71,7 +71,10 @@ public partial class VisualStudioAuthenticationHandler : OAuthHandler<VisualStud
         }
 
         using var request = new HttpRequestMessage(HttpMethod.Post, Options.TokenEndpoint);
+
+        // TODO Review whether this is just a copy-paste mistake and is redundant by testing with a real instance
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/x-www-form-urlencoded"));
+
         request.Content = new FormUrlEncodedContent(tokenRequestParameters);
 
         using var response = await Backchannel.SendAsync(request, Context.RequestAborted);

--- a/src/AspNet.Security.OAuth.VisualStudio/VisualStudioAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.VisualStudio/VisualStudioAuthenticationHandler.cs
@@ -83,14 +83,15 @@ public partial class VisualStudioAuthenticationHandler : OAuthHandler<VisualStud
 
     protected override string BuildChallengeUrl([NotNull] AuthenticationProperties properties, [NotNull] string redirectUri)
     {
-        return QueryHelpers.AddQueryString(Options.AuthorizationEndpoint, new Dictionary<string, string?>
-        {
-            ["client_id"] = Options.ClientId,
-            ["response_type"] = "Assertion",
-            ["scope"] = FormatScope(),
-            ["redirect_uri"] = redirectUri,
-            ["state"] = Options.StateDataFormat.Protect(properties),
-        });
+        var challengeUrl = base.BuildChallengeUrl(properties, redirectUri);
+
+        // Visual Studio Online/Azure DevOps uses "Assertion" instead of "code"
+        var challengeUri = new Uri(challengeUrl);
+        var query = QueryHelpers.ParseQuery(challengeUri.Query);
+
+        query["response_type"] = "Assertion";
+
+        return QueryHelpers.AddQueryString(Options.AuthorizationEndpoint, query);
     }
 
     private static partial class Log

--- a/src/AspNet.Security.OAuth.VisualStudio/VisualStudioAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.VisualStudio/VisualStudioAuthenticationHandler.cs
@@ -92,7 +92,7 @@ public partial class VisualStudioAuthenticationHandler : OAuthHandler<VisualStud
         var challengeUrl = base.BuildChallengeUrl(properties, redirectUri);
 
         // Visual Studio Online/Azure DevOps uses "Assertion" instead of "code"
-        var challengeUri = new Uri(challengeUrl);
+        var challengeUri = new Uri(challengeUrl, UriKind.Absolute);
         var query = QueryHelpers.ParseQuery(challengeUri.Query);
 
         query["response_type"] = "Assertion";

--- a/src/AspNet.Security.OAuth.VisualStudio/VisualStudioAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.VisualStudio/VisualStudioAuthenticationHandler.cs
@@ -60,7 +60,7 @@ public partial class VisualStudioAuthenticationHandler : OAuthHandler<VisualStud
             ["client_assertion"] = Options.ClientSecret,
             ["assertion"] = context.Code,
             ["grant_type"] = "urn:ietf:params:oauth:grant-type:jwt-bearer",
-            ["client_assertion_type"] = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+            ["client_assertion_type"] = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
         };
 
         // PKCE https://tools.ietf.org/html/rfc7636#section-4.5, see BuildChallengeUrl

--- a/src/AspNet.Security.OAuth.Vkontakte/VkontakteAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Vkontakte/VkontakteAuthenticationHandler.cs
@@ -29,11 +29,13 @@ public partial class VkontakteAuthenticationHandler : OAuthHandler<VkontakteAuth
         [NotNull] AuthenticationProperties properties,
         [NotNull] OAuthTokenResponse tokens)
     {
-        string address = QueryHelpers.AddQueryString(Options.UserInformationEndpoint, new Dictionary<string, string?>
+        var parameters = new Dictionary<string, string?>
         {
             ["access_token"] = tokens.AccessToken,
-            ["v"] = !string.IsNullOrEmpty(Options.ApiVersion) ? Options.ApiVersion : VkontakteAuthenticationDefaults.ApiVersion
-        });
+            ["v"] = !string.IsNullOrEmpty(Options.ApiVersion) ? Options.ApiVersion : VkontakteAuthenticationDefaults.ApiVersion,
+        };
+
+        var address = QueryHelpers.AddQueryString(Options.UserInformationEndpoint, parameters);
 
         if (Options.Fields.Count != 0)
         {

--- a/src/AspNet.Security.OAuth.Weibo/WeiboAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Weibo/WeiboAuthenticationHandler.cs
@@ -71,7 +71,13 @@ public partial class WeiboAuthenticationHandler : OAuthHandler<WeiboAuthenticati
         return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
     }
 
-    protected override string FormatScope() => string.Join(',', Options.Scope);
+    /// <inheritdoc/>
+    protected override string FormatScope()
+        => FormatScope(Options.Scope); // TODO This override is the same as the base class' and can be removed in the next major version
+
+    /// <inheritdoc/>
+    protected override string FormatScope([NotNull] IEnumerable<string> scopes)
+        => string.Join(',', scopes);
 
     protected virtual async Task<string?> GetEmailAsync([NotNull] OAuthTokenResponse tokens)
     {

--- a/src/AspNet.Security.OAuth.Weibo/WeiboAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Weibo/WeiboAuthenticationHandler.cs
@@ -31,11 +31,13 @@ public partial class WeiboAuthenticationHandler : OAuthHandler<WeiboAuthenticati
         [NotNull] AuthenticationProperties properties,
         [NotNull] OAuthTokenResponse tokens)
     {
-        string address = QueryHelpers.AddQueryString(Options.UserInformationEndpoint, new Dictionary<string, string?>
+        var parameters = new Dictionary<string, string?>
         {
             ["access_token"] = tokens.AccessToken,
-            ["uid"] = tokens.Response!.RootElement.GetString("uid")
-        });
+            ["uid"] = tokens.Response!.RootElement.GetString("uid"),
+        };
+
+        var address = QueryHelpers.AddQueryString(Options.UserInformationEndpoint, parameters);
 
         using var request = new HttpRequestMessage(HttpMethod.Get, address);
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
@@ -55,7 +57,7 @@ public partial class WeiboAuthenticationHandler : OAuthHandler<WeiboAuthenticati
             !identity.HasClaim(claim => claim.Type == ClaimTypes.Email) &&
             Options.Scope.Contains("email"))
         {
-            string? email = await GetEmailAsync(tokens);
+            var email = await GetEmailAsync(tokens);
 
             if (!string.IsNullOrEmpty(address))
             {
@@ -82,7 +84,7 @@ public partial class WeiboAuthenticationHandler : OAuthHandler<WeiboAuthenticati
     protected virtual async Task<string?> GetEmailAsync([NotNull] OAuthTokenResponse tokens)
     {
         // See http://open.weibo.com/wiki/2/account/profile/email for more information about the /account/profile/email.json endpoint.
-        string address = QueryHelpers.AddQueryString(Options.UserEmailsEndpoint, "access_token", tokens.AccessToken!);
+        var address = QueryHelpers.AddQueryString(Options.UserEmailsEndpoint, "access_token", tokens.AccessToken!);
 
         using var request = new HttpRequestMessage(HttpMethod.Get, address);
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));

--- a/src/AspNet.Security.OAuth.Weixin/WeixinAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Weixin/WeixinAuthenticationHandler.cs
@@ -139,7 +139,7 @@ public partial class WeixinAuthenticationHandler : OAuthHandler<WeixinAuthentica
         if (Options.UsePkce)
         {
             var bytes = RandomNumberGenerator.GetBytes(32);
-            var codeVerifier = Microsoft.AspNetCore.Authentication.Base64UrlTextEncoder.Encode(bytes);
+            var codeVerifier = WebEncoders.Base64UrlEncode(bytes);
 
             // Store this for use during the code redemption.
             properties.Items.Add(OAuthConstants.CodeVerifierKey, codeVerifier);

--- a/src/AspNet.Security.OAuth.Weixin/WeixinAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Weixin/WeixinAuthenticationHandler.cs
@@ -57,7 +57,7 @@ public partial class WeixinAuthenticationHandler : OAuthHandler<WeixinAuthentica
         var parameters = new Dictionary<string, string?>
         {
             ["access_token"] = tokens.AccessToken,
-            ["openid"] = tokens.Response?.RootElement.GetString("openid")
+            ["openid"] = tokens.Response?.RootElement.GetString("openid"),
         };
 
         var address = QueryHelpers.AddQueryString(Options.UserInformationEndpoint, parameters);
@@ -94,7 +94,7 @@ public partial class WeixinAuthenticationHandler : OAuthHandler<WeixinAuthentica
             ["appid"] = Options.ClientId,
             ["secret"] = Options.ClientSecret,
             ["code"] = context.Code,
-            ["grant_type"] = "authorization_code"
+            ["grant_type"] = "authorization_code",
         };
 
         // PKCE https://tools.ietf.org/html/rfc7636#section-4.5, see BuildChallengeUrl

--- a/src/AspNet.Security.OAuth.Weixin/WeixinAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Weixin/WeixinAuthenticationHandler.cs
@@ -54,11 +54,13 @@ public partial class WeixinAuthenticationHandler : OAuthHandler<WeixinAuthentica
         [NotNull] AuthenticationProperties properties,
         [NotNull] OAuthTokenResponse tokens)
     {
-        string address = QueryHelpers.AddQueryString(Options.UserInformationEndpoint, new Dictionary<string, string?>
+        var parameters = new Dictionary<string, string?>
         {
             ["access_token"] = tokens.AccessToken,
             ["openid"] = tokens.Response?.RootElement.GetString("openid")
-        });
+        };
+
+        var address = QueryHelpers.AddQueryString(Options.UserInformationEndpoint, parameters);
 
         using var response = await Backchannel.GetAsync(address);
         if (!response.IsSuccessStatusCode)
@@ -102,7 +104,7 @@ public partial class WeixinAuthenticationHandler : OAuthHandler<WeixinAuthentica
             context.Properties.Items.Remove(OAuthConstants.CodeVerifierKey);
         }
 
-        string address = QueryHelpers.AddQueryString(Options.TokenEndpoint, tokenRequestParameters);
+        var address = QueryHelpers.AddQueryString(Options.TokenEndpoint, tokenRequestParameters);
 
         using var response = await Backchannel.GetAsync(address);
         if (!response.IsSuccessStatusCode)
@@ -150,8 +152,8 @@ public partial class WeixinAuthenticationHandler : OAuthHandler<WeixinAuthentica
             parameters[OAuthConstants.CodeChallengeMethodKey] = OAuthConstants.CodeChallengeMethodS256;
         }
 
-        string state = Options.StateDataFormat.Protect(properties);
-        bool addRedirectHash = false;
+        var state = Options.StateDataFormat.Protect(properties);
+        var addRedirectHash = false;
 
         if (!IsWeixinAuthorizationEndpointInUse())
         {
@@ -163,7 +165,7 @@ public partial class WeixinAuthenticationHandler : OAuthHandler<WeixinAuthentica
         parameters["redirect_uri"] = redirectUri;
         parameters[State] = addRedirectHash ? OauthState : state;
 
-        string challengeUrl = QueryHelpers.AddQueryString(Options.AuthorizationEndpoint, parameters);
+        var challengeUrl = QueryHelpers.AddQueryString(Options.AuthorizationEndpoint, parameters);
 
         if (addRedirectHash)
         {

--- a/src/AspNet.Security.OAuth.Weixin/WeixinAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Weixin/WeixinAuthenticationHandler.cs
@@ -143,7 +143,13 @@ public partial class WeixinAuthenticationHandler : OAuthHandler<WeixinAuthentica
         return redirectUri;
     }
 
-    protected override string FormatScope() => string.Join(',', Options.Scope);
+    /// <inheritdoc/>
+    protected override string FormatScope()
+        => FormatScope(Options.Scope); // TODO This override is the same as the base class' and can be removed in the next major version
+
+    /// <inheritdoc/>
+    protected override string FormatScope([NotNull] IEnumerable<string> scopes)
+        => string.Join(',', scopes);
 
     private bool IsWeixinAuthorizationEndpointInUse()
     {

--- a/src/AspNet.Security.OAuth.Weixin/WeixinAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Weixin/WeixinAuthenticationHandler.cs
@@ -138,7 +138,7 @@ public partial class WeixinAuthenticationHandler : OAuthHandler<WeixinAuthentica
 
         if (Options.UsePkce)
         {
-            var bytes = RandomNumberGenerator.GetBytes(32);
+            var bytes = RandomNumberGenerator.GetBytes(256 / 8);
             var codeVerifier = WebEncoders.Base64UrlEncode(bytes);
 
             // Store this for use during the code redemption.

--- a/src/AspNet.Security.OAuth.WorkWeixin/WorkWeixinAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.WorkWeixin/WorkWeixinAuthenticationHandler.cs
@@ -111,7 +111,7 @@ public partial class WorkWeixinAuthenticationHandler : OAuthHandler<WorkWeixinAu
 
         if (Options.UsePkce)
         {
-            var bytes = RandomNumberGenerator.GetBytes(32);
+            var bytes = RandomNumberGenerator.GetBytes(256 / 8);
             var codeVerifier = WebEncoders.Base64UrlEncode(bytes);
 
             // Store this for use during the code redemption.

--- a/src/AspNet.Security.OAuth.WorkWeixin/WorkWeixinAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.WorkWeixin/WorkWeixinAuthenticationHandler.cs
@@ -43,7 +43,7 @@ public partial class WorkWeixinAuthenticationHandler : OAuthHandler<WorkWeixinAu
         var parameters = new Dictionary<string, string?>
         {
             ["access_token"] = tokens.AccessToken,
-            ["userid"] = userId
+            ["userid"] = userId,
         };
 
         var address = QueryHelpers.AddQueryString(Options.UserInformationEndpoint, parameters);
@@ -137,7 +137,7 @@ public partial class WorkWeixinAuthenticationHandler : OAuthHandler<WorkWeixinAu
         var parameters = new Dictionary<string, string?>
         {
             ["access_token"] = tokens.AccessToken,
-            ["code"] = Request.Query["code"]
+            ["code"] = Request.Query["code"],
         };
 
         var address = QueryHelpers.AddQueryString(Options.UserIdentificationEndpoint, parameters);

--- a/src/AspNet.Security.OAuth.WorkWeixin/WorkWeixinAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.WorkWeixin/WorkWeixinAuthenticationHandler.cs
@@ -112,7 +112,7 @@ public partial class WorkWeixinAuthenticationHandler : OAuthHandler<WorkWeixinAu
         if (Options.UsePkce)
         {
             var bytes = RandomNumberGenerator.GetBytes(32);
-            var codeVerifier = Microsoft.AspNetCore.Authentication.Base64UrlTextEncoder.Encode(bytes);
+            var codeVerifier = WebEncoders.Base64UrlEncode(bytes);
 
             // Store this for use during the code redemption.
             properties.Items.Add(OAuthConstants.CodeVerifierKey, codeVerifier);

--- a/src/AspNet.Security.OAuth.Yahoo/YahooAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Yahoo/YahooAuthenticationHandler.cs
@@ -58,7 +58,7 @@ public partial class YahooAuthenticationHandler : OAuthHandler<YahooAuthenticati
         {
             ["grant_type"] = "authorization_code",
             ["redirect_uri"] = context.RedirectUri,
-            ["code"] = context.Code
+            ["code"] = context.Code,
         };
 
         // PKCE https://tools.ietf.org/html/rfc7636#section-4.5, see BuildChallengeUrl
@@ -97,7 +97,7 @@ public partial class YahooAuthenticationHandler : OAuthHandler<YahooAuthenticati
             return Uri.EscapeDataString(value).Replace("%20", "+", StringComparison.Ordinal);
         }
 
-        string credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes(
+        var credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes(
             string.Concat(
                 EscapeDataString(Options.ClientId),
                 ":",

--- a/src/AspNet.Security.OAuth.Yahoo/YahooAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Yahoo/YahooAuthenticationHandler.cs
@@ -54,18 +54,24 @@ public partial class YahooAuthenticationHandler : OAuthHandler<YahooAuthenticati
 
     protected override async Task<OAuthTokenResponse> ExchangeCodeAsync([NotNull] OAuthCodeExchangeContext context)
     {
-        using var request = new HttpRequestMessage(HttpMethod.Post, Options.TokenEndpoint);
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-        request.Headers.Authorization = CreateAuthorizationHeader();
-
-        var parameters = new Dictionary<string, string>
+        var tokenRequestParameters = new Dictionary<string, string>
         {
             ["grant_type"] = "authorization_code",
             ["redirect_uri"] = context.RedirectUri,
             ["code"] = context.Code
         };
 
-        request.Content = new FormUrlEncodedContent(parameters!);
+        // PKCE https://tools.ietf.org/html/rfc7636#section-4.5, see BuildChallengeUrl
+        if (context.Properties.Items.TryGetValue(OAuthConstants.CodeVerifierKey, out var codeVerifier))
+        {
+            tokenRequestParameters.Add(OAuthConstants.CodeVerifierKey, codeVerifier!);
+            context.Properties.Items.Remove(OAuthConstants.CodeVerifierKey);
+        }
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, Options.TokenEndpoint);
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        request.Headers.Authorization = CreateAuthorizationHeader();
+        request.Content = new FormUrlEncodedContent(tokenRequestParameters);
 
         using var response = await Backchannel.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, Context.RequestAborted);
         if (!response.IsSuccessStatusCode)

--- a/src/AspNet.Security.OAuth.Yammer/YammerAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Yammer/YammerAuthenticationHandler.cs
@@ -59,7 +59,7 @@ public partial class YammerAuthenticationHandler : OAuthHandler<YammerAuthentica
             ["redirect_uri"] = context.RedirectUri,
             ["client_secret"] = Options.ClientSecret,
             ["code"] = context.Code,
-            ["grant_type"] = "authorization_code"
+            ["grant_type"] = "authorization_code",
         };
 
         // PKCE https://tools.ietf.org/html/rfc7636#section-4.5, see BuildChallengeUrl
@@ -84,7 +84,7 @@ public partial class YammerAuthenticationHandler : OAuthHandler<YammerAuthentica
         // with the OAuth2 generic middleware, a compliant JSON payload is generated manually.
         // See https://developer.yammer.com/docs/oauth-2 for more information about this process.
         using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
-        string? accessToken = payload.RootElement.GetProperty("access_token").GetString("token");
+        var accessToken = payload.RootElement.GetProperty("access_token").GetString("token");
 
         var token = new
         {

--- a/src/AspNet.Security.OAuth.Yandex/YandexAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Yandex/YandexAuthenticationHandler.cs
@@ -98,7 +98,7 @@ public partial class YandexAuthenticationHandler : OAuthHandler<YandexAuthentica
             return Uri.EscapeDataString(value).Replace("%20", "+", StringComparison.Ordinal);
         }
 
-        string credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes(
+        var credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes(
             string.Concat(
                 EscapeDataString(Options.ClientId),
                 ":",

--- a/src/AspNet.Security.OAuth.Zalo/ZaloAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Zalo/ZaloAuthenticationHandler.cs
@@ -31,11 +31,13 @@ public partial class ZaloAuthenticationHandler : OAuthHandler<ZaloAuthentication
         [NotNull] OAuthTokenResponse tokens)
     {
         // See https://developers.zalo.me/docs/api/social-api/tai-lieu/thong-tin-nguoi-dung-post-28
-        string address = QueryHelpers.AddQueryString(Options.UserInformationEndpoint, new Dictionary<string, string?>
+        var parameters = new Dictionary<string, string?>
         {
             ["access_token"] = tokens.AccessToken,
-            ["fields"] = "id,name,birthday,gender"
-        });
+            ["fields"] = "id,name,birthday,gender",
+        };
+
+        var address = QueryHelpers.AddQueryString(Options.UserInformationEndpoint, parameters);
 
         using var request = new HttpRequestMessage(HttpMethod.Get, address);
 
@@ -79,7 +81,7 @@ public partial class ZaloAuthenticationHandler : OAuthHandler<ZaloAuthentication
             context.Properties.Items.Remove(OAuthConstants.CodeVerifierKey);
         }
 
-        string address = QueryHelpers.AddQueryString(Options.TokenEndpoint, tokenRequestParameters);
+        var address = QueryHelpers.AddQueryString(Options.TokenEndpoint, tokenRequestParameters);
 
         using var request = new HttpRequestMessage(HttpMethod.Get, address);
         using var response = await Backchannel.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, Context.RequestAborted);

--- a/src/AspNet.Security.OAuth.Zalo/ZaloAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Zalo/ZaloAuthenticationHandler.cs
@@ -58,8 +58,8 @@ public partial class ZaloAuthenticationHandler : OAuthHandler<ZaloAuthentication
 
     protected override string BuildChallengeUrl([NotNull] AuthenticationProperties properties, [NotNull] string redirectUri)
     {
-        string address = base.BuildChallengeUrl(properties, redirectUri);
-        return QueryHelpers.AddQueryString(address, "app_id", Options.ClientId);
+        var challengeUrl = base.BuildChallengeUrl(properties, redirectUri);
+        return QueryHelpers.AddQueryString(challengeUrl, "app_id", Options.ClientId);
     }
 
     protected override async Task<OAuthTokenResponse> ExchangeCodeAsync([NotNull] OAuthCodeExchangeContext context)

--- a/test/AspNet.Security.OAuth.Providers.Tests/Alipay/AlipayTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Alipay/AlipayTests.cs
@@ -93,6 +93,6 @@ public class AlipayTests : OAuthTests<AlipayAuthenticationOptions>
 
     private sealed class FixedClock : ISystemClock
     {
-        public DateTimeOffset UtcNow => new DateTimeOffset(2019, 12, 14, 22, 22, 22, TimeSpan.Zero);
+        public DateTimeOffset UtcNow => new(2019, 12, 14, 22, 22, 22, TimeSpan.Zero);
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/AspNet.Security.OAuth.Providers.Tests.csproj
+++ b/test/AspNet.Security.OAuth.Providers.Tests/AspNet.Security.OAuth.Providers.Tests.csproj
@@ -5,7 +5,7 @@
     <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-    <NoWarn>$(NoWarn);CA1707;CA2227;CA5404</NoWarn>
+    <NoWarn>$(NoWarn);CA1054;CA1055;CA1707;CA2227;CA5404</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/AspNet.Security.OAuth.Providers.Tests/Infrastructure/ApplicationFactory.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Infrastructure/ApplicationFactory.cs
@@ -29,7 +29,7 @@ public static class ApplicationFactory
     /// The test application to use for the authentication provider.
     /// </returns>
     public static WebApplicationFactory<Program> CreateApplication<TOptions>(OAuthTests<TOptions> tests, Action<IServiceCollection>? configureServices = null)
-        where TOptions : OAuthOptions
+        where TOptions : OAuthOptions, new()
     {
 #pragma warning disable CA2000
         return new TestApplicationFactory()
@@ -46,7 +46,7 @@ public static class ApplicationFactory
     }
 
     private static void Configure<TOptions>(IWebHostBuilder builder, OAuthTests<TOptions> tests)
-        where TOptions : OAuthOptions
+        where TOptions : OAuthOptions, new()
     {
         // Route application logs to xunit output for debugging
         builder.ConfigureLogging(logging =>
@@ -79,7 +79,7 @@ public static class ApplicationFactory
     }
 
     private static void ConfigureApplication<TOptions>(IApplicationBuilder app, OAuthTests<TOptions> tests)
-        where TOptions : OAuthOptions
+        where TOptions : OAuthOptions, new()
     {
         tests.ConfigureApplication(app);
 

--- a/test/AspNet.Security.OAuth.Providers.Tests/Mixcloud/MixcloudTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Mixcloud/MixcloudTests.cs
@@ -4,6 +4,8 @@
  * for more information concerning the license and the contributors participating to this project.
  */
 
+using Microsoft.AspNetCore.WebUtilities;
+
 namespace AspNet.Security.OAuth.Mixcloud;
 
 public class MixcloudTests : OAuthTests<MixcloudAuthenticationOptions>
@@ -40,5 +42,48 @@ public class MixcloudTests : OAuthTests<MixcloudAuthenticationOptions>
 
         // Assert
         AssertClaim(claims, claimType, claimValue);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task BuildChallengeUrl_Generates_Correct_Url(bool usePkce)
+    {
+        // Arrange
+        var options = new MixcloudAuthenticationOptions()
+        {
+            UsePkce = usePkce,
+        };
+
+        string redirectUrl = "https://my-site.local/signin-mixcloud";
+
+        // Act
+        Uri actual = await BuildChallengeUriAsync(
+            options,
+            redirectUrl,
+            (options, loggerFactory, encoder, clock) => new MixcloudAuthenticationHandler(options, loggerFactory, encoder, clock));
+
+        // Assert
+        actual.ShouldNotBeNull();
+        actual.ToString().ShouldStartWith("https://www.mixcloud.com/oauth/authorize?");
+
+        var query = QueryHelpers.ParseQuery(actual.Query);
+
+        query.ShouldContainKey("state");
+        query.ShouldContainKeyAndValue("client_id", options.ClientId);
+        query.ShouldContainKeyAndValue("redirect_uri", redirectUrl + "?state=");
+        query.ShouldContainKeyAndValue("response_type", "code");
+        query.ShouldContainKeyAndValue("scope", "scope-1 scope-2");
+
+        if (usePkce)
+        {
+            query.ShouldContainKey(OAuthConstants.CodeChallengeKey);
+            query.ShouldContainKey(OAuthConstants.CodeChallengeMethodKey);
+        }
+        else
+        {
+            query.ShouldNotContainKey(OAuthConstants.CodeChallengeKey);
+            query.ShouldNotContainKey(OAuthConstants.CodeChallengeMethodKey);
+        }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/OAuthTests`1.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/OAuthTests`1.cs
@@ -306,11 +306,14 @@ public abstract class OAuthTests<TOptions> : ITestOutputHelperAccessor
     protected async Task<Uri> BuildChallengeUriAsync<THandler>(
         TOptions options,
         string redirectUrl,
-        Func<IOptionsMonitor<TOptions>, ILoggerFactory, UrlEncoder, ISystemClock, THandler> factory)
+        Func<IOptionsMonitor<TOptions>, ILoggerFactory, UrlEncoder, ISystemClock, THandler> factory,
+        AuthenticationProperties? properties = null)
         where THandler : OAuthHandler<TOptions>
     {
         var scheme = new AuthenticationScheme("Test", "Test", typeof(THandler));
         var context = new DefaultHttpContext();
+
+        properties ??= new();
 
         options.ClientId ??= "client-id";
         options.ClientSecret ??= "client-secret";
@@ -348,7 +351,7 @@ public abstract class OAuthTests<TOptions> : ITestOutputHelperAccessor
         var type = handler.GetType();
         var method = type.GetMethod("BuildChallengeUrl", BindingFlags.NonPublic | BindingFlags.Instance);
 
-        object[] parameters = new object[] { new AuthenticationProperties(), redirectUrl };
+        object[] parameters = new object[] { properties, redirectUrl };
 
         string url = (string)method!.Invoke(handler, parameters)!;
 

--- a/test/AspNet.Security.OAuth.Providers.Tests/QQ/QQTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/QQ/QQTests.cs
@@ -4,6 +4,8 @@
  * for more information concerning the license and the contributors participating to this project.
  */
 
+using Microsoft.AspNetCore.WebUtilities;
+
 namespace AspNet.Security.OAuth.QQ;
 
 public class QQTests : OAuthTests<QQAuthenticationOptions>
@@ -43,5 +45,50 @@ public class QQTests : OAuthTests<QQAuthenticationOptions>
 
         // Assert
         AssertClaim(claims, claimType, claimValue);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task BuildChallengeUrl_Generates_Correct_Url(bool usePkce)
+    {
+        // Arrange
+        var options = new QQAuthenticationOptions()
+        {
+            UsePkce = usePkce,
+        };
+
+        options.Scope.Add("scope-1");
+
+        string redirectUrl = "https://my-site.local/signin-qq";
+
+        // Act
+        Uri actual = await BuildChallengeUriAsync(
+            options,
+            redirectUrl,
+            (options, loggerFactory, encoder, clock) => new QQAuthenticationHandler(options, loggerFactory, encoder, clock));
+
+        // Assert
+        actual.ShouldNotBeNull();
+        actual.ToString().ShouldStartWith("https://graph.qq.com/oauth2.0/authorize?");
+
+        var query = QueryHelpers.ParseQuery(actual.Query);
+
+        query.ShouldContainKey("state");
+        query.ShouldContainKeyAndValue("client_id", options.ClientId);
+        query.ShouldContainKeyAndValue("redirect_uri", redirectUrl);
+        query.ShouldContainKeyAndValue("response_type", "code");
+        query.ShouldContainKeyAndValue("scope", "get_user_info,scope-1");
+
+        if (usePkce)
+        {
+            query.ShouldContainKey(OAuthConstants.CodeChallengeKey);
+            query.ShouldContainKey(OAuthConstants.CodeChallengeMethodKey);
+        }
+        else
+        {
+            query.ShouldNotContainKey(OAuthConstants.CodeChallengeKey);
+            query.ShouldNotContainKey(OAuthConstants.CodeChallengeMethodKey);
+        }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Strava/StravaTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Strava/StravaTests.cs
@@ -4,6 +4,8 @@
  * for more information concerning the license and the contributors participating to this project.
  */
 
+using Microsoft.AspNetCore.WebUtilities;
+
 namespace AspNet.Security.OAuth.Strava;
 
 public class StravaTests : OAuthTests<StravaAuthenticationOptions>
@@ -45,5 +47,50 @@ public class StravaTests : OAuthTests<StravaAuthenticationOptions>
 
         // Assert
         AssertClaim(claims, claimType, claimValue);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task BuildChallengeUrl_Generates_Correct_Url(bool usePkce)
+    {
+        // Arrange
+        var options = new StravaAuthenticationOptions()
+        {
+            UsePkce = usePkce,
+        };
+
+        options.Scope.Add("scope-1");
+
+        string redirectUrl = "https://my-site.local/signin-strava";
+
+        // Act
+        Uri actual = await BuildChallengeUriAsync(
+            options,
+            redirectUrl,
+            (options, loggerFactory, encoder, clock) => new StravaAuthenticationHandler(options, loggerFactory, encoder, clock));
+
+        // Assert
+        actual.ShouldNotBeNull();
+        actual.ToString().ShouldStartWith("https://www.strava.com/oauth/authorize?");
+
+        var query = QueryHelpers.ParseQuery(actual.Query);
+
+        query.ShouldContainKey("state");
+        query.ShouldContainKeyAndValue("client_id", options.ClientId);
+        query.ShouldContainKeyAndValue("redirect_uri", redirectUrl);
+        query.ShouldContainKeyAndValue("response_type", "code");
+        query.ShouldContainKeyAndValue("scope", "read,scope-1");
+
+        if (usePkce)
+        {
+            query.ShouldContainKey(OAuthConstants.CodeChallengeKey);
+            query.ShouldContainKey(OAuthConstants.CodeChallengeMethodKey);
+        }
+        else
+        {
+            query.ShouldNotContainKey(OAuthConstants.CodeChallengeKey);
+            query.ShouldNotContainKey(OAuthConstants.CodeChallengeMethodKey);
+        }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Streamlabs/StreamlabsTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Streamlabs/StreamlabsTests.cs
@@ -4,6 +4,8 @@
  * for more information concerning the license and the contributors participating to this project.
  */
 
+using Microsoft.AspNetCore.WebUtilities;
+
 namespace AspNet.Security.OAuth.Streamlabs;
 
 public class StreamlabsTests : OAuthTests<StreamlabsAuthenticationOptions>
@@ -44,5 +46,48 @@ public class StreamlabsTests : OAuthTests<StreamlabsAuthenticationOptions>
 
         // Assert
         AssertClaim(claims, claimType, claimValue);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task BuildChallengeUrl_Generates_Correct_Url(bool usePkce)
+    {
+        // Arrange
+        var options = new StreamlabsAuthenticationOptions()
+        {
+            UsePkce = usePkce,
+        };
+
+        string redirectUrl = "https://my-site.local/signin-streamlabs";
+
+        // Act
+        Uri actual = await BuildChallengeUriAsync(
+            options,
+            redirectUrl,
+            (options, loggerFactory, encoder, clock) => new StreamlabsAuthenticationHandler(options, loggerFactory, encoder, clock));
+
+        // Assert
+        actual.ShouldNotBeNull();
+        actual.ToString().ShouldStartWith("https://streamlabs.com/api/v1.0/authorize?");
+
+        var query = QueryHelpers.ParseQuery(actual.Query);
+
+        query.ShouldContainKey("state");
+        query.ShouldContainKeyAndValue("client_id", options.ClientId);
+        query.ShouldContainKeyAndValue("redirect_uri", redirectUrl);
+        query.ShouldContainKeyAndValue("response_type", "code");
+        query.ShouldContainKeyAndValue("scope", "scope-1 scope-2");
+
+        if (usePkce)
+        {
+            query.ShouldContainKey(OAuthConstants.CodeChallengeKey);
+            query.ShouldContainKey(OAuthConstants.CodeChallengeMethodKey);
+        }
+        else
+        {
+            query.ShouldNotContainKey(OAuthConstants.CodeChallengeKey);
+            query.ShouldNotContainKey(OAuthConstants.CodeChallengeMethodKey);
+        }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Twitch/TwitchTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Twitch/TwitchTests.cs
@@ -4,6 +4,8 @@
  * for more information concerning the license and the contributors participating to this project.
  */
 
+using Microsoft.AspNetCore.WebUtilities;
+
 namespace AspNet.Security.OAuth.Twitch;
 
 public class TwitchTests : OAuthTests<TwitchAuthenticationOptions>
@@ -40,5 +42,60 @@ public class TwitchTests : OAuthTests<TwitchAuthenticationOptions>
 
         // Assert
         AssertClaim(claims, claimType, claimValue);
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(true, true)]
+    public async Task BuildChallengeUrl_Generates_Correct_Url(bool usePkce, bool forceVerify)
+    {
+        // Arrange
+        var options = new TwitchAuthenticationOptions()
+        {
+            ForceVerify = forceVerify,
+            UsePkce = usePkce,
+        };
+
+        options.Scope.Add("scope-1");
+
+        string redirectUrl = "https://my-site.local/signin-twitch";
+
+        // Act
+        Uri actual = await BuildChallengeUriAsync(
+            options,
+            redirectUrl,
+            (options, loggerFactory, encoder, clock) => new TwitchAuthenticationHandler(options, loggerFactory, encoder, clock));
+
+        // Assert
+        actual.ShouldNotBeNull();
+        actual.ToString().ShouldStartWith("https://id.twitch.tv/oauth2/authorize?");
+
+        var query = QueryHelpers.ParseQuery(actual.Query);
+
+        query.ShouldContainKey("state");
+        query.ShouldContainKeyAndValue("client_id", options.ClientId);
+        query.ShouldContainKeyAndValue("redirect_uri", redirectUrl);
+        query.ShouldContainKeyAndValue("response_type", "code");
+        query.ShouldContainKeyAndValue("scope", "user:read:email scope-1");
+
+        if (usePkce)
+        {
+            query.ShouldContainKey(OAuthConstants.CodeChallengeKey);
+            query.ShouldContainKey(OAuthConstants.CodeChallengeMethodKey);
+        }
+        else
+        {
+            query.ShouldNotContainKey(OAuthConstants.CodeChallengeKey);
+            query.ShouldNotContainKey(OAuthConstants.CodeChallengeMethodKey);
+        }
+
+        if (forceVerify)
+        {
+            query.ShouldContainKey("force_verify", "true");
+        }
+        else
+        {
+            query.ShouldContainKey("force_verify", "false");
+        }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Weibo/WeiboTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Weibo/WeiboTests.cs
@@ -4,6 +4,8 @@
  * for more information concerning the license and the contributors participating to this project.
  */
 
+using Microsoft.AspNetCore.WebUtilities;
+
 namespace AspNet.Security.OAuth.Weibo;
 
 public class WeiboTests : OAuthTests<WeiboAuthenticationOptions>
@@ -41,5 +43,50 @@ public class WeiboTests : OAuthTests<WeiboAuthenticationOptions>
 
         // Assert
         AssertClaim(claims, claimType, claimValue);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task BuildChallengeUrl_Generates_Correct_Url(bool usePkce)
+    {
+        // Arrange
+        var options = new WeiboAuthenticationOptions()
+        {
+            UsePkce = usePkce,
+        };
+
+        options.Scope.Add("scope-1");
+
+        string redirectUrl = "https://my-site.local/signin-weibo";
+
+        // Act
+        Uri actual = await BuildChallengeUriAsync(
+            options,
+            redirectUrl,
+            (options, loggerFactory, encoder, clock) => new WeiboAuthenticationHandler(options, loggerFactory, encoder, clock));
+
+        // Assert
+        actual.ShouldNotBeNull();
+        actual.ToString().ShouldStartWith("https://api.weibo.com/oauth2/authorize?");
+
+        var query = QueryHelpers.ParseQuery(actual.Query);
+
+        query.ShouldContainKey("state");
+        query.ShouldContainKeyAndValue("client_id", options.ClientId);
+        query.ShouldContainKeyAndValue("redirect_uri", redirectUrl);
+        query.ShouldContainKeyAndValue("response_type", "code");
+        query.ShouldContainKeyAndValue("scope", "email,scope-1");
+
+        if (usePkce)
+        {
+            query.ShouldContainKey(OAuthConstants.CodeChallengeKey);
+            query.ShouldContainKey(OAuthConstants.CodeChallengeMethodKey);
+        }
+        else
+        {
+            query.ShouldNotContainKey(OAuthConstants.CodeChallengeKey);
+            query.ShouldNotContainKey(OAuthConstants.CodeChallengeMethodKey);
+        }
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Weixin/WeixinTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Weixin/WeixinTests.cs
@@ -4,6 +4,8 @@
  * for more information concerning the license and the contributors participating to this project.
  */
 
+using Microsoft.AspNetCore.WebUtilities;
+
 namespace AspNet.Security.OAuth.Weixin;
 
 public class WeixinTests : OAuthTests<WeixinAuthenticationOptions>
@@ -40,5 +42,48 @@ public class WeixinTests : OAuthTests<WeixinAuthenticationOptions>
 
         // Assert
         AssertClaim(claims, claimType, claimValue);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task BuildChallengeUrl_Generates_Correct_Url(bool usePkce)
+    {
+        // Arrange
+        var options = new WeixinAuthenticationOptions()
+        {
+            UsePkce = usePkce,
+        };
+
+        string redirectUrl = "https://my-site.local/signin-weixin";
+
+        // Act
+        Uri actual = await BuildChallengeUriAsync(
+            options,
+            redirectUrl,
+            (options, loggerFactory, encoder, clock) => new WeixinAuthenticationHandler(options, loggerFactory, encoder, clock));
+
+        // Assert
+        actual.ShouldNotBeNull();
+        actual.ToString().ShouldStartWith("https://open.weixin.qq.com/connect/qrconnect?");
+
+        var query = QueryHelpers.ParseQuery(actual.Query);
+
+        query.ShouldContainKey("state");
+        query.ShouldContainKeyAndValue("appid", options.ClientId);
+        query.ShouldContainKeyAndValue("redirect_uri", redirectUrl);
+        query.ShouldContainKeyAndValue("response_type", "code");
+        query.ShouldContainKeyAndValue("scope", "snsapi_login,snsapi_userinfo");
+
+        if (usePkce)
+        {
+            query.ShouldContainKey(OAuthConstants.CodeChallengeKey);
+            query.ShouldContainKey(OAuthConstants.CodeChallengeMethodKey);
+        }
+        else
+        {
+            query.ShouldNotContainKey(OAuthConstants.CodeChallengeKey);
+            query.ShouldNotContainKey(OAuthConstants.CodeChallengeMethodKey);
+        }
     }
 }


### PR DESCRIPTION
Refactor the overrides of `BuildChallengeUrl()` to still leverage the base class' functionality for PKCE ([code](https://github.com/dotnet/aspnetcore/blob/4e5cdf955be6cca550e3db38e5de98f1643a67ac/src/Security/Authentication/OAuth/src/OAuthHandler.cs#L291-L323)) and reduce duplication/re-implementation. While these providers might not actually support PKCE, any that do cannot leverage it even if `UsePkce` is set to true on these providers' options in the consuming applications.

Also updates the .NET SDK to 6.0.101.
