### PR TITLE
Bump version to 7.0.3

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <MajorVersion>7</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PatchVersion>2</PatchVersion>
+    <PatchVersion>3</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <PackageValidationBaselineVersion Condition="'$(PackageValidationBaselineVersion)' == ''">7.0.0</PackageValidationBaselineVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>

--- a/src/AspNet.Security.OAuth.Kook/AspNet.Security.OAuth.Kook.csproj
+++ b/src/AspNet.Security.OAuth.Kook/AspNet.Security.OAuth.Kook.csproj
@@ -4,9 +4,7 @@
     <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
-  <!-- TODO Remove once published to NuGet.org -->
   <PropertyGroup>
-    <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
     <PackageValidationBaselineVersion>7.0.2</PackageValidationBaselineVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
- Bump version to 7.0.3 for next release.
- Enable package baseline validation for KOOK.
