### PR TITLE
Add security policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -8,7 +8,7 @@ The .NET Core and ASP.NET Core support policy, including currently supported ver
 
 ## Reporting a Vulnerability
 
-Security issues and bugs should be reported privately by emailing CHANGE_ME.
+Security issues and bugs should be reported privately by emailing [contact@kevinchalet.com](mailto:contact@kevinchalet.com).
 
 You should receive a response within 48 hours. If for some reason you do not, please follow up via email to ensure we received your original message.
 

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,15 @@
+# Security policy
+
+## Supported Versions
+
+Only versions of the providers that target versions of ASP.NET Core that are in support by Microsoft are supported by the maintainers.
+
+The .NET Core and ASP.NET Core support policy, including currently supported versions, can be found at the [.NET and .NET Core Support Policy page](https://dotnet.microsoft.com/platform/support/policy/dotnet-core).
+
+## Reporting a Vulnerability
+
+Security issues and bugs should be reported privately by emailing CHANGE_ME.
+
+You should receive a response within 48 hours. If for some reason you do not, please follow up via email to ensure we received your original message.
+
+Please do not open GitHub issues for anything you think might have a security implication.

--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ We would love it if you could help contributing to this repository.
 * [Volodymyr Baydalka](https://github.com/zVolodymyr)
 * [Logan Dam](https://github.com/biltongza)
 
+## Security policy
+
+Please see [SECURITY.md](./.github/SECURITY.md) for information about reporting security issues and bugs.
+
 ## Support
 
 **Need help or wanna share your thoughts?** Don't hesitate to join us on Gitter or ask your question on StackOverflow:


### PR DESCRIPTION
Add security policy documentation for GitHub.

Based on ASP.NET Core's.

Feedback on the wording aside, just needs the email address adding.

See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/issues/713#issuecomment-1232718044.
