### PR TITLE
[rel/3.1.8] Extract email from ID token not user parameter

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,8 +30,10 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
 
-    - name: Setup .NET Core SDK
-      uses: actions/setup-dotnet@v1
+    - name: Setup NuGet
+      uses: nuget/setup-nuget@v1
+      with:
+        nuget-version: '5.11.0'
 
     # Arcade only allows the revision to contain up to two characters, and GitHub Actions does not roll-over
     # build numbers every day like Azure DevOps does. To balance these two requirements, set the official
@@ -88,9 +90,9 @@ jobs:
         path: ./artifacts/TestResults/Release
 
     - name: Push NuGet packages to aspnet-contrib MyGet
-      run: dotnet nuget push "artifacts\packages\Release\Shipping\*.nupkg" --api-key ${{ secrets.MYGET_API_KEY }} --skip-duplicate --source https://www.myget.org/F/aspnet-contrib/api/v3/index.json
       if: ${{ github.repository_owner == 'aspnet-contrib' && (github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/heads/rel/') || startsWith(github.ref, 'refs/tags/')) && runner.os == 'Windows' }}
+      run: nuget push "artifacts\packages\Release\Shipping\*.nupkg" -ApiKey ${{ secrets.MYGET_API_KEY }} -SkipDuplicate -Source https://www.myget.org/F/aspnet-contrib/api/v3/index.json
 
     - name: Push NuGet packages to NuGet.org
-      run: dotnet nuget push "artifacts\packages\Release\Shipping\*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate --source https://api.nuget.org/v3/index.json
       if: ${{ github.repository_owner == 'aspnet-contrib' && startsWith(github.ref, 'refs/tags/') && runner.os == 'Windows' }}
+      run: nuget push "artifacts\packages\Release\Shipping\*.nupkg" -ApiKey ${{ secrets.NUGET_API_KEY }} -SkipDuplicate -Source https://api.nuget.org/v3/index.json

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "3.1.401"
+    "dotnet": "3.1.422"
   },
 
   "msbuild-sdks": {

--- a/test/AspNet.Security.OAuth.Providers.Tests/Apple/AppleTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Apple/AppleTests.cs
@@ -51,9 +51,7 @@ namespace AspNet.Security.OAuth.Apple
 
         [Theory]
         [InlineData(ClaimTypes.Email, "johnny.appleseed@apple.local")]
-        [InlineData(ClaimTypes.GivenName, "Johnny")]
         [InlineData(ClaimTypes.NameIdentifier, "001883.fcc77ba97500402389df96821ad9c790.1517")]
-        [InlineData(ClaimTypes.Surname, "Appleseed")]
         public async Task Can_Sign_In_Using_Apple_With_Client_Secret(string claimType, string claimValue)
         {
             // Arrange
@@ -78,9 +76,7 @@ namespace AspNet.Security.OAuth.Apple
 
         [Theory]
         [InlineData(ClaimTypes.Email, "johnny.appleseed@apple.local")]
-        [InlineData(ClaimTypes.GivenName, "Johnny")]
         [InlineData(ClaimTypes.NameIdentifier, "001883.fcc77ba97500402389df96821ad9c790.1517")]
-        [InlineData(ClaimTypes.Surname, "Appleseed")]
         public async Task Can_Sign_In_Using_Apple_With_Private_Key(string claimType, string claimValue)
         {
             // Arrange
@@ -153,9 +149,7 @@ namespace AspNet.Security.OAuth.Apple
 
         [Theory]
         [InlineData(ClaimTypes.Email, "johnny.appleseed@apple.local")]
-        [InlineData(ClaimTypes.GivenName, "Johnny")]
         [InlineData(ClaimTypes.NameIdentifier, "001883.fcc77ba97500402389df96821ad9c790.1517")]
-        [InlineData(ClaimTypes.Surname, "Appleseed")]
         public async Task Can_Sign_In_Using_Apple_With_No_Token_Validation(string claimType, string claimValue)
         {
             // Arrange

--- a/test/AspNet.Security.OAuth.Providers.Tests/Apple/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Apple/bundle.json
@@ -13,7 +13,7 @@
             "kid": "AIDOPK1",
             "use": "sig",
             "alg": "RS256",
-            "n": "lxrwmuYSAsTfn-lUu4goZSXBD9ackM9OJuwUVQHmbZo6GW4Fu_auUdN5zI7Y1dEDfgt7m7QXWbHuMD01HLnD4eRtY-RNwCWdjNfEaY_esUPY3OVMrNDI15Ns13xspWS3q-13kdGv9jHI28P87RvMpjz_JCpQ5IM44oSyRnYtVJO-320SB8E2Bw92pmrenbp67KRUzTEVfGU4-obP5RZ09OxvCr1io4KJvEOjDJuuoClF66AT72WymtoMdwzUmhINjR0XSqK6H0MdWsjw7ysyd_JhmqX5CAaT9Pgi0J8lU_pcl215oANqjy7Ob-VMhug9eGyxAWVfu_1u6QJKePlE-w",
+            "n": "1VIMsu0l2vntPVynIAkok5NGPQtM2Rkrs6PZGKHrfoBoHBBAk3oIGybfshc1YBZwcKYAMSh0tMt0YC8o6FMIrY4VmABgaiInU_IZWwJVnW4uQScPixLfygQ4MGbocICKc-YbcLepReCbmBe1QImOClbG_aPNR-EttysW9gJyc1aZPmDm9nsfrWSPBN75ZjM1u01b_FcwsnwdrGplDsSUU9ULQ7ySw4s3whCGGKPE3vN1ZVkZLN-Avm69CzFvrdXrNp4qnltJ3SUYM73RGEhuNa6J2KqPDzc-VW5V0zeGv2j2PjadJ1r-69d6QIM6Oa2vNSHJxzrqwhLAEgZ_SGngyQ",
             "e": "AQAB"
           }
         ]
@@ -27,7 +27,7 @@
       "contentJson": {
         "access_token": "secret-access-token",
         "expires_in": "300",
-        "id_token": "eyJraWQiOiJBSURPUEsxIiwiYWxnIjoiUlMyNTYifQ.eyJpc3MiOiJodHRwczovL2FwcGxlaWQuYXBwbGUuY29tIiwiYXVkIjoiY29tLm1hcnRpbmNvc3RlbGxvLnNpZ25pbndpdGhhcHBsZS50ZXN0LmNsaWVudCIsImV4cCI6MTU2MDAwODkxMCwiaWF0IjoxNTYwMDA4MzEwLCJzdWIiOiIwMDE4ODMuZmNjNzdiYTk3NTAwNDAyMzg5ZGY5NjgyMWFkOWM3OTAuMTUxNyIsImF0X2hhc2giOiJjN0xnNk9mSk1WQVUyUHRJVGRaeW93In0.hwLfuE0dB3mNYnDFWCd08MyJThsiRbGQmF-KX6VpGQttXRzChNgy9QWTT3vfd4bftMvlWCUlUEwCG0Os7hQUbWPknKYYIdxZGAejtCSCWYQ4PMhS_eQ5goICdLdi3ITzOG2JUmU-Vry4bPn3dJiyZ8ODGpj7MIBsVaRlfL4AlAgOKi9rp5UjVqj05M4qm512G-u-tVX7nasx3Eg-pFvS-w0CQJtVp3xIR2Ez3DRRt2roL0S6f0jNA-zb-zhOt_sFwmeqElGnQAidakUvrPTN0tORMUk_rKuohtkcY1_6uaVIsQ8NnOMl5Xszg9NzkQh5Je2Gi-qRzMxskJ0fJDCAfA",
+        "id_token": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOiIxNTg3MjExNTU5Iiwic3ViIjoiMDAxODgzLmZjYzc3YmE5NzUwMDQwMjM4OWRmOTY4MjFhZDljNzkwLjE1MTciLCJhdF9oYXNoIjoiZU95MHk3WFZleGRremM3dXVEWmlDUSIsImVtYWlsIjoiam9obm55LmFwcGxlc2VlZEBhcHBsZS5sb2NhbCIsImVtYWlsX3ZlcmlmaWVkIjoidHJ1ZSIsImF1dGhfdGltZSI6IjE1ODcyMTE1NTYiLCJub25jZV9zdXBwb3J0ZWQiOiJ0cnVlIiwiZXhwIjoxNTg3MjEyMTU5LCJpc3MiOiJodHRwczovL2FwcGxlaWQuYXBwbGUuY29tIiwiYXVkIjoiY29tLm1hcnRpbmNvc3RlbGxvLnNpZ25pbndpdGhhcHBsZS50ZXN0LmNsaWVudCJ9.zu386hf3Y_3EG_OZsf-jpPKurH5HFmJ0Aal4Gnc_G-VpVoa8SvhNR_7UTbZtmQs8jOvjldPZzzXHJLWDBL_6yKIhnOntxd3G4QwIfM6PzkhiFiZXd1xHbDdx1aJ1EPnZWHPfRPtaQibda5BhenBRwAK3CPhvr7DLio54xtw-FDZgyakOHbb_2QYz0N0FBlyM5vzQEVObOKm9V2qx6hk5t7aeobOf8jOKJcx8WXWCpGQX6LOTpNnfD7Jw4Xlnb0IK6BC-agyFy_KZ5ujmB10wFnmIz9-QtvwTY4tTYpY7RigMHGIbmLS6egJTI0UhsvEHuXxaEXJ-52YGo_IIJCV6DQ",
         "refresh_token": "secret-refresh-token",
         "token_type": "bearer"
       }
@@ -40,7 +40,7 @@
       "contentJson": {
         "access_token": "secret-access-token",
         "expires_in": "300",
-        "id_token": "eyJraWQiOiI4NkQ4OEtmIiwiYWxnIjoiUlMyNTYifQ.eyJpc3MiOiJodHRwczovL2FwcGxlaWQuYXBwbGUuY29tIiwiYXVkIjoiY29tLm1hcnRpbmNvc3RlbGxvLnNpZ25pbndpdGhhcHBsZS50ZXN0LmNsaWVudCIsImV4cCI6MTU4NzIxMjE1OSwiaWF0IjoxNTg3MjExNTU5LCJzdWIiOiIwMDE4ODMuZmNjNzdiYTk3NTAwNDAyMzg5ZGY5NjgyMWFkOWM3OTAuMTUxNyIsImF0X2hhc2giOiJlT3kweTdYVmV4ZGt6Yzd1dURaaUNRIiwiZW1haWwiOiJ1c3Nja2VmdXo2QHByaXZhdGVyZWxheS5hcHBsZWlkLmNvbSIsImVtYWlsX3ZlcmlmaWVkIjoidHJ1ZSIsImlzX3ByaXZhdGVfZW1haWwiOiJ0cnVlIiwiYXV0aF90aW1lIjoxNTg3MjExNTU2LCJub25jZV9zdXBwb3J0ZWQiOnRydWV9.ZPUgcJlCneXLNZiFDraKpWVtFPSyoxkWgrMlTZ8tM3IBBXOmQFbb75OBQC-JbZHciry96y-sy33O_fF8gaudmInH1EorDIsfryafNd0POD-8pJWY9PiGrGx50c_1DLIIIsYEm0p-JEIfQpzJ-lIWpz9ujv4ChmZx-t3PzPzzZOVlC0q1pATqJaxhY_ntL_u98BZnfAKxzqEhb5q-1TmhtHFaEtAtsd2gGm6PTaM5N-2HXQ8Bh_BlJMH3u_KakFNJRhaezlVIlLtmgxM4VjrxUeIqba-fwBlfGXPonA_xZIHg71ZujJSlYJp3yWW3Kjsb4rUUUff7yEQF5A1LVnghwA",
+        "id_token": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOiIxNTg3MjExNTU5Iiwic3ViIjoiMDAxODgzLmZjYzc3YmE5NzUwMDQwMjM4OWRmOTY4MjFhZDljNzkwLjE1MTciLCJhdF9oYXNoIjoiZU95MHk3WFZleGRremM3dXVEWmlDUSIsImVtYWlsIjoidXNzY2tlZnV6NkBwcml2YXRlcmVsYXkuYXBwbGVpZC5jb20iLCJlbWFpbF92ZXJpZmllZCI6InRydWUiLCJhdXRoX3RpbWUiOiIxNTg3MjExNTU2Iiwibm9uY2Vfc3VwcG9ydGVkIjoidHJ1ZSIsImlzX3ByaXZhdGVfZW1haWwiOiJ0cnVlIiwiZXhwIjoxNTg3MjEyMTU5LCJpc3MiOiJodHRwczovL2FwcGxlaWQuYXBwbGUuY29tIiwiYXVkIjoiY29tLm1hcnRpbmNvc3RlbGxvLnNpZ25pbndpdGhhcHBsZS50ZXN0LmNsaWVudCJ9.Xz-HeSAGEvPL0ObpZUYYexefSAPmRO9O_x2MTdbJKXuW65gluyJoRYfjzkKrnQUGEFvGUJ1qUiEIcdGs3kCo_TmSk6xH6e_loNYMI2J_7qb2i1-LOFHajNd1g1kTNGwSu2E22iE2IqecwfKpE7-a8thRFfbwuKyd6MNnm_NwMKBWr7IaekUc3Z876gtq94QlhItbBz8brQO6qTTekEigGEfa_h20WkPg3ZZVdqV8F-mJAQZXsGbVKToLi_L1AS6AiKxuHpTn04IGz1y6ezbng3STp-JzZslv85DJAJdZTieFh4s9RH0RFV_1GvfiExB8Q6COCaMFP7rnAVgc-27Uhg",
         "refresh_token": "secret-refresh-token",
         "token_type": "bearer"
       }


### PR DESCRIPTION
Use the verified ID token JWT as the source of the email claim rather than the user parameter in the callback for the Apple provider.

As a result of this change, the `ClaimTypes.GivenName` and `ClaimTypes.Surname` claims are no longer set.

Backport of #716 for #713.
