### PR TITLE
Remove Weibo email scope

### DIFF
--- a/src/AspNet.Security.OAuth.Weibo/WeiboAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Weibo/WeiboAuthenticationOptions.cs
@@ -32,8 +32,6 @@ public class WeiboAuthenticationOptions : OAuthOptions
         ClaimActions.MapJsonKey(Claims.AvatarHd, "avatar_hd");
         ClaimActions.MapJsonKey(Claims.CoverImagePhone, "cover_image_phone");
         ClaimActions.MapJsonKey(Claims.Location, "location");
-
-        Scope.Add("email");
     }
 
     /// <summary>

--- a/test/AspNet.Security.OAuth.Providers.Tests/Weibo/WeiboTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Weibo/WeiboTests.cs
@@ -19,7 +19,11 @@ public class WeiboTests : OAuthTests<WeiboAuthenticationOptions>
 
     protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
     {
-        builder.AddWeibo(options => ConfigureDefaults(builder, options));
+        builder.AddWeibo(options =>
+        {
+            ConfigureDefaults(builder, options);
+            options.Scope.Add("email");
+        });
     }
 
     [Theory]
@@ -57,6 +61,7 @@ public class WeiboTests : OAuthTests<WeiboAuthenticationOptions>
         };
 
         options.Scope.Add("scope-1");
+        options.Scope.Add("scope-2");
 
         string redirectUrl = "https://my-site.local/signin-weibo";
 
@@ -76,7 +81,7 @@ public class WeiboTests : OAuthTests<WeiboAuthenticationOptions>
         query.ShouldContainKeyAndValue("client_id", options.ClientId);
         query.ShouldContainKeyAndValue("redirect_uri", redirectUrl);
         query.ShouldContainKeyAndValue("response_type", "code");
-        query.ShouldContainKeyAndValue("scope", "email,scope-1");
+        query.ShouldContainKeyAndValue("scope", "scope-1,scope-2");
 
         if (usePkce)
         {


### PR DESCRIPTION
Remove `email` from the default Weibo scopes.

Resolves #692.
