### PR TITLE
Assert on claims in Apple JWT

### DIFF
--- a/test/AspNet.Security.OAuth.Providers.Tests/Apple/AppleClientSecretGeneratorTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Apple/AppleClientSecretGeneratorTests.cs
@@ -59,14 +59,26 @@ public class AppleClientSecretGeneratorTests
             securityToken.Header.ShouldContainKeyAndValue("kid", "my-key-id");
             securityToken.Header.ShouldContainKeyAndValue("typ", "JWT");
 
+            // See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/issues/684
+            securityToken.Header.Keys.OrderBy((p) => p).ShouldBe(
+                new string[] { "alg", "kid", "typ" },
+                Case.Sensitive,
+                "JWT header contains unexpected additional claims.");
+
             securityToken.Payload.ShouldNotBeNull();
             securityToken.Payload.ShouldContainKey("exp");
             securityToken.Payload.ShouldContainKey("iat");
+            securityToken.Payload.ShouldContainKey("nbf");
             securityToken.Payload.ShouldContainKeyAndValue("aud", "https://appleid.apple.com");
             securityToken.Payload.ShouldContainKeyAndValue("iss", "my-team-id");
             securityToken.Payload.ShouldContainKeyAndValue("sub", "my-client-id");
             securityToken.Payload.Iat.HasValue.ShouldBeTrue();
             securityToken.Payload.Exp.HasValue.ShouldBeTrue();
+
+            securityToken.Payload.Keys.OrderBy((p) => p).ShouldBe(
+                new string[] { "aud", "exp", "iat", "iss", "nbf", "sub" },
+                Case.Sensitive,
+                "JWT payload contains unexpected additional claims.");
 
             ((long)securityToken.Payload.Iat!.Value).ShouldBeGreaterThanOrEqualTo(utcNow.ToUnixTimeSeconds());
             ((long)securityToken.Payload.Exp!.Value).ShouldBeGreaterThanOrEqualTo(utcNow.AddSeconds(60).ToUnixTimeSeconds());


### PR DESCRIPTION
Updates the unit test for the Apple JWT to validate it _only_ contains the claims expected.

This should help protect (or at least encourage further investigation) if we update to a newer version of `Microsoft.IdentityModel.Protocols.OpenIdConnect` in the future that creates an incompatibility of the same kind.

See #684 for context.
