### PR TITLE
Bump for 6.0.8

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -1,16 +1,16 @@
 <Project>
 
   <ItemGroup>
-    <PackageReference Update="JetBrains.Annotations" Version="2021.3.0" />
-    <PackageReference Update="JustEat.HttpClientInterception" Version="3.1.1" />
-    <PackageReference Update="MartinCostello.Logging.XUnit" Version="0.2.0" />
-    <PackageReference Update="Microsoft.AspNetCore.Authentication.Google" Version="6.0.2" />
-    <PackageReference Update="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.2" />
-    <PackageReference Update="Microsoft.AspNetCore.TestHost" Version="6.0.2" />
+    <PackageReference Update="JetBrains.Annotations" Version="2022.1.0" />
+    <PackageReference Update="JustEat.HttpClientInterception" Version="3.1.2" />
+    <PackageReference Update="MartinCostello.Logging.XUnit" Version="0.3.0" />
+    <PackageReference Update="Microsoft.AspNetCore.Authentication.Google" Version="6.0.8" />
+    <PackageReference Update="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.8" />
+    <PackageReference Update="Microsoft.AspNetCore.TestHost" Version="6.0.8" />
     <PackageReference Update="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.10.0" />
-    <PackageReference Update="Moq" Version="4.16.1" />
+    <PackageReference Update="Moq" Version="4.18.2" />
     <PackageReference Update="Shouldly" Version="4.0.3" />
-    <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.406" />
+    <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.435" />
   </ItemGroup>
 
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <MajorVersion>6</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PatchVersion>7</PatchVersion>
+    <PatchVersion>8</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <PackageValidationBaselineVersion Condition="'$(PackageValidationBaselineVersion)' == ''">6.0.0</PackageValidationBaselineVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>

--- a/global.json
+++ b/global.json
@@ -1,10 +1,10 @@
 {
   "sdk": {
-    "version": "6.0.102"
+    "version": "6.0.400"
   },
-  
+
   "tools": {
-    "dotnet": "6.0.102"
+    "dotnet": "6.0.400"
   },
 
   "msbuild-sdks": {

--- a/src/AspNet.Security.OAuth.HubSpot/AspNet.Security.OAuth.HubSpot.csproj
+++ b/src/AspNet.Security.OAuth.HubSpot/AspNet.Security.OAuth.HubSpot.csproj
@@ -6,14 +6,10 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <Description>ASP.NET Core security middleware enabling HubSpot authentication.</Description>
     <Authors>Shayaan Ahmed Farooqi</Authors>
     <PackageTags>hubspot;aspnetcore;authentication;oauth;security</PackageTags>
-  </PropertyGroup>  
+  </PropertyGroup>
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />


### PR DESCRIPTION
- Bump version to 6.0.8 for next release.
- Update to the latest .NET 6 SDK.
- Update all of the dev and test dependencies to their latest versions.
- Enable package baseline validation for the new HubSpot provider.
