### PR TITLE
Ignore user parameter for non-POST requests

### DIFF
--- a/src/AspNet.Security.OAuth.Apple/AppleAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Apple/AppleAuthenticationHandler.cs
@@ -172,26 +172,26 @@ public partial class AppleAuthenticationHandler : OAuthHandler<AppleAuthenticati
     /// <inheritdoc />
     protected override async Task<HandleRequestResult> HandleRemoteAuthenticateAsync()
     {
-        bool trustUserResponse;
+        bool trustUserParameter;
         IEnumerable<KeyValuePair<string, StringValues>> source;
 
         // If form_post was used, then read the parameters from the form rather than the query string
         if (string.Equals(Request.Method, HttpMethod.Post.Method, StringComparison.OrdinalIgnoreCase))
         {
-            trustUserResponse = true;
+            trustUserParameter = true;
             source = Request.Form;
         }
         else
         {
             // Do not trust the user query string parameter to
             // prevent an elevation of privilege vulnerability.
-            trustUserResponse = false;
+            trustUserParameter = false;
             source = Request.Query;
         }
 
         var parameters = new Dictionary<string, StringValues>(source);
 
-        return await HandleRemoteAuthenticateAsync(parameters, trustUserResponse);
+        return await HandleRemoteAuthenticateAsync(parameters, trustUserParameter);
     }
 
     private async Task<HandleRequestResult> HandleRemoteAuthenticateAsync(


### PR DESCRIPTION
Resolves #713 as an alternative to #714 by achieving the same goal without adding a new option.

I had a quick look at _removing_ the other code path, but I think it needs a bit more thought regarding compatibility to remove it completely (just deleting it as I suggested here would break things completely https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/pull/714#discussion_r959389922) so I thought this might be a bit more expedient. It's still a breaking change for anyone not using `form_post` anyway as they'll no longer get some of the claims set.

/cc @royzhang666
