### PR TITLE
Support trimming

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -50,10 +50,12 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" $(RepoRelativeProjectDir.Contains('src')) ">
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IncludeSymbols>true</IncludeSymbols>
     <IsPackable>true</IsPackable>
     <IsShipping>true</IsShipping>
+    <IsTrimmable>true</IsTrimmable>
     <Serviceable>false</Serviceable>
   </PropertyGroup>
 

--- a/src/AspNet.Security.OAuth.StackExchange/CustomJsonSerializerContext.cs
+++ b/src/AspNet.Security.OAuth.StackExchange/CustomJsonSerializerContext.cs
@@ -1,0 +1,15 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+
+namespace AspNet.Security.OAuth.StackExchange;
+
+[JsonSerializable(typeof(JsonObject))]
+internal sealed partial class CustomJsonSerializerContext : JsonSerializerContext
+{
+}

--- a/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationHandler.cs
@@ -112,7 +112,7 @@ public partial class StackExchangeAuthenticationHandler : OAuthHandler<StackExch
             token[key] = value.ToString();
         }
 
-        return OAuthTokenResponse.Success(JsonSerializer.SerializeToDocument(token));
+        return OAuthTokenResponse.Success(JsonSerializer.SerializeToDocument(token, CustomJsonSerializerContext.Default.JsonObject));
     }
 
     private static partial class Log

--- a/src/AspNet.Security.OAuth.Trovo/CustomJsonSerializerContext.cs
+++ b/src/AspNet.Security.OAuth.Trovo/CustomJsonSerializerContext.cs
@@ -1,0 +1,14 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Text.Json.Serialization;
+
+namespace AspNet.Security.OAuth.Trovo;
+
+[JsonSerializable(typeof(Dictionary<string, string>))]
+internal sealed partial class CustomJsonSerializerContext : JsonSerializerContext
+{
+}

--- a/src/AspNet.Security.OAuth.Trovo/TrovoAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Trovo/TrovoAuthenticationHandler.cs
@@ -73,11 +73,13 @@ public partial class TrovoAuthenticationHandler : OAuthHandler<TrovoAuthenticati
             context.Properties.Items.Remove(OAuthConstants.CodeVerifierKey);
         }
 
+        var json = JsonSerializer.Serialize(tokenRequestParameters, CustomJsonSerializerContext.Default.DictionaryStringString);
+
         using var request = new HttpRequestMessage(HttpMethod.Post, Options.TokenEndpoint);
 
         request.Headers.Add(ClientIdHeaderName, Options.ClientId);
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(MediaTypeNames.Application.Json));
-        request.Content = new StringContent(JsonSerializer.Serialize(tokenRequestParameters), Encoding.UTF8, MediaTypeNames.Application.Json);
+        request.Content = new StringContent(json, Encoding.UTF8, MediaTypeNames.Application.Json);
 
         using var response = await Backchannel.SendAsync(request, Context.RequestAborted);
 

--- a/src/AspNet.Security.OAuth.Yammer/CustomJsonSerializerContext.cs
+++ b/src/AspNet.Security.OAuth.Yammer/CustomJsonSerializerContext.cs
@@ -1,0 +1,15 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+
+namespace AspNet.Security.OAuth.Yammer;
+
+[JsonSerializable(typeof(JsonObject))]
+internal sealed partial class CustomJsonSerializerContext : JsonSerializerContext
+{
+}

--- a/src/AspNet.Security.OAuth.Yammer/YammerAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Yammer/YammerAuthenticationHandler.cs
@@ -9,6 +9,7 @@ using System.Net.Http.Headers;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -86,15 +87,15 @@ public partial class YammerAuthenticationHandler : OAuthHandler<YammerAuthentica
         using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
         var accessToken = payload.RootElement.GetProperty("access_token").GetString("token");
 
-        var token = new
+        var token = new JsonObject()
         {
-            access_token = accessToken,
-            token_type = string.Empty,
-            refresh_token = string.Empty,
-            expires_in = string.Empty,
+            ["access_token"] = accessToken,
+            ["token_type"] = string.Empty,
+            ["refresh_token"] = string.Empty,
+            ["expires_in"] = string.Empty,
         };
 
-        return OAuthTokenResponse.Success(JsonSerializer.SerializeToDocument(token));
+        return OAuthTokenResponse.Success(JsonSerializer.SerializeToDocument(token, CustomJsonSerializerContext.Default.JsonObject));
     }
 
     private static partial class Log


### PR DESCRIPTION
I've been playing around with trimming in some applications this afternoon, and thought I'd try it out with the provider assemblies. Going through [the documentation](https://docs.microsoft.com/en-us/dotnet/core/deploying/trimming/prepare-libraries-for-trimming) this involved:

- Enabling the trimming analyzer.
- Marking shipping assemblies as trimmable.
- Fixing JSON serializer usage that is not supported by trimming.

Thoughts about this @kevinchalet? For the small amount  of work involved in getting it to build I thought it was at least worth pushing up a draft to seek an opinion. Note that I haven't tried this out in an actual real trimmed ASP.NET Core application yet.