### PR TITLE
Add issue template for new providers 

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,19 +1,29 @@
 ### Provider name
 
-_State which provider(s) you are experiencing an issue with._
+<!--
+State which provider(s) you are experiencing an issue with.
+-->
 
 ### Expected behavior
 
-_Explain what you expected to happen._
+<!--
+Explain what you expected to happen.
+-->
 
 ### Actual behavior
 
-_Explain what actually happened. If an exception occurred, please include a stack trace if available._
+<!--
+Explain what actually happened. If an exception occurred, please include a stack trace if available.
+-->
 
 ### Steps to reproduce
 
-_A concise and repeatable example of how to illustrate the issue._
+<!--
+A concise and repeatable example of how to illustrate the issue.
+-->
 
 ### Additional information
 
-_Any additional information that may be useful, such as the version of the package you are using or the version of .NET Core._
+<!--
+Any additional information that may be useful, such as the version of the package you are using or the version of .NET.
+-->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,25 +1,44 @@
 ---
 name: Bug report
 about: Create a bug report to help us improve AspNet.Security.OAuth.Providers
+labels: bug
 
 ---
 
-**Describe the bug**
-_A clear and concise description of what the bug is. State which provider(s) the bug relates to._
+### Describe the bug
 
-**Steps To reproduce**
-_A concise and repeatable example of how to illustrate the issue._
+<!--
+A clear and concise description of what the bug is. State which provider(s) the bug relates to.
+-->
 
-**Expected behaviour**
-_A clear and concise description of what you expected to happen._
+### Steps To reproduce
 
-**Actual behaviour**
-_A clear and concise description of what actually happened. If an exception occurred, please include a stack trace if available._
+<!--
+A concise and repeatable example of how to illustrate the issue.
+-->
 
-**System information:**
- - OS: [e.g. Windows 10]
- - Library Version [e.g. 2.0.1]
- - .NET version (e.g. output from `dotnet --info`)
+### Expected behaviour
 
-**Additional context**
-_Add any other context about the problem here._
+<!--
+A clear and concise description of what you expected to happen.
+-->
+
+### Actual behaviour
+
+<!--
+A clear and concise description of what actually happened. If an exception occurred, please include a stack trace if available.
+-->
+
+### System information
+
+<!--
+- OS: [e.g. Windows 11]
+- Library Version [e.g. 6.0.0]
+- .NET version (e.g. output from `dotnet --info`)
+-->
+
+### Additional context
+
+<!--
+Add any other context about the problem here.
+-->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,14 +4,26 @@ about: Suggest an idea for a new feature for AspNet.Security.OAuth.Providers
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. For example: _I'm always frustrated when [...]_
+### Is your feature request related to a problem? Please describe.
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+<!--
+A clear and concise description of what the problem is. For example: _It would be useful if [...]_
+-->
 
-**Describe alternatives you've considered**
+### Describe the solution you'd like
+
+<!--
+A clear and concise description of what you would like to happen.
+-->
+
+### Describe alternatives you've considered
+
+<!--
 A clear and concise description of any alternative solutions or features you've considered.
+-->
 
-**Additional context**
+### Additional context
+
+<!--
 Add any other context or screenshots about the feature request here.
+-->

--- a/.github/ISSUE_TEMPLATE/new_provider.md
+++ b/.github/ISSUE_TEMPLATE/new_provider.md
@@ -1,0 +1,45 @@
+---
+name: New provider
+about: Suggest a new OAuth provider for AspNet.Security.OAuth.Providers
+labels: new provider
+
+---
+
+### Which provider would you like support added for?
+
+<!--
+The name of the OAuth 2.0 provider you'd like to support added for.
+Providers that deviate significantly from the OAuth 2.0 specification
+with non-standard extensions and/or behavior are unlikely to be accepted.
+-->
+
+### Provider Documentation
+
+<!--
+Any relevant links to the reference documentation for the OAuth 2.0 provider.
+These links are preferably to the technical documentation that can be worked
+from to implement the provider code with.
+-->
+
+### Are you willing to implement this provider yourself?
+
+<!--
+Are you willing to implement this provider yourself and contribute it to the
+repository as a pull request?
+
+If you are not able or willing to implement this provider yourself, the repository
+maintainers are unlikely to be able to commit to implement it for you, especially
+if the provider is not a product or service that the maintainers actively use
+and/or have access to (for example, a paid-for enterprise service).
+
+Providers that you are not able to implement yourself but would be valuable
+to the open source community if they existed will be labelled with "help wanted".
+Such issues will then be dependent on the community to implement at some point,
+but do not represent any commitment from the maintainers to do so.
+-->
+
+### Additional context
+
+<!--
+Add any other context about the new provider that may be relevant.
+-->


### PR DESCRIPTION
* Add a GitHub issue template for new providers (the bit it I'd like reviewed, the first commit).
* Tidy up the existing issue templates (use markdown headings and use comments for hints).

I've intentionally not gone down the path of trying to use GitHub issue forms at this point, I just did a quick pass on what we already have while adding the new template with some more focused questions and information.
