### PR TITLE
Huawei provider tweaks

### DIFF
--- a/docs/huawei.md
+++ b/docs/huawei.md
@@ -9,12 +9,12 @@ services.AddAuthentication(options => /* Auth configuration */)
             options.ClientId = "my-client-id";
             options.ClientSecret = "my-client-secret";
 
-            // Optionally.
+            // Optionally return the user's profile and email address
             options.Scope.Add("profile");
             options.Scope.Add("email");
 
-            // Optionally.
-            options.FetchNickName = true;
+            // Optionally get the user's nickname
+            options.FetchNickname = true;
         });
 ```
 
@@ -26,9 +26,4 @@ _None._
 
 | Property Name | Property Type | Description | Default Value |
 |:--|:--|:--|:--|
-| `FetchNickName` | `bool` | When FetchNickName is set to false or not set, the anonymous account is returned. If the anonymous account is unavailable, the nickname is returned. When FetchNickName is set to true, the nickname is returned. If the nickname is unavailable, the anonymous account is returned. | `false` |
-
-### Scope
-Corresponding information, such as the profile picture and email address, can be obtained only if the app has the permission to obtain the information.
-* `profile`   basic information of a HUAWEI ID, such as the profile picture and nickname.
-* `email` email address of a HUAWEI ID.
+| `FetchNickname` | `bool` | When `false` the anonymous account is returned. If the anonymous account is unavailable, the nickname is returned. When `true`, the nickname is returned. If the nickname is unavailable, the anonymous account is returned. | `false` |

--- a/src/AspNet.Security.OAuth.Huawei/HuaweiAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Huawei/HuaweiAuthenticationHandler.cs
@@ -33,7 +33,7 @@ public partial class HuaweiAuthenticationHandler : OAuthHandler<HuaweiAuthentica
 
         var content = new FormUrlEncodedContent(new[]
         {
-            new KeyValuePair<string, string>("getNickName", Options.FetchNickName ? "1" : "0"),
+            new KeyValuePair<string, string>("getNickName", Options.FetchNickname ? "1" : "0"),
             new KeyValuePair<string, string>("access_token", tokens.AccessToken!)
         });
 

--- a/src/AspNet.Security.OAuth.Huawei/HuaweiAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Huawei/HuaweiAuthenticationOptions.cs
@@ -31,5 +31,8 @@ public class HuaweiAuthenticationOptions : OAuthOptions
         Scope.Add("openid");
     }
 
-    public bool FetchNickName { get; set; }
+    /// <summary>
+    /// Gets or sets a value indicating whether to use the user's nickname, if available.
+    /// </summary>
+    public bool FetchNickname { get; set; }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Huawei/HuaweiTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Huawei/HuaweiTests.cs
@@ -19,7 +19,7 @@ public class HuaweiTests : OAuthTests<HuaweiAuthenticationOptions>
     {
         builder.AddHuawei(options =>
         {
-            options.FetchNickName = true;
+            options.FetchNickname = true;
 
             options.Scope.Add("profile");
             options.Scope.Add("email");


### PR DESCRIPTION
- Rename `FetchNickName` to `FetchNickname` to reflect typical English spelling.
- Add missing XML documentation.
- Remove documentation copied from Huawei that isn't provider-specific.
- Simplify sentence in documentation.
