### PR TITLE
Support custom Okta authorization servers

### DIFF
--- a/docs/okta.md
+++ b/docs/okta.md
@@ -16,6 +16,7 @@ services.AddAuthentication(options => /* Auth configuration */)
 
 | Property Name | Property Type | Description | Default Value |
 |:--|:--|:--|:--|
+| `AuthorizationServer` | `string` | The Okta custom authorization server to use for authentication. | `default` |
 | `Domain` | `string?` | The Okta domain (_Org URL_) to use for authentication. This can be found on the `/dev/console` page of the Okta admin portal for your account. | `null` |
 
 ## Optional Settings

--- a/src/AspNet.Security.OAuth.Okta/OktaAuthenticationDefaults.cs
+++ b/src/AspNet.Security.OAuth.Okta/OktaAuthenticationDefaults.cs
@@ -4,6 +4,8 @@
  * for more information concerning the license and the contributors participating to this project.
  */
 
+using System.Globalization;
+
 namespace AspNet.Security.OAuth.Okta;
 
 /// <summary>
@@ -27,22 +29,42 @@ public static class OktaAuthenticationDefaults
     public static readonly string Issuer = "Okta";
 
     /// <summary>
+    /// The name of the default Okta custom Authorization Server.
+    /// </summary>
+    public static readonly string DefaultAuthorizationServer = "default";
+
+    /// <summary>
     /// Default value for <see cref="RemoteAuthenticationOptions.CallbackPath"/>.
     /// </summary>
     public static readonly string CallbackPath = "/signin-okta";
 
     /// <summary>
+    /// Default path format to use for <see cref="OAuthOptions.AuthorizationEndpoint"/>.
+    /// </summary>
+    public static readonly string AuthorizationEndpointPathFormat = "/oauth2/{0}/v1/authorize";
+
+    /// <summary>
+    /// Default path format to use for <see cref="OAuthOptions.TokenEndpoint"/>.
+    /// </summary>
+    public static readonly string TokenEndpointPathFormat = "/oauth2/{0}/v1/token";
+
+    /// <summary>
+    /// Default path format to use for <see cref="OAuthOptions.UserInformationEndpoint"/>.
+    /// </summary>
+    public static readonly string UserInformationEndpointPathFormat = "/oauth2/{0}/v1/userinfo";
+
+    /// <summary>
     /// Default path to use for <see cref="OAuthOptions.AuthorizationEndpoint"/>.
     /// </summary>
-    public static readonly string AuthorizationEndpointPath = "/oauth2/default/v1/authorize";
+    public static readonly string AuthorizationEndpointPath = string.Format(CultureInfo.InvariantCulture, AuthorizationEndpointPathFormat, DefaultAuthorizationServer);
 
     /// <summary>
     /// Default path to use for <see cref="OAuthOptions.TokenEndpoint"/>.
     /// </summary>
-    public static readonly string TokenEndpointPath = "/oauth2/default/v1/token";
+    public static readonly string TokenEndpointPath = string.Format(CultureInfo.InvariantCulture, TokenEndpointPathFormat, DefaultAuthorizationServer);
 
     /// <summary>
     /// Default path to use for <see cref="OAuthOptions.UserInformationEndpoint"/>.
     /// </summary>
-    public static readonly string UserInformationEndpointPath = "/oauth2/default/v1/userinfo";
+    public static readonly string UserInformationEndpointPath = string.Format(CultureInfo.InvariantCulture, UserInformationEndpointPathFormat, DefaultAuthorizationServer);
 }

--- a/src/AspNet.Security.OAuth.Okta/OktaAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Okta/OktaAuthenticationOptions.cs
@@ -33,6 +33,14 @@ public class OktaAuthenticationOptions : OAuthOptions
     }
 
     /// <summary>
+    /// Gets or sets the Okta custom authorization server to use for authentication.
+    /// </summary>
+    /// <remarks>
+    /// The default value is <c>default</c>.
+    /// </remarks>
+    public string AuthorizationServer { get; set; } = OktaAuthenticationDefaults.DefaultAuthorizationServer;
+
+    /// <summary>
     /// Gets or sets the Okta domain (Org URL) to use for authentication.
     /// </summary>
     public string? Domain { get; set; }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Okta/OktaPostConfigureOptionsTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Okta/OktaPostConfigureOptionsTests.cs
@@ -40,6 +40,38 @@ public static class OktaPostConfigureOptionsTests
     }
 
     [Theory]
