### PR TITLE
Bump version to 6.0.10

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <MajorVersion>6</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PatchVersion>9</PatchVersion>
+    <PatchVersion>10</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <PackageValidationBaselineVersion Condition="'$(PackageValidationBaselineVersion)' == ''">6.0.0</PackageValidationBaselineVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>

--- a/src/AspNet.Security.OAuth.Feishu/AspNet.Security.OAuth.Feishu.csproj
+++ b/src/AspNet.Security.OAuth.Feishu/AspNet.Security.OAuth.Feishu.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
     <PackageValidationBaselineVersion>6.0.9</PackageValidationBaselineVersion>
     <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>

--- a/src/AspNet.Security.OAuth.Kroger/AspNet.Security.OAuth.Kroger.csproj
+++ b/src/AspNet.Security.OAuth.Kroger/AspNet.Security.OAuth.Kroger.csproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
     <PackageValidationBaselineVersion>6.0.9</PackageValidationBaselineVersion>
     <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
-  
+
   <PropertyGroup>
     <Description>ASP.NET Core security middleware enabling Kroger authentication.</Description>
     <Authors>Luke Moore</Authors>


### PR DESCRIPTION
- Bump version to 6.0.10 for next release.
- Enable package baseline validation for the new Feishu and Kroger providers.
