### PR TITLE
Bump version to 7.0.2

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <MajorVersion>7</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PatchVersion>1</PatchVersion>
+    <PatchVersion>2</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <PackageValidationBaselineVersion Condition="'$(PackageValidationBaselineVersion)' == ''">7.0.0</PackageValidationBaselineVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>

--- a/src/AspNet.Security.OAuth.PingOne/AspNet.Security.OAuth.PingOne.csproj
+++ b/src/AspNet.Security.OAuth.PingOne/AspNet.Security.OAuth.PingOne.csproj
@@ -5,9 +5,7 @@
   </PropertyGroup>
 
 
-  <!-- TODO Remove once published to NuGet.org -->
   <PropertyGroup>
-    <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
     <PackageValidationBaselineVersion>7.0.1</PackageValidationBaselineVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
- Bump version to 7.0.2 for next release.
- Enable package baseline validation for PingOne.
