### PR TITLE
Support Keycloak v18+

### DIFF
--- a/docs/keycloak.md
+++ b/docs/keycloak.md
@@ -12,6 +12,7 @@ services.AddAuthentication(options => /* Auth configuration */)
             options.ClientSecret = "my-client-secret";
             options.Domain = "mydomain.local";
             options.Realm = "myrealm";
+            options.Version = new Version(19, 0);
         });
 ```
 
@@ -25,6 +26,7 @@ services.AddAuthentication(options => /* Auth configuration */)
             options.ClientId = "my-client-id";
             options.Domain = "mydomain.local";
             options.Realm = "myrealm";
+            options.Version = new Version(19, 0);
         });
 ```
 
@@ -38,6 +40,7 @@ services.AddAuthentication(options => /* Auth configuration */)
             options.ClientId = "my-client-id";
             options.ClientSecret = "my-client-secret";
             options.Realm = "myrealm";
+            options.Version = new Version(19, 0);
         });
 ```
 
@@ -56,3 +59,4 @@ Only one of either `BaseAddress` or `Domain` is required to be set. If both are 
 | Property Name | Property Type                      | Description                              | Default Value                                   |
 | :------------ | :--------------------------------- | :--------------------------------------- | :---------------------------------------------- |
 | `AccessType`  | `KeycloakAuthenticationAccessType` | The Keycloak client's access token type. | `KeycloakAuthenticationAccessType.Confidential` |
+| `Version`     | `Version?`                         | The Keycloak server version.             | `null`                                          |

--- a/src/AspNet.Security.OAuth.Keycloak/KeycloakAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Keycloak/KeycloakAuthenticationOptions.cs
@@ -54,6 +54,11 @@ public class KeycloakAuthenticationOptions : OAuthOptions
     /// </summary>
     public string? Realm { get; set; }
 
+    /// <summary>
+    /// Gets or sets the version of Keycloak being used.
+    /// </summary>
+    public Version? Version { get; set; }
+
     /// <inheritdoc />
     public override void Validate()
     {

--- a/src/AspNet.Security.OAuth.Keycloak/KeycloakPostConfigureOptions.cs
+++ b/src/AspNet.Security.OAuth.Keycloak/KeycloakPostConfigureOptions.cs
@@ -12,6 +12,8 @@ namespace AspNet.Security.OAuth.Keycloak;
 /// </summary>
 public class KeycloakPostConfigureOptions : IPostConfigureOptions<KeycloakAuthenticationOptions>
 {
+    private static readonly Version NoAuthPrefixVersion = new(18, 0);
+
     public void PostConfigure([NotNull] string name, [NotNull] KeycloakAuthenticationOptions options)
     {
         if ((!string.IsNullOrWhiteSpace(options.Domain) || options.BaseAddress is not null) &&
@@ -36,7 +38,15 @@ public class KeycloakPostConfigureOptions : IPostConfigureOptions<KeycloakAuthen
             builder.Scheme = Uri.UriSchemeHttps;
         }
 
-        builder.Path = new PathString("/auth/realms")
+        var pathBase = new PathString("/");
+
+        if (options.Version is null || options.Version < NoAuthPrefixVersion)
+        {
+            pathBase = pathBase.Add("/auth");
+        }
+
+        builder.Path = pathBase
+            .Add("/realms")
             .Add("/" + options.Realm!.Trim('/'))
             .Add(resource);
 

--- a/test/AspNet.Security.OAuth.Providers.Tests/Keycloak/KeycloakTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Keycloak/KeycloakTests.cs
@@ -52,19 +52,39 @@ public class KeycloakTests : OAuthTests<KeycloakAuthenticationOptions>
     }
 
     [Theory]
-    [InlineData(ClaimTypes.NameIdentifier, "995c1500-0dca-495e-ba72-2499d370d181")]
-    [InlineData(ClaimTypes.Email, "john@smith.com")]
-    [InlineData(ClaimTypes.GivenName, "John")]
-    [InlineData(ClaimTypes.Role, "admin")]
-    [InlineData(ClaimTypes.Name, "John Smith")]
-    public async Task Can_Sign_In_Using_Keycloak_Domain(string claimType, string claimValue)
+    [InlineData(null, ClaimTypes.NameIdentifier, "995c1500-0dca-495e-ba72-2499d370d181")]
+    [InlineData(null, ClaimTypes.Email, "john@smith.com")]
+    [InlineData(null, ClaimTypes.GivenName, "John")]
+    [InlineData(null, ClaimTypes.Role, "admin")]
+    [InlineData(null, ClaimTypes.Name, "John Smith")]
+    [InlineData("17.0", ClaimTypes.NameIdentifier, "995c1500-0dca-495e-ba72-2499d370d181")]
+    [InlineData("17.0", ClaimTypes.Email, "john@smith.com")]
+    [InlineData("17.0", ClaimTypes.GivenName, "John")]
+    [InlineData("17.0", ClaimTypes.Role, "admin")]
+    [InlineData("17.0", ClaimTypes.Name, "John Smith")]
+    [InlineData("18.0", ClaimTypes.NameIdentifier, "995c1500-0dca-495e-ba72-2499d370d181")]
+    [InlineData("18.0", ClaimTypes.Email, "john@smith.com")]
+    [InlineData("18.0", ClaimTypes.GivenName, "John")]
+    [InlineData("18.0", ClaimTypes.Role, "admin")]
+    [InlineData("18.0", ClaimTypes.Name, "John Smith")]
+    [InlineData("19.0", ClaimTypes.NameIdentifier, "995c1500-0dca-495e-ba72-2499d370d181")]
+    [InlineData("19.0", ClaimTypes.Email, "john@smith.com")]
+    [InlineData("19.0", ClaimTypes.GivenName, "John")]
+    [InlineData("19.0", ClaimTypes.Role, "admin")]
+    [InlineData("19.0", ClaimTypes.Name, "John Smith")]
+    public async Task Can_Sign_In_Using_Keycloak_Domain(string? version, string claimType, string claimValue)
     {
         // Arrange
-        static void ConfigureServices(IServiceCollection services)
+        void ConfigureServices(IServiceCollection services)
         {
             services.PostConfigureAll<KeycloakAuthenticationOptions>((options) =>
             {
                 options.Domain = "keycloak.local";
+
+                if (version is not null)
+                {
+                    options.Version = Version.Parse(version);
+                }
             });
         }
 

--- a/test/AspNet.Security.OAuth.Providers.Tests/Keycloak/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Keycloak/bundle.json
@@ -25,6 +25,29 @@
       }
     },
     {
+      "uri": "https://keycloak.local/realms/myrealm/protocol/openid-connect/token",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "79d687a0ea4910c6662b2e38116528fdcd65f0d1",
+        "expires_in": 3600,
+        "token_type": "Bearer",
+        "scope": "openid",
+        "refresh_token": "c1de730eef1b2072b48799000ec7cde4ea6d2af0"
+      }
+    },
+    {
+      "uri": "https://keycloak.local/realms/myrealm/protocol/openid-connect/userinfo",
+      "contentFormat": "json",
+      "contentJson": {
+        "sub": "995c1500-0dca-495e-ba72-2499d370d181",
+        "roles": "admin",
+        "name": "John Smith",
+        "given_name": "John",
+        "email": "john@smith.com"
+      }
+    },
+    {
       "uri": "http://localhost:8080/auth/realms/myrealm/protocol/openid-connect/token",
       "method": "POST",
       "contentFormat": "json",


### PR DESCRIPTION
Support changes to the resource paths in Keycloak 18.0+.

Tested locally using the Docker image following [these instructions](https://www.keycloak.org/getting-started/getting-started-docker).

## Client configuration

```csharp
.AddKeycloak(options =>
{
    options.BaseAddress = new Uri("http://localhost:8080");
    options.ClientId = "myclient";
    options.ClientSecret = string.Empty;
    options.Realm = "myrealm";
    options.Version = new Version(19, 0);
    options.AccessType = AspNet.Security.OAuth.Keycloak.KeycloakAuthenticationAccessType.Public;
})
```

## Server configuration

![keycloak-server](https://user-images.githubusercontent.com/1439341/185747473-204b7501-c5d1-4aac-9055-b446b05ca10c.png)

## Successful login

![keycloak-client](https://user-images.githubusercontent.com/1439341/185747482-c257d615-018d-4858-98b9-719a28695d0d.png)

Resolves #695.
