### PR TITLE
Update StackExchange provider

### DIFF
--- a/docs/stackexchange.md
+++ b/docs/stackexchange.md
@@ -8,16 +8,18 @@ services.AddAuthentication(options => /* Auth configuration */)
         {
             options.ClientId = "my-client-id";
             options.ClientSecret = "my-client-secret";
+            options.RequestKey = "my-request-key";
         });
 ```
 
 ## Required Additional Settings
 
-_None._
+| Property Name | Property Type | Description |
+|:--|:--|:--|:--|
+| `RequestKey` | `string` | The application request key. |
 
 ## Optional Settings
 
 | Property Name | Property Type | Description | Default Value |
 |:--|:--|:--|:--|
-| `RequestKey` | `string` | The application request key. | `""` |
 | `Site` | `string` | The site the users being authenticated are registered with. | `"StackOverflow"` |

--- a/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationDefaults.cs
+++ b/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationDefaults.cs
@@ -34,15 +34,15 @@ public static class StackExchangeAuthenticationDefaults
     /// <summary>
     /// Default value for <see cref="OAuthOptions.AuthorizationEndpoint"/>.
     /// </summary>
-    public static readonly string AuthorizationEndpoint = "https://stackexchange.com/oauth";
+    public static readonly string AuthorizationEndpoint = "https://stackoverflow.com/oauth";
 
     /// <summary>
     /// Default value for <see cref="OAuthOptions.TokenEndpoint"/>.
     /// </summary>
-    public static readonly string TokenEndpoint = "https://stackexchange.com/oauth/access_token";
+    public static readonly string TokenEndpoint = "https://stackoverflow.com/oauth/access_token/json";
 
     /// <summary>
     /// Default value for <see cref="OAuthOptions.UserInformationEndpoint"/>.
     /// </summary>
-    public static readonly string UserInformationEndpoint = "https://api.stackexchange.com/2.2/me";
+    public static readonly string UserInformationEndpoint = "https://api.stackexchange.com/2.3/me";
 }

--- a/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationOptions.cs
@@ -43,4 +43,20 @@ public class StackExchangeAuthenticationOptions : OAuthOptions
     /// By default, this property is set to "StackOverflow".
     /// </summary>
     public string Site { get; set; } = "StackOverflow";
+
+    /// <inheritdoc />
+    public override void Validate()
+    {
+        base.Validate();
+
+        if (string.IsNullOrEmpty(RequestKey))
+        {
+            throw new ArgumentException($"The '{nameof(RequestKey)}' option must be provided.", nameof(RequestKey));
+        }
+
+        if (string.IsNullOrEmpty(Site))
+        {
+            throw new ArgumentException($"The '{nameof(Site)}' option must be provided.", nameof(Site));
+        }
+    }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/StackExchange/StackExchangeAuthenticationOptionsTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/StackExchange/StackExchangeAuthenticationOptionsTests.cs
@@ -1,0 +1,45 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+namespace AspNet.Security.OAuth.StackExchange;
+
+public static class StackExchangeAuthenticationOptionsTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public static void Validate_Throws_If_RequestKey_Is_Not_Set(string? value)
+    {
+        // Arrange
+        var options = new StackExchangeAuthenticationOptions()
+        {
+            ClientId = "my-client-id",
+            ClientSecret = "my-client-secret",
+            RequestKey = value!,
+        };
+
+        // Act and Assert
+        Assert.Throws<ArgumentException>("RequestKey", () => options.Validate());
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public static void Validate_Throws_If_Site_Is_Not_Set(string? value)
+    {
+        // Arrange
+        var options = new StackExchangeAuthenticationOptions()
+        {
+            ClientId = "my-client-id",
+            ClientSecret = "my-client-secret",
+            RequestKey = "my-request-key",
+            Site = value!,
+        };
+
+        // Act and Assert
+        Assert.Throws<ArgumentException>("Site", () => options.Validate());
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/StackExchange/StackExchangeTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/StackExchange/StackExchangeTests.cs
@@ -17,7 +17,11 @@ public class StackExchangeTests : OAuthTests<StackExchangeAuthenticationOptions>
 
     protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
     {
-        builder.AddStackExchange(options => ConfigureDefaults(builder, options));
+        builder.AddStackExchange(options =>
+        {
+            ConfigureDefaults(builder, options);
+            options.RequestKey = "request-key";
+        });
     }
 
     [Theory]

--- a/test/AspNet.Security.OAuth.Providers.Tests/StackExchange/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/StackExchange/bundle.json
@@ -3,13 +3,17 @@
   "items": [
     {
       "comment": "https://api.stackexchange.com/docs/authentication",
-      "uri": "https://stackexchange.com/oauth/access_token",
+      "uri": "https://stackoverflow.com/oauth/access_token/json",
       "method": "POST",
-      "contentString": "access_token=secret-access-token"
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "secret-access-token",
+        "expires": 86400
+      }
     },
     {
       "comment": "https://api.stackexchange.com/docs/me",
-      "uri": "https://api.stackexchange.com/2.2/me?access_token=secret-access-token&site=StackOverflow",
+      "uri": "https://api.stackexchange.com/2.3/me?access_token=secret-access-token&key=request-key&site=StackOverflow",
       "contentFormat": "json",
       "contentJson": {
         "items": [


### PR DESCRIPTION
- Use the JSON token exchange endpoint.
- Use the domains given in the [API documentation](https://api.stackexchange.com/docs/authentication).
- Update to version 2.3 of the API.
- Align the provider with the request key being required.
- Validate the Site once, rather than per request.

See https://github.com/openiddict/openiddict-core/pull/1531#discussion_r994929629.