+    [InlineData("okta.local")]
+    [InlineData("http://okta.local")]
+    [InlineData("http://okta.local/")]
+    [InlineData("https://okta.local")]
+    [InlineData("https://okta.local/")]
+    public static void PostConfigure_Configures_Valid_Endpoints_With_Custom_Authorization_Server(string domain)
+    {
+        // Arrange
+        string name = "Okta";
+        var target = new OktaPostConfigureOptions();
+
+        var options = new OktaAuthenticationOptions()
+        {
+            AuthorizationServer = "custom",
+            Domain = domain,
+        };
+
+        // Act
+        target.PostConfigure(name, options);
+
+        // Assert
+        options.AuthorizationEndpoint.ShouldStartWith("https://okta.local/oauth2/custom/v1/");
+        Uri.TryCreate(options.AuthorizationEndpoint, UriKind.Absolute, out _).ShouldBeTrue();
+
+        options.TokenEndpoint.ShouldStartWith("https://okta.local/oauth2/custom/v1/");
+        Uri.TryCreate(options.TokenEndpoint, UriKind.Absolute, out _).ShouldBeTrue();
+
+        options.UserInformationEndpoint.ShouldStartWith("https://okta.local/oauth2/custom/v1/");
+        Uri.TryCreate(options.UserInformationEndpoint, UriKind.Absolute, out _).ShouldBeTrue();
+    }
+
+    [Theory]
     [InlineData(null)]
     [InlineData("")]
     [InlineData(" ")]
@@ -52,6 +84,26 @@ public static class OktaPostConfigureOptionsTests
         var options = new OktaAuthenticationOptions()
         {
             Domain = value,
+        };
+
+        // Act and Assert
+        Assert.Throws<ArgumentException>("options", () => target.PostConfigure(name, options));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public static void PostConfigure_Throws_If_AuthorizationServer_Is_Invalid(string value)
+    {
+        // Arrange
+        string name = "Okta";
+        var target = new OktaPostConfigureOptions();
+
+        var options = new OktaAuthenticationOptions()
+        {
+            AuthorizationServer = value,
+            Domain = "okta.local",
         };
 
         // Act and Assert

--- a/test/AspNet.Security.OAuth.Providers.Tests/Okta/OktaTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Okta/OktaTests.cs
@@ -41,4 +41,30 @@ public class OktaTests : OAuthTests<OktaAuthenticationOptions>
         // Assert
         AssertClaim(claims, claimType, claimValue);
     }
+
+    [Theory]
+    [InlineData(ClaimTypes.Email, "jane.doe@example.com")]
+    [InlineData(ClaimTypes.GivenName, "Jane")]
+    [InlineData(ClaimTypes.Name, "Jane Doe")]
+    [InlineData(ClaimTypes.NameIdentifier, "00uid4BxXw6I6TV4m0g4")]
+    [InlineData(ClaimTypes.Surname, "Doe")]
+    public async Task Can_Sign_In_Using_Okta_With_Custom_Authorization_Server(string claimType, string claimValue)
+    {
+        // Arrange
+        static void ConfigureServices(IServiceCollection services)
+        {
+            services.Configure<OktaAuthenticationOptions>("Okta", (options) =>
+            {
+                options.AuthorizationServer = "custom";
+            });
+        }
+
+        using var server = CreateTestServer(ConfigureServices);
+
+        // Act
+        var claims = await AuthenticateUserAsync(server);
+
+        // Assert
+        AssertClaim(claims, claimType, claimValue);
+    }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Okta/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Okta/bundle.json
@@ -41,6 +41,47 @@
         },
         "phone_number": "+1 (425) 555-1212"
       }
+    },
+    {
+      "comment": "https://developer.okta.com/docs/reference/api/oidc/#response-example-success-2",
+      "uri": "https://okta.local/oauth2/custom/v1/token",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "secret-access-token",
+        "token_type": "Bearer",
+        "expires_in": 3600,
+        "scope": "openid email",
+        "refresh_token": "secret-refresh-token",
+        "id_token": "secret-id-token"
+      }
+    },
+    {
+      "comment": "https://developer.okta.com/docs/reference/api/oidc/#userinfo",
+      "uri": "https://okta.local/oauth2/custom/v1/userinfo",
+      "contentFormat": "json",
+      "contentJson": {
+        "sub": "00uid4BxXw6I6TV4m0g4",
+        "name": "Jane Doe",
+        "nickname": "Jan",
+        "given_name": "Jane",
+        "middle_name": "Jenny",
+        "family_name": "Doe",
+        "profile": "https://example.com/jane.doe",
+        "zoneinfo": "America/Los_Angeles",
+        "locale": "en-US",
+        "updated_at": 1311280970,
+        "email": "jane.doe@example.com",
+        "email_verified": true,
+        "address": {
+          "street_address": "123 Hollywood Blvd.",
+          "locality": "Los Angeles",
+          "region": "CA",
+          "postal_code": "90210",
+          "country": "US"
+        },
+        "phone_number": "+1 (425) 555-1212"
+      }
     }
   ]
 }


### PR DESCRIPTION
Add built-in support for using a [custom Okta Authorization Server](https://developer.okta.com/docs/concepts/auth-servers/#custom-authorization-server).
