### PR TITLE
Update actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Setup NuGet
       uses: nuget/setup-nuget@v1
@@ -69,20 +69,20 @@ jobs:
         NUGET_XMLDOC_MODE: skip
 
     - name: Publish logs
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       if: ${{ always() }}
       with:
         name: logs-${{ matrix.os_name }}
         path: ./artifacts/log/Release
 
     - name: Publish NuGet packages
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       with:
         name: packages-${{ matrix.os_name }}
         path: ./artifacts/packages/Release/Shipping
 
     - name: Publish test results
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       if: ${{ always() }}
       with:
         name: testresults-${{ matrix.os_name }}


### PR DESCRIPTION
Update GitHub Actions to their latest version to fix warnings about Node.js 12 deprecation.
