### PR TITLE
Bump version to 6.0.9

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <MajorVersion>6</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PatchVersion>8</PatchVersion>
+    <PatchVersion>9</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <PackageValidationBaselineVersion Condition="'$(PackageValidationBaselineVersion)' == ''">6.0.0</PackageValidationBaselineVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>

--- a/src/AspNet.Security.OAuth.Snapchat/AspNet.Security.OAuth.Snapchat.csproj
+++ b/src/AspNet.Security.OAuth.Snapchat/AspNet.Security.OAuth.Snapchat.csproj
@@ -1,9 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
     <PackageValidationBaselineVersion>6.0.8</PackageValidationBaselineVersion>
-    <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
- Bump version to 6.0.9 for next release.
- Enable package baseline validation for the new Snapchat provider.
