### PR TITLE
Updated ClaimActions for QuickBooks OpenID

### DIFF
--- a/src/AspNet.Security.OAuth.QuickBooks/QuickBooksAuthenticationConstants.cs
+++ b/src/AspNet.Security.OAuth.QuickBooks/QuickBooksAuthenticationConstants.cs
@@ -15,5 +15,6 @@ public static class QuickBooksAuthenticationConstants
     {
         public const string AccountType = "urn:quickbooks:appenvrionment";
         public const string EmailVerified = "urn:quickbooks:email_verified";
+        public const string PhoneNumberVerified = "urn:quickbooks:phone_number_verified";
     }
 }

--- a/src/AspNet.Security.OAuth.QuickBooks/QuickBooksAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.QuickBooks/QuickBooksAuthenticationOptions.cs
@@ -29,8 +29,11 @@ public class QuickBooksAuthenticationOptions : OAuthOptions
         Scope.Add("email");
 
         ClaimActions.MapJsonKey(ClaimTypes.NameIdentifier, "sub");
-        ClaimActions.MapJsonKey(ClaimTypes.MobilePhone, "mobilephone");
+        ClaimActions.MapJsonKey(ClaimTypes.OtherPhone, "phoneNumber");
+        ClaimActions.MapJsonKey(Claims.PhoneNumberVerified, "phoneNumberVerified");
         ClaimActions.MapJsonKey(ClaimTypes.Email, "email");
         ClaimActions.MapJsonKey(Claims.EmailVerified, "emailVerified");
+        ClaimActions.MapJsonKey(ClaimTypes.GivenName, "givenName");
+        ClaimActions.MapJsonKey(ClaimTypes.Surname, "familyName");
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/QuickBooks/QuickBooksTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/QuickBooks/QuickBooksTests.cs
@@ -28,9 +28,12 @@ public class QuickBooksTests : OAuthTests<QuickBooksAuthenticationOptions>
 
     [Theory]
     [InlineData(ClaimTypes.NameIdentifier, "2039290222")]
-    [InlineData(ClaimTypes.MobilePhone, "(314)000-0000")]
+    [InlineData(ClaimTypes.OtherPhone, "(314)000-0000")]
+    [InlineData(Claims.PhoneNumberVerified, "true")]
     [InlineData(ClaimTypes.Email, "john.smith@test.local")]
     [InlineData(Claims.EmailVerified, "true")]
+    [InlineData(ClaimTypes.GivenName, "John")]
+    [InlineData(ClaimTypes.Surname, "Smith")]
     public async Task Can_Sign_In_Using_QuickBooks(string claimType, string claimValue)
     {
         // Arrange

--- a/test/AspNet.Security.OAuth.Providers.Tests/QuickBooks/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/QuickBooks/bundle.json
@@ -17,9 +17,12 @@
       "contentFormat": "json",
       "contentJson": {
         "sub": "2039290222",
-        "mobilephone": "(314)000-0000",
+        "phoneNumber": "(314)000-0000",
+        "phoneNumberVerified": "true",
         "email": "john.smith@test.local",
-        "emailVerified": "true"
+        "emailVerified": "true",
+        "givenName": "John",
+        "familyName": "Smith"
       }
     }
   ]


### PR DESCRIPTION
Updated ClaimActions JsonKey maps to match current Intuit/QuickBooks OpenID user profile result data according to [this documentation](https://www.developer.intuit.com/app/developer/qbo/docs/develop/authentication-and-authorization/openid-connect#obtaining-user-profile-information).

Fully scoped (minus ```address```) requests will contain the following profile data:
```
Status: 200
Connection: keep-alive
Keep-Alive: timeout=5
Strict-Transport-Security: max-age=15552000
Cache-Control: no-cache, no-store
Content-Type: application/json;charset=utf-8
Server: nginx
{
 "sub": "01875812-e615-4047-95cb-8c93ac1789ef",
 "givenName": "FirstName",
 "familyName": "LastName",
 "email": "first@email.com",
 "emailVerified": true,
 "phoneNumber": "+1 9995551212",
 "phoneNumberVerified": true
}
```
