### PR TITLE
Update to ASP.NET Core 8 preview 5

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,9 +4,9 @@
     <PackageVersion Include="JetBrains.Annotations" Version="2022.1.0" />
     <PackageVersion Include="JustEat.HttpClientInterception" Version="3.1.2" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.0-preview.4.23260.4" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0-preview.4.23260.4" />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.0-preview.4.23260.4" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.0-preview.5.23302.2" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0-preview.5.23302.2" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.0-preview.5.23302.2" />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.16.0" />
     <PackageVersion Include="Moq" Version="4.18.2" />
     <PackageVersion Include="Shouldly" Version="4.1.0" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -10,7 +10,7 @@
     -->
     <PackageValidationBaselineVersion Condition="'$(PackageValidationBaselineVersion)' == ''">7.0.0</PackageValidationBaselineVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
-    <PreReleaseVersionIteration>3</PreReleaseVersionIteration>
+    <PreReleaseVersionIteration>5</PreReleaseVersionIteration>
     <PreReleaseBrandingLabel>Preview $(PreReleaseVersionIteration)</PreReleaseBrandingLabel>
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>

--- a/global.json
+++ b/global.json
@@ -1,10 +1,10 @@
 {
   "sdk": {
-    "version": "8.0.100-preview.4.23260.5"
+    "version": "8.0.100-preview.5.23303.2"
   },
 
   "tools": {
-    "dotnet": "8.0.100-preview.4.23260.5"
+    "dotnet": "8.0.100-preview.5.23303.2"
   },
 
   "msbuild-sdks": {

--- a/src/AspNet.Security.OAuth.AdobeIO/AdobeIOAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.AdobeIO/AdobeIOAuthenticationHandler.cs
@@ -19,9 +19,8 @@ public partial class AdobeIOAuthenticationHandler : OAuthHandler<AdobeIOAuthenti
     public AdobeIOAuthenticationHandler(
         [NotNull] IOptionsMonitor<AdobeIOAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Alipay/AlipayAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Alipay/AlipayAuthenticationHandler.cs
@@ -27,9 +27,8 @@ public partial class AlipayAuthenticationHandler : OAuthHandler<AlipayAuthentica
     public AlipayAuthenticationHandler(
         [NotNull] IOptionsMonitor<AlipayAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 
@@ -57,7 +56,7 @@ public partial class AlipayAuthenticationHandler : OAuthHandler<AlipayAuthentica
             ["grant_type"] = "authorization_code",
             ["method"] = "alipay.system.oauth.token",
             ["sign_type"] = "RSA2",
-            ["timestamp"] = Clock.UtcNow.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture),
+            ["timestamp"] = TimeProvider.GetUtcNow().ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture),
             ["version"] = "1.0",
         };
         tokenRequestParameters.Add("sign", GetRSA2Signature(tokenRequestParameters));
@@ -105,7 +104,7 @@ public partial class AlipayAuthenticationHandler : OAuthHandler<AlipayAuthentica
             ["format"] = "JSON",
             ["method"] = "alipay.user.info.share",
             ["sign_type"] = "RSA2",
-            ["timestamp"] = Clock.UtcNow.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture),
+            ["timestamp"] = TimeProvider.GetUtcNow().ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture),
             ["version"] = "1.0",
         };
         parameters.Add("sign", GetRSA2Signature(parameters));

--- a/src/AspNet.Security.OAuth.Amazon/AmazonAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Amazon/AmazonAuthenticationHandler.cs
@@ -25,13 +25,11 @@ public partial class AmazonAuthenticationHandler : OAuthHandler<AmazonAuthentica
     /// <param name="options">The authentication options.</param>
     /// <param name="logger">The logger to use.</param>
     /// <param name="encoder">The URL encoder to use.</param>
-    /// <param name="clock">The system clock to use.</param>
     public AmazonAuthenticationHandler(
         [NotNull] IOptionsMonitor<AmazonAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.AmoCrm/AmoCrmAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.AmoCrm/AmoCrmAuthenticationHandler.cs
@@ -24,13 +24,11 @@ public partial class AmoCrmAuthenticationHandler : OAuthHandler<AmoCrmAuthentica
     /// <param name="options">The authentication options.</param>
     /// <param name="logger">The logger to use.</param>
     /// <param name="encoder">The URL encoder to use.</param>
-    /// <param name="clock">The system clock to use.</param>
     public AmoCrmAuthenticationHandler(
         [NotNull] IOptionsMonitor<AmoCrmAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Apple/ApplePostConfigureOptions.cs
+++ b/src/AspNet.Security.OAuth.Apple/ApplePostConfigureOptions.cs
@@ -22,22 +22,22 @@ namespace AspNet.Security.OAuth.Apple;
 public class ApplePostConfigureOptions : IPostConfigureOptions<AppleAuthenticationOptions>
 {
     private readonly IMemoryCache _cache;
-    private readonly ISystemClock _clock;
+    private readonly TimeProvider _timeProvider;
     private readonly ILoggerFactory _loggerFactory;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ApplePostConfigureOptions"/> class.
     /// </summary>
     /// <param name="cache">The <see cref="IMemoryCache"/> to use.</param>
-    /// <param name="clock">The <see cref="ISystemClock"/> to use.</param>
+    /// <param name="timeProvider">The <see cref="TimeProvider"/> to use.</param>
     /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use.</param>
     public ApplePostConfigureOptions(
         IMemoryCache cache,
-        ISystemClock clock,
+        TimeProvider timeProvider,
         ILoggerFactory loggerFactory)
     {
         _cache = cache;
-        _clock = clock;
+        _timeProvider = timeProvider;
         _loggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
     }
 
@@ -50,20 +50,14 @@ public class ApplePostConfigureOptions : IPostConfigureOptions<AppleAuthenticati
         // https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/1302
         var cryptoProviderFactory = new CryptoProviderFactory() { CacheSignatureProviders = false };
 
-        if (options.ClientSecretGenerator is null)
-        {
-            options.ClientSecretGenerator = new DefaultAppleClientSecretGenerator(
-                _cache,
-                _clock,
-                cryptoProviderFactory,
-                _loggerFactory.CreateLogger<DefaultAppleClientSecretGenerator>());
-        }
+        options.ClientSecretGenerator ??= new DefaultAppleClientSecretGenerator(
+            _cache,
+            _timeProvider,
+            cryptoProviderFactory,
+            _loggerFactory.CreateLogger<DefaultAppleClientSecretGenerator>());
 
-        if (options.TokenValidator is null)
-        {
-            options.TokenValidator = new DefaultAppleIdTokenValidator(
-                _loggerFactory.CreateLogger<DefaultAppleIdTokenValidator>());
-        }
+        options.TokenValidator ??= new DefaultAppleIdTokenValidator(
+            _loggerFactory.CreateLogger<DefaultAppleIdTokenValidator>());
 
         if (options.ConfigurationManager is null)
         {
@@ -73,7 +67,7 @@ public class ApplePostConfigureOptions : IPostConfigureOptions<AppleAuthenticati
             }
 
             // As seen in:
-            // github.com/dotnet/aspnetcore/blob/master/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectPostConfigureOptions.cs#L71-L102
+            // https://github.com/dotnet/aspnetcore/blob/master/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectPostConfigureOptions.cs#L71-L102
             // need this now to successfully instantiate ConfigurationManager below.
             if (options.Backchannel is null)
             {
@@ -91,21 +85,14 @@ public class ApplePostConfigureOptions : IPostConfigureOptions<AppleAuthenticati
                 new HttpDocumentRetriever(options.Backchannel));
         }
 
-        if (options.SecurityTokenHandler is null)
+        options.SecurityTokenHandler ??= new JsonWebTokenHandler();
+        options.TokenValidationParameters ??= new TokenValidationParameters()
         {
-            options.SecurityTokenHandler = new JsonWebTokenHandler();
-        }
-
-        if (options.TokenValidationParameters is null)
-        {
-            options.TokenValidationParameters = new TokenValidationParameters()
-            {
-                CryptoProviderFactory = cryptoProviderFactory,
-                ValidateAudience = true,
-                ValidateIssuer = true,
-                ValidAudience = options.ClientId,
-                ValidIssuer = options.TokenAudience
-            };
-        }
+            CryptoProviderFactory = cryptoProviderFactory,
+            ValidateAudience = true,
+            ValidateIssuer = true,
+            ValidAudience = options.ClientId,
+            ValidIssuer = options.TokenAudience
+        };
     }
 }

--- a/src/AspNet.Security.OAuth.ArcGIS/ArcGISAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.ArcGIS/ArcGISAuthenticationHandler.cs
@@ -19,9 +19,8 @@ public partial class ArcGISAuthenticationHandler : OAuthHandler<ArcGISAuthentica
     public ArcGISAuthenticationHandler(
         [NotNull] IOptionsMonitor<ArcGISAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Asana/AsanaAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Asana/AsanaAuthenticationHandler.cs
@@ -18,9 +18,8 @@ public partial class AsanaAuthenticationHandler : OAuthHandler<AsanaAuthenticati
     public AsanaAuthenticationHandler(
         [NotNull] IOptionsMonitor<AsanaAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Autodesk/AutodeskAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Autodesk/AutodeskAuthenticationHandler.cs
@@ -18,9 +18,8 @@ public partial class AutodeskAuthenticationHandler : OAuthHandler<AutodeskAuthen
     public AutodeskAuthenticationHandler(
         [NotNull] IOptionsMonitor<AutodeskAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Baidu/BaiduAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Baidu/BaiduAuthenticationHandler.cs
@@ -19,9 +19,8 @@ public partial class BaiduAuthenticationHandler : OAuthHandler<BaiduAuthenticati
     public BaiduAuthenticationHandler(
         [NotNull] IOptionsMonitor<BaiduAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Basecamp/BasecampAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Basecamp/BasecampAuthenticationHandler.cs
@@ -18,9 +18,8 @@ public partial class BasecampAuthenticationHandler : OAuthHandler<BasecampAuthen
     public BasecampAuthenticationHandler(
         [NotNull] IOptionsMonitor<BasecampAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.BattleNet/BattleNetAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.BattleNet/BattleNetAuthenticationHandler.cs
@@ -19,9 +19,8 @@ public partial class BattleNetAuthenticationHandler : OAuthHandler<BattleNetAuth
     public BattleNetAuthenticationHandler(
         [NotNull] IOptionsMonitor<BattleNetAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Beam/BeamAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Beam/BeamAuthenticationHandler.cs
@@ -18,9 +18,8 @@ public partial class BeamAuthenticationHandler : OAuthHandler<BeamAuthentication
     public BeamAuthenticationHandler(
         [NotNull] IOptionsMonitor<BeamAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Bitbucket/BitbucketAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Bitbucket/BitbucketAuthenticationHandler.cs
@@ -18,9 +18,8 @@ public partial class BitbucketAuthenticationHandler : OAuthHandler<BitbucketAuth
     public BitbucketAuthenticationHandler(
         [NotNull] IOptionsMonitor<BitbucketAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Buffer/BufferAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Buffer/BufferAuthenticationHandler.cs
@@ -18,9 +18,8 @@ public partial class BufferAuthenticationHandler : OAuthHandler<BufferAuthentica
     public BufferAuthenticationHandler(
         [NotNull] IOptionsMonitor<BufferAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.CiscoSpark/CiscoSparkAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.CiscoSpark/CiscoSparkAuthenticationHandler.cs
@@ -18,9 +18,8 @@ public partial class CiscoSparkAuthenticationHandler : OAuthHandler<CiscoSparkAu
     public CiscoSparkAuthenticationHandler(
         [NotNull] IOptionsMonitor<CiscoSparkAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Coinbase/CoinbaseAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Coinbase/CoinbaseAuthenticationHandler.cs
@@ -18,9 +18,8 @@ public partial class CoinbaseAuthenticationHandler : OAuthHandler<CoinbaseAuthen
     public CoinbaseAuthenticationHandler(
         [NotNull] IOptionsMonitor<CoinbaseAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Deezer/DeezerAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Deezer/DeezerAuthenticationHandler.cs
@@ -22,9 +22,8 @@ public partial class DeezerAuthenticationHandler : OAuthHandler<DeezerAuthentica
     public DeezerAuthenticationHandler(
         [NotNull] IOptionsMonitor<DeezerAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.DeviantArt/DeviantArtAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.DeviantArt/DeviantArtAuthenticationHandler.cs
@@ -18,9 +18,8 @@ public partial class DeviantArtAuthenticationHandler : OAuthHandler<DeviantArtAu
     public DeviantArtAuthenticationHandler(
         [NotNull] IOptionsMonitor<DeviantArtAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.DigitalOcean/DigitalOceanAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.DigitalOcean/DigitalOceanAuthenticationHandler.cs
@@ -20,9 +20,8 @@ public partial class DigitalOceanAuthenticationHandler : OAuthHandler<DigitalOce
     public DigitalOceanAuthenticationHandler(
         [NotNull] IOptionsMonitor<DigitalOceanAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Discord/DiscordAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Discord/DiscordAuthenticationHandler.cs
@@ -19,9 +19,8 @@ public partial class DiscordAuthenticationHandler : OAuthHandler<DiscordAuthenti
     public DiscordAuthenticationHandler(
         [NotNull] IOptionsMonitor<DiscordAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Dropbox/DropboxAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Dropbox/DropboxAuthenticationHandler.cs
@@ -19,9 +19,8 @@ public partial class DropboxAuthenticationHandler : OAuthHandler<DropboxAuthenti
     public DropboxAuthenticationHandler(
         [NotNull] IOptionsMonitor<DropboxAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.EVEOnline/EVEOnlineAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.EVEOnline/EVEOnlineAuthenticationHandler.cs
@@ -21,13 +21,11 @@ public partial class EVEOnlineAuthenticationHandler : OAuthHandler<EVEOnlineAuth
     /// <param name="options">The authentication options.</param>
     /// <param name="logger">The logger to use.</param>
     /// <param name="encoder">The URL encoder to use.</param>
-    /// <param name="clock">The system clock to use.</param>
     public EVEOnlineAuthenticationHandler(
         [NotNull] IOptionsMonitor<EVEOnlineAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Ebay/EbayAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Ebay/EbayAuthenticationHandler.cs
@@ -19,9 +19,8 @@ public partial class EbayAuthenticationHandler : OAuthHandler<EbayAuthentication
     public EbayAuthenticationHandler(
         IOptionsMonitor<EbayAuthenticationOptions> options,
         ILoggerFactory logger,
-        UrlEncoder encoder,
-        ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.ExactOnline/ExactOnlineAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.ExactOnline/ExactOnlineAuthenticationHandler.cs
@@ -19,9 +19,8 @@ public partial class ExactOnlineAuthenticationHandler : OAuthHandler<ExactOnline
     public ExactOnlineAuthenticationHandler(
         [NotNull] IOptionsMonitor<ExactOnlineAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Feishu/FeishuAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Feishu/FeishuAuthenticationHandler.cs
@@ -18,9 +18,8 @@ public partial class FeishuAuthenticationHandler : OAuthHandler<FeishuAuthentica
     public FeishuAuthenticationHandler(
         [NotNull] IOptionsMonitor<FeishuAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Fitbit/FitbitAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Fitbit/FitbitAuthenticationHandler.cs
@@ -19,9 +19,8 @@ public partial class FitbitAuthenticationHandler : OAuthHandler<FitbitAuthentica
     public FitbitAuthenticationHandler(
         [NotNull] IOptionsMonitor<FitbitAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Foursquare/FoursquareAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Foursquare/FoursquareAuthenticationHandler.cs
@@ -18,9 +18,8 @@ public partial class FoursquareAuthenticationHandler : OAuthHandler<FoursquareAu
     public FoursquareAuthenticationHandler(
         [NotNull] IOptionsMonitor<FoursquareAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.GitHub/GitHubAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.GitHub/GitHubAuthenticationHandler.cs
@@ -18,9 +18,8 @@ public partial class GitHubAuthenticationHandler : OAuthHandler<GitHubAuthentica
     public GitHubAuthenticationHandler(
         [NotNull] IOptionsMonitor<GitHubAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.GitLab/GitLabAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.GitLab/GitLabAuthenticationHandler.cs
@@ -18,9 +18,8 @@ public partial class GitLabAuthenticationHandler : OAuthHandler<GitLabAuthentica
     public GitLabAuthenticationHandler(
         [NotNull] IOptionsMonitor<GitLabAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Gitee/GiteeAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Gitee/GiteeAuthenticationHandler.cs
@@ -19,9 +19,8 @@ public partial class GiteeAuthenticationHandler : OAuthHandler<GiteeAuthenticati
     public GiteeAuthenticationHandler(
         [NotNull] IOptionsMonitor<GiteeAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Gitter/GitterAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Gitter/GitterAuthenticationHandler.cs
@@ -18,9 +18,8 @@ public partial class GitterAuthenticationHandler : OAuthHandler<GitterAuthentica
     public GitterAuthenticationHandler(
         [NotNull] IOptionsMonitor<GitterAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Harvest/HarvestAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Harvest/HarvestAuthenticationHandler.cs
@@ -18,9 +18,8 @@ public partial class HarvestAuthenticationHandler : OAuthHandler<HarvestAuthenti
     public HarvestAuthenticationHandler(
         [NotNull] IOptionsMonitor<HarvestAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.HealthGraph/HealthGraphAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.HealthGraph/HealthGraphAuthenticationHandler.cs
@@ -18,9 +18,8 @@ public partial class HealthGraphAuthenticationHandler : OAuthHandler<HealthGraph
     public HealthGraphAuthenticationHandler(
         [NotNull] IOptionsMonitor<HealthGraphAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Huawei/HuaweiAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Huawei/HuaweiAuthenticationHandler.cs
@@ -18,9 +18,8 @@ public partial class HuaweiAuthenticationHandler : OAuthHandler<HuaweiAuthentica
     public HuaweiAuthenticationHandler(
         [NotNull] IOptionsMonitor<HuaweiAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.HubSpot/HubSpotAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.HubSpot/HubSpotAuthenticationHandler.cs
@@ -20,9 +20,8 @@ public partial class HubSpotAuthenticationHandler : OAuthHandler<HubSpotAuthenti
     public HubSpotAuthenticationHandler(
         [NotNull] IOptionsMonitor<HubSpotAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Imgur/ImgurAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Imgur/ImgurAuthenticationHandler.cs
@@ -18,9 +18,8 @@ public partial class ImgurAuthenticationHandler : OAuthHandler<ImgurAuthenticati
     public ImgurAuthenticationHandler(
         [NotNull] IOptionsMonitor<ImgurAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Instagram/InstagramAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Instagram/InstagramAuthenticationHandler.cs
@@ -19,9 +19,8 @@ public partial class InstagramAuthenticationHandler : OAuthHandler<InstagramAuth
     public InstagramAuthenticationHandler(
         [NotNull] IOptionsMonitor<InstagramAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.KakaoTalk/KakaoTalkAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.KakaoTalk/KakaoTalkAuthenticationHandler.cs
@@ -18,9 +18,8 @@ public partial class KakaoTalkAuthenticationHandler : OAuthHandler<KakaoTalkAuth
     public KakaoTalkAuthenticationHandler(
         [NotNull] IOptionsMonitor<KakaoTalkAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Keycloak/KeycloakAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Keycloak/KeycloakAuthenticationHandler.cs
@@ -24,13 +24,11 @@ public partial class KeycloakAuthenticationHandler : OAuthHandler<KeycloakAuthen
     /// <param name="options">The authentication options.</param>
     /// <param name="logger">The logger to use.</param>
     /// <param name="encoder">The URL encoder to use.</param>
-    /// <param name="clock">The system clock to use.</param>
     public KeycloakAuthenticationHandler(
         [NotNull] IOptionsMonitor<KeycloakAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Kloudless/KloudlessAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Kloudless/KloudlessAuthenticationHandler.cs
@@ -18,9 +18,8 @@ public partial class KloudlessAuthenticationHandler : OAuthHandler<KloudlessAuth
     public KloudlessAuthenticationHandler(
         [NotNull] IOptionsMonitor<KloudlessAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Kook/KookAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Kook/KookAuthenticationHandler.cs
@@ -18,9 +18,8 @@ public partial class KookAuthenticationHandler : OAuthHandler<KookAuthentication
     public KookAuthenticationHandler(
         [NotNull] IOptionsMonitor<KookAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Kroger/KrogerAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Kroger/KrogerAuthenticationHandler.cs
@@ -24,13 +24,11 @@ public partial class KrogerAuthenticationHandler : OAuthHandler<KrogerAuthentica
     /// <param name="options">The authentication options.</param>
     /// <param name="logger">The logger to use.</param>
     /// <param name="encoder">The URL encoder to use.</param>
-    /// <param name="clock">The system clock to use.</param>
     public KrogerAuthenticationHandler(
         IOptionsMonitor<KrogerAuthenticationOptions> options,
         ILoggerFactory logger,
-        UrlEncoder encoder,
-        ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Lichess/LichessAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Lichess/LichessAuthenticationHandler.cs
@@ -24,13 +24,11 @@ public partial class LichessAuthenticationHandler : OAuthHandler<LichessAuthenti
     /// <param name="options">The authentication options.</param>
     /// <param name="logger">The logger to use.</param>
     /// <param name="encoder">The URL encoder to use.</param>
-    /// <param name="clock">The system clock to use.</param>
     public LichessAuthenticationHandler(
         [NotNull] IOptionsMonitor<LichessAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Line/LineAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Line/LineAuthenticationHandler.cs
@@ -20,9 +20,8 @@ public partial class LineAuthenticationHandler : OAuthHandler<LineAuthentication
     public LineAuthenticationHandler(
         [NotNull] IOptionsMonitor<LineAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.LinkedIn/LinkedInAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.LinkedIn/LinkedInAuthenticationHandler.cs
@@ -20,9 +20,8 @@ public partial class LinkedInAuthenticationHandler : OAuthHandler<LinkedInAuthen
     public LinkedInAuthenticationHandler(
         [NotNull] IOptionsMonitor<LinkedInAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.MailChimp/MailChimpAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.MailChimp/MailChimpAuthenticationHandler.cs
@@ -18,9 +18,8 @@ public partial class MailChimpAuthenticationHandler : OAuthHandler<MailChimpAuth
     public MailChimpAuthenticationHandler(
         [NotNull] IOptionsMonitor<MailChimpAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.MailRu/MailRuAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.MailRu/MailRuAuthenticationHandler.cs
@@ -19,9 +19,8 @@ public partial class MailRuAuthenticationHandler : OAuthHandler<MailRuAuthentica
     public MailRuAuthenticationHandler(
         [NotNull] IOptionsMonitor<MailRuAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Mixcloud/MixcloudAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Mixcloud/MixcloudAuthenticationHandler.cs
@@ -21,9 +21,8 @@ public partial class MixcloudAuthenticationHandler : OAuthHandler<MixcloudAuthen
     public MixcloudAuthenticationHandler(
         [NotNull] IOptionsMonitor<MixcloudAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Moodle/MoodleAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Moodle/MoodleAuthenticationHandler.cs
@@ -18,9 +18,8 @@ public partial class MoodleAuthenticationHandler : OAuthHandler<MoodleAuthentica
     public MoodleAuthenticationHandler(
         [NotNull] IOptionsMonitor<MoodleAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Myob/MyobAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Myob/MyobAuthenticationHandler.cs
@@ -16,9 +16,8 @@ public class MyobAuthenticationHandler : OAuthHandler<MyobAuthenticationOptions>
     public MyobAuthenticationHandler(
         [NotNull] IOptionsMonitor<MyobAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Naver/NaverAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Naver/NaverAuthenticationHandler.cs
@@ -18,9 +18,8 @@ public partial class NaverAuthenticationHandler : OAuthHandler<NaverAuthenticati
     public NaverAuthenticationHandler(
         [NotNull] IOptionsMonitor<NaverAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.NetEase/NetEaseAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.NetEase/NetEaseAuthenticationHandler.cs
@@ -18,9 +18,8 @@ public partial class NetEaseAuthenticationHandler : OAuthHandler<NetEaseAuthenti
     public NetEaseAuthenticationHandler(
         [NotNull] IOptionsMonitor<NetEaseAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Nextcloud/NextcloudAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Nextcloud/NextcloudAuthenticationHandler.cs
@@ -18,9 +18,8 @@ public partial class NextcloudAuthenticationHandler : OAuthHandler<NextcloudAuth
     public NextcloudAuthenticationHandler(
         [NotNull] IOptionsMonitor<NextcloudAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Notion/NotionAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Notion/NotionAuthenticationHandler.cs
@@ -19,9 +19,8 @@ public class NotionAuthenticationHandler : OAuthHandler<NotionAuthenticationOpti
     public NotionAuthenticationHandler(
         [NotNull] IOptionsMonitor<NotionAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Odnoklassniki/OdnoklassnikiAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Odnoklassniki/OdnoklassnikiAuthenticationHandler.cs
@@ -21,9 +21,8 @@ public partial class OdnoklassnikiAuthenticationHandler : OAuthHandler<Odnoklass
     public OdnoklassnikiAuthenticationHandler(
         [NotNull] IOptionsMonitor<OdnoklassnikiAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Okta/OktaAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Okta/OktaAuthenticationHandler.cs
@@ -24,13 +24,11 @@ public partial class OktaAuthenticationHandler : OAuthHandler<OktaAuthentication
     /// <param name="options">The authentication options.</param>
     /// <param name="logger">The logger to use.</param>
     /// <param name="encoder">The URL encoder to use.</param>
-    /// <param name="clock">The system clock to use.</param>
     public OktaAuthenticationHandler(
         [NotNull] IOptionsMonitor<OktaAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Onshape/OnshapeAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Onshape/OnshapeAuthenticationHandler.cs
@@ -18,9 +18,8 @@ public partial class OnshapeAuthenticationHandler : OAuthHandler<OnshapeAuthenti
     public OnshapeAuthenticationHandler(
         [NotNull] IOptionsMonitor<OnshapeAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Patreon/PatreonAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Patreon/PatreonAuthenticationHandler.cs
@@ -19,9 +19,8 @@ public partial class PatreonAuthenticationHandler : OAuthHandler<PatreonAuthenti
     public PatreonAuthenticationHandler(
         [NotNull] IOptionsMonitor<PatreonAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Paypal/PaypalAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Paypal/PaypalAuthenticationHandler.cs
@@ -18,9 +18,8 @@ public partial class PaypalAuthenticationHandler : OAuthHandler<PaypalAuthentica
     public PaypalAuthenticationHandler(
         [NotNull] IOptionsMonitor<PaypalAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.PingOne/PingOneAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.PingOne/PingOneAuthenticationHandler.cs
@@ -24,13 +24,11 @@ public partial class PingOneAuthenticationHandler : OAuthHandler<PingOneAuthenti
     /// <param name="options">The authentication options.</param>
     /// <param name="logger">The logger to use.</param>
     /// <param name="encoder">The URL encoder to use.</param>
-    /// <param name="clock">The system clock to use.</param>
     public PingOneAuthenticationHandler(
         [NotNull] IOptionsMonitor<PingOneAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.QQ/QQAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.QQ/QQAuthenticationHandler.cs
@@ -19,9 +19,8 @@ public partial class QQAuthenticationHandler : OAuthHandler<QQAuthenticationOpti
     public QQAuthenticationHandler(
         [NotNull] IOptionsMonitor<QQAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.QuickBooks/QuickBooksAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.QuickBooks/QuickBooksAuthenticationHandler.cs
@@ -19,9 +19,8 @@ public partial class QuickBooksAuthenticationHandler : OAuthHandler<QuickBooksAu
     public QuickBooksAuthenticationHandler(
         [NotNull] IOptionsMonitor<QuickBooksAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Reddit/RedditAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Reddit/RedditAuthenticationHandler.cs
@@ -20,9 +20,8 @@ public partial class RedditAuthenticationHandler : OAuthHandler<RedditAuthentica
     public RedditAuthenticationHandler(
         [NotNull] IOptionsMonitor<RedditAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Salesforce/SalesforceAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Salesforce/SalesforceAuthenticationHandler.cs
@@ -18,9 +18,8 @@ public partial class SalesforceAuthenticationHandler : OAuthHandler<SalesforceAu
     public SalesforceAuthenticationHandler(
         [NotNull] IOptionsMonitor<SalesforceAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.ServiceChannel/ServiceChannelAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.ServiceChannel/ServiceChannelAuthenticationHandler.cs
@@ -18,9 +18,8 @@ public partial class ServiceChannelAuthenticationHandler : OAuthHandler<ServiceC
     public ServiceChannelAuthenticationHandler(
         [NotNull] IOptionsMonitor<ServiceChannelAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Shopify/ShopifyAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Shopify/ShopifyAuthenticationHandler.cs
@@ -23,9 +23,8 @@ public partial class ShopifyAuthenticationHandler : OAuthHandler<ShopifyAuthenti
     public ShopifyAuthenticationHandler(
         [NotNull] IOptionsMonitor<ShopifyAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 
@@ -65,7 +64,7 @@ public partial class ShopifyAuthenticationHandler : OAuthHandler<ShopifyAuthenti
 
             if (expiresInProperty.TryGetInt32(out var expiresIn))
             {
-                var expires = Clock.UtcNow.AddSeconds(expiresIn);
+                var expires = TimeProvider.GetUtcNow().AddSeconds(expiresIn);
                 identity.AddClaim(new Claim(ClaimTypes.Expiration, expires.ToString("O", CultureInfo.InvariantCulture), ClaimValueTypes.DateTime));
             }
 

--- a/src/AspNet.Security.OAuth.Slack/SlackAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Slack/SlackAuthenticationHandler.cs
@@ -19,9 +19,8 @@ public partial class SlackAuthenticationHandler : OAuthHandler<SlackAuthenticati
     public SlackAuthenticationHandler(
         [NotNull] IOptionsMonitor<SlackAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Smartsheet/SmartsheetAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Smartsheet/SmartsheetAuthenticationHandler.cs
@@ -20,9 +20,8 @@ public partial class SmartsheetAuthenticationHandler : OAuthHandler<SmartsheetAu
     public SmartsheetAuthenticationHandler(
         [NotNull] IOptionsMonitor<SmartsheetAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Snapchat/SnapchatAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Snapchat/SnapchatAuthenticationHandler.cs
@@ -20,9 +20,8 @@ public partial class SnapchatAuthenticationHandler : OAuthHandler<SnapchatAuthen
     public SnapchatAuthenticationHandler(
         [NotNull] IOptionsMonitor<SnapchatAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.SoundCloud/SoundCloudAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.SoundCloud/SoundCloudAuthenticationHandler.cs
@@ -19,9 +19,8 @@ public partial class SoundCloudAuthenticationHandler : OAuthHandler<SoundCloudAu
     public SoundCloudAuthenticationHandler(
         [NotNull] IOptionsMonitor<SoundCloudAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Spotify/SpotifyAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Spotify/SpotifyAuthenticationHandler.cs
@@ -18,9 +18,8 @@ public partial class SpotifyAuthenticationHandler : OAuthHandler<SpotifyAuthenti
     public SpotifyAuthenticationHandler(
         [NotNull] IOptionsMonitor<SpotifyAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationHandler.cs
@@ -19,9 +19,8 @@ public partial class StackExchangeAuthenticationHandler : OAuthHandler<StackExch
     public StackExchangeAuthenticationHandler(
         [NotNull] IOptionsMonitor<StackExchangeAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Strava/StravaAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Strava/StravaAuthenticationHandler.cs
@@ -13,17 +13,16 @@ using Microsoft.Extensions.Options;
 
 namespace AspNet.Security.OAuth.Strava;
 
+/// <summary>
+/// Authentication handler for Strava authentication
+/// </summary>
 public partial class StravaAuthenticationHandler : OAuthHandler<StravaAuthenticationOptions>
 {
-    /// <summary>
-    /// Authentication handler for Strava authentication
-    /// </summary>
     public StravaAuthenticationHandler(
         [NotNull] IOptionsMonitor<StravaAuthenticationOptions> options,
         [NotNull] ILoggerFactory factory,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, factory, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, factory, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Streamlabs/StreamlabsAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Streamlabs/StreamlabsAuthenticationHandler.cs
@@ -18,9 +18,8 @@ public partial class StreamlabsAuthenticationHandler : OAuthHandler<StreamlabsAu
     public StreamlabsAuthenticationHandler(
         [NotNull] IOptionsMonitor<StreamlabsAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.SuperOffice/SuperOfficeAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.SuperOffice/SuperOfficeAuthenticationHandler.cs
@@ -24,9 +24,8 @@ public partial class SuperOfficeAuthenticationHandler : OAuthHandler<SuperOffice
     public SuperOfficeAuthenticationHandler(
         [NotNull] IOptionsMonitor<SuperOfficeAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Trakt/TraktAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Trakt/TraktAuthenticationHandler.cs
@@ -18,9 +18,8 @@ public partial class TraktAuthenticationHandler : OAuthHandler<TraktAuthenticati
     public TraktAuthenticationHandler(
         [NotNull] IOptionsMonitor<TraktAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Trovo/TrovoAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Trovo/TrovoAuthenticationHandler.cs
@@ -23,9 +23,8 @@ public partial class TrovoAuthenticationHandler : OAuthHandler<TrovoAuthenticati
     public TrovoAuthenticationHandler(
         [NotNull] IOptionsMonitor<TrovoAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Twitch/TwitchAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Twitch/TwitchAuthenticationHandler.cs
@@ -19,9 +19,8 @@ public partial class TwitchAuthenticationHandler : OAuthHandler<TwitchAuthentica
     public TwitchAuthenticationHandler(
         [NotNull] IOptionsMonitor<TwitchAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Twitter/TwitterAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Twitter/TwitterAuthenticationHandler.cs
@@ -27,13 +27,11 @@ public partial class TwitterAuthenticationHandler : OAuthHandler<TwitterAuthenti
     /// <param name="options">The authentication options.</param>
     /// <param name="logger">The logger to use.</param>
     /// <param name="encoder">The URL encoder to use.</param>
-    /// <param name="clock">The system clock to use.</param>
     public TwitterAuthenticationHandler(
         [NotNull] IOptionsMonitor<TwitterAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 
@@ -43,7 +41,7 @@ public partial class TwitterAuthenticationHandler : OAuthHandler<TwitterAuthenti
         [NotNull] AuthenticationProperties properties,
         [NotNull] OAuthTokenResponse tokens)
     {
-        string endpoint = Options.UserInformationEndpoint;
+        var endpoint = Options.UserInformationEndpoint;
 
         endpoint = AddQueryParameterIfValues(endpoint, "expansions", Options.Expansions);
         endpoint = AddQueryParameterIfValues(endpoint, "tweet.fields", Options.TweetFields);
@@ -88,7 +86,7 @@ public partial class TwitterAuthenticationHandler : OAuthHandler<TwitterAuthenti
             context.Properties.Items.Remove(OAuthConstants.CodeVerifierKey);
         }
 
-        string credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes(
+        var credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes(
             string.Concat(
                 Uri.EscapeDataString(Options.ClientId),
                 ":",

--- a/src/AspNet.Security.OAuth.Untappd/UntappdAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Untappd/UntappdAuthenticationHandler.cs
@@ -20,9 +20,8 @@ public partial class UntappdAuthenticationHandler : OAuthHandler<UntappdAuthenti
     public UntappdAuthenticationHandler(
         [NotNull] IOptionsMonitor<UntappdAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Vimeo/VimeoAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Vimeo/VimeoAuthenticationHandler.cs
@@ -18,9 +18,8 @@ public partial class VimeoAuthenticationHandler : OAuthHandler<VimeoAuthenticati
     public VimeoAuthenticationHandler(
         [NotNull] IOptionsMonitor<VimeoAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.VisualStudio/VisualStudioAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.VisualStudio/VisualStudioAuthenticationHandler.cs
@@ -20,9 +20,8 @@ public partial class VisualStudioAuthenticationHandler : OAuthHandler<VisualStud
     public VisualStudioAuthenticationHandler(
         [NotNull] IOptionsMonitor<VisualStudioAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Vkontakte/VkontakteAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Vkontakte/VkontakteAuthenticationHandler.cs
@@ -18,9 +18,8 @@ public partial class VkontakteAuthenticationHandler : OAuthHandler<VkontakteAuth
     public VkontakteAuthenticationHandler(
         [NotNull] IOptionsMonitor<VkontakteAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Weibo/WeiboAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Weibo/WeiboAuthenticationHandler.cs
@@ -20,9 +20,8 @@ public partial class WeiboAuthenticationHandler : OAuthHandler<WeiboAuthenticati
     public WeiboAuthenticationHandler(
         [NotNull] IOptionsMonitor<WeiboAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Weixin/WeixinAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Weixin/WeixinAuthenticationHandler.cs
@@ -23,9 +23,8 @@ public partial class WeixinAuthenticationHandler : OAuthHandler<WeixinAuthentica
     public WeixinAuthenticationHandler(
         [NotNull] IOptionsMonitor<WeixinAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.WordPress/WordPressAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.WordPress/WordPressAuthenticationHandler.cs
@@ -18,9 +18,8 @@ public partial class WordPressAuthenticationHandler : OAuthHandler<WordPressAuth
     public WordPressAuthenticationHandler(
         [NotNull] IOptionsMonitor<WordPressAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.WorkWeixin/WorkWeixinAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.WorkWeixin/WorkWeixinAuthenticationHandler.cs
@@ -22,9 +22,8 @@ public partial class WorkWeixinAuthenticationHandler : OAuthHandler<WorkWeixinAu
     public WorkWeixinAuthenticationHandler(
         [NotNull] IOptionsMonitor<WorkWeixinAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Xero/XeroAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Xero/XeroAuthenticationHandler.cs
@@ -25,9 +25,8 @@ public partial class XeroAuthenticationHandler : OAuthHandler<XeroAuthentication
     public XeroAuthenticationHandler(
         [NotNull] IOptionsMonitor<XeroAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Xumm/XummAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Xumm/XummAuthenticationHandler.cs
@@ -19,9 +19,8 @@ public partial class XummAuthenticationHandler : OAuthHandler<XummAuthentication
     public XummAuthenticationHandler(
         [NotNull] IOptionsMonitor<XummAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Yahoo/YahooAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Yahoo/YahooAuthenticationHandler.cs
@@ -20,9 +20,8 @@ public partial class YahooAuthenticationHandler : OAuthHandler<YahooAuthenticati
     public YahooAuthenticationHandler(
         [NotNull] IOptionsMonitor<YahooAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Yammer/YammerAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Yammer/YammerAuthenticationHandler.cs
@@ -19,9 +19,8 @@ public partial class YammerAuthenticationHandler : OAuthHandler<YammerAuthentica
     public YammerAuthenticationHandler(
         [NotNull] IOptionsMonitor<YammerAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Yandex/YandexAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Yandex/YandexAuthenticationHandler.cs
@@ -20,9 +20,8 @@ public partial class YandexAuthenticationHandler : OAuthHandler<YandexAuthentica
     public YandexAuthenticationHandler(
         [NotNull] IOptionsMonitor<YandexAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Zalo/ZaloAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Zalo/ZaloAuthenticationHandler.cs
@@ -19,9 +19,8 @@ public partial class ZaloAuthenticationHandler : OAuthHandler<ZaloAuthentication
     public ZaloAuthenticationHandler(
         [NotNull] IOptionsMonitor<ZaloAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/src/AspNet.Security.OAuth.Zendesk/ZendeskAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Zendesk/ZendeskAuthenticationHandler.cs
@@ -18,9 +18,8 @@ public partial class ZendeskAuthenticationHandler : OAuthHandler<ZendeskAuthenti
     public ZendeskAuthenticationHandler(
         [NotNull] IOptionsMonitor<ZendeskAuthenticationOptions> options,
         [NotNull] ILoggerFactory logger,
-        [NotNull] UrlEncoder encoder,
-        [NotNull] ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        [NotNull] UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/test/AspNet.Security.OAuth.Providers.Tests/AdobeIO/AdobeIOTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/AdobeIO/AdobeIOTests.cs
@@ -52,13 +52,13 @@ public class AdobeIOTests : OAuthTests<AdobeIOAuthenticationOptions>
         // Arrange
         var options = new AdobeIOAuthenticationOptions();
 
-        string redirectUrl = "https://my-site.local/signin-adobeio";
+        var redirectUrl = "https://my-site.local/signin-adobeio";
 
         // Act
         Uri actual = await BuildChallengeUriAsync(
             options,
             redirectUrl,
-            (options, loggerFactory, encoder, clock) => new AdobeIOAuthenticationHandler(options, loggerFactory, encoder, clock));
+            (options, loggerFactory, encoder) => new AdobeIOAuthenticationHandler(options, loggerFactory, encoder));
 
         // Assert
         actual.ShouldNotBeNull();

--- a/test/AspNet.Security.OAuth.Providers.Tests/Alipay/AlipayTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Alipay/AlipayTests.cs
@@ -19,7 +19,7 @@ public class AlipayTests : OAuthTests<AlipayAuthenticationOptions>
 
     protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
     {
-        builder.Services.AddSingleton<ISystemClock, FixedClock>();
+        builder.Services.AddSingleton<TimeProvider, FixedClock>();
         builder.AddAlipay(options =>
         {
             ConfigureDefaults(builder, options);
@@ -59,13 +59,13 @@ public class AlipayTests : OAuthTests<AlipayAuthenticationOptions>
 
         options.Scope.Add("scope-1");
 
-        string redirectUrl = "https://my-site.local/signin-alipay";
+        var redirectUrl = "https://my-site.local/signin-alipay";
 
         // Act
         Uri actual = await BuildChallengeUriAsync(
             options,
             redirectUrl,
-            (options, loggerFactory, encoder, clock) => new AlipayAuthenticationHandler(options, loggerFactory, encoder, clock));
+            (options, loggerFactory, encoder) => new AlipayAuthenticationHandler(options, loggerFactory, encoder));
 
         // Assert
         actual.ShouldNotBeNull();
@@ -91,8 +91,8 @@ public class AlipayTests : OAuthTests<AlipayAuthenticationOptions>
         }
     }
 
-    private sealed class FixedClock : ISystemClock
+    private sealed class FixedClock : TimeProvider
     {
-        public DateTimeOffset UtcNow => new(2019, 12, 14, 22, 22, 22, TimeSpan.Zero);
+        public override DateTimeOffset GetUtcNow() => new(2019, 12, 14, 22, 22, 22, TimeSpan.Zero);
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Apple/AppleClientSecretGeneratorTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Apple/AppleClientSecretGeneratorTests.cs
@@ -41,7 +41,7 @@ public class AppleClientSecretGeneratorTests
             var utcNow = DateTimeOffset.UtcNow;
 
             // Act
-            string token = await context.Options.ClientSecretGenerator.GenerateAsync(context);
+            var token = await context.Options.ClientSecretGenerator.GenerateAsync(context);
 
             // Assert
             token.ShouldNotBeNullOrWhiteSpace();
@@ -61,7 +61,7 @@ public class AppleClientSecretGeneratorTests
 
             // See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/issues/684
             securityToken.Header.Keys.OrderBy((p) => p).ShouldBe(
-                new string[] { "alg", "kid", "typ" },
+                new[] { "alg", "kid", "typ" },
                 Case.Sensitive,
                 "JWT header contains unexpected additional claims.");
 
@@ -76,7 +76,7 @@ public class AppleClientSecretGeneratorTests
             securityToken.Payload.Exp.HasValue.ShouldBeTrue();
 
             securityToken.Payload.Keys.OrderBy((p) => p).ShouldBe(
-                new string[] { "aud", "exp", "iat", "iss", "nbf", "sub" },
+                new[] { "aud", "exp", "iat", "iss", "nbf", "sub" },
                 Case.Sensitive,
                 "JWT payload contains unexpected additional claims.");
 
@@ -101,18 +101,18 @@ public class AppleClientSecretGeneratorTests
 
         await GenerateTokenAsync(Configure, async (context) =>
         {
-            AppleClientSecretGenerator generator = context.Options.ClientSecretGenerator;
+            var generator = context.Options.ClientSecretGenerator;
 
             // Act
-            string token1 = await generator.GenerateAsync(context);
-            string token2 = await generator.GenerateAsync(context);
+            var token1 = await generator.GenerateAsync(context);
+            var token2 = await generator.GenerateAsync(context);
 
             // Assert
             token2.ShouldBe(token1);
 
             // Act
             await Task.Delay(context.Options.ClientSecretExpiresAfter * 2);
-            string token3 = await generator.GenerateAsync(context);
+            var token3 = await generator.GenerateAsync(context);
 
             // Assert
             token3.ShouldNotBe(token1);
@@ -146,18 +146,18 @@ public class AppleClientSecretGeneratorTests
 
         await GenerateTokenAsync(ConfigureA, async (contextA) =>
         {
-            AppleClientSecretGenerator generator = contextA.Options.ClientSecretGenerator;
+            var generator = contextA.Options.ClientSecretGenerator;
 
             var httpContext = new DefaultHttpContext();
             var scheme = new AuthenticationScheme("AppleB", "AppleB", typeof(AppleAuthenticationHandler));
             var contextB = new AppleGenerateClientSecretContext(httpContext, scheme, optionsB);
 
             // Act
-            string tokenA1 = await generator.GenerateAsync(contextA);
-            string tokenA2 = await generator.GenerateAsync(contextA);
+            var tokenA1 = await generator.GenerateAsync(contextA);
+            var tokenA2 = await generator.GenerateAsync(contextA);
 
-            string tokenB1 = await generator.GenerateAsync(contextB);
-            string tokenB2 = await generator.GenerateAsync(contextB);
+            var tokenB1 = await generator.GenerateAsync(contextB);
+            var tokenB2 = await generator.GenerateAsync(contextB);
 
             // Assert
             tokenA1.ShouldNotBeNullOrWhiteSpace();
@@ -169,8 +169,8 @@ public class AppleClientSecretGeneratorTests
             // Act
             await Task.Delay(clientSecretExpiresAfter * 3);
 
-            string tokenA3 = await generator.GenerateAsync(contextA);
-            string tokenB3 = await generator.GenerateAsync(contextB);
+            var tokenA3 = await generator.GenerateAsync(contextA);
+            var tokenB3 = await generator.GenerateAsync(contextB);
 
             // Assert
             tokenA3.ShouldNotBeNullOrWhiteSpace();

--- a/test/AspNet.Security.OAuth.Providers.Tests/Apple/AppleTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Apple/AppleTests.cs
@@ -178,7 +178,7 @@ public class AppleTests : OAuthTests<AppleAuthenticationOptions>
         using var server = CreateTestServer(ConfigureServices);
 
         // Act
-        var exception = await Assert.ThrowsAsync<Exception>(() => AuthenticateUserAsync(server));
+        var exception = await Assert.ThrowsAsync<AuthenticationFailureException>(() => AuthenticateUserAsync(server));
 
         // Assert
         exception.InnerException.ShouldBeOfType<SecurityTokenValidationException>();
@@ -202,7 +202,7 @@ public class AppleTests : OAuthTests<AppleAuthenticationOptions>
         using var server = CreateTestServer(ConfigureServices);
 
         // Act
-        var exception = await Assert.ThrowsAsync<Exception>(() => AuthenticateUserAsync(server));
+        var exception = await Assert.ThrowsAsync<AuthenticationFailureException>(() => AuthenticateUserAsync(server));
 
         // Assert
         exception.InnerException.ShouldBeOfType<SecurityTokenValidationException>();
@@ -226,7 +226,7 @@ public class AppleTests : OAuthTests<AppleAuthenticationOptions>
         using var server = CreateTestServer(ConfigureServices);
 
         // Act
-        var exception = await Assert.ThrowsAsync<Exception>(() => AuthenticateUserAsync(server));
+        var exception = await Assert.ThrowsAsync<AuthenticationFailureException>(() => AuthenticateUserAsync(server));
 
         // Assert
         exception.InnerException.ShouldBeOfType<SecurityTokenValidationException>();
@@ -249,7 +249,7 @@ public class AppleTests : OAuthTests<AppleAuthenticationOptions>
         using var server = CreateTestServer(ConfigureServices);
 
         // Act
-        var exception = await Assert.ThrowsAsync<Exception>(() => AuthenticateUserAsync(server));
+        var exception = await Assert.ThrowsAsync<AuthenticationFailureException>(() => AuthenticateUserAsync(server));
 
         // Assert
         exception.InnerException.ShouldNotBeNull();
@@ -273,7 +273,7 @@ public class AppleTests : OAuthTests<AppleAuthenticationOptions>
         using var server = CreateTestServer(ConfigureServices);
 
         // Act
-        var exception = await Assert.ThrowsAsync<Exception>(() => AuthenticateUserAsync(server));
+        var exception = await Assert.ThrowsAsync<AuthenticationFailureException>(() => AuthenticateUserAsync(server));
 
         // Assert
         exception.InnerException.ShouldNotBeNull();
@@ -299,7 +299,7 @@ public class AppleTests : OAuthTests<AppleAuthenticationOptions>
         using var server = CreateTestServer(ConfigureServices);
 
         // Act
-        var exception = await Assert.ThrowsAsync<Exception>(() => AuthenticateUserAsync(server));
+        var exception = await Assert.ThrowsAsync<AuthenticationFailureException>(() => AuthenticateUserAsync(server));
 
         // Assert
         exception.InnerException.ShouldNotBeNull();
@@ -312,8 +312,8 @@ public class AppleTests : OAuthTests<AppleAuthenticationOptions>
     public async Task Custom_Events_Are_Raised_By_Handler()
     {
         // Arrange
-        bool onGenerateClientSecretEventRaised = false;
-        bool onValidateIdTokenEventRaised = false;
+        var onGenerateClientSecretEventRaised = false;
+        var onValidateIdTokenEventRaised = false;
 
         void ConfigureServices(IServiceCollection services)
         {
@@ -363,8 +363,8 @@ public class AppleTests : OAuthTests<AppleAuthenticationOptions>
     public async Task Custom_Events_Are_Raised_By_Handler_Using_Custom_Events_Type()
     {
         // Arrange
-        bool onGenerateClientSecretEventRaised = false;
-        bool onValidateIdTokenEventRaised = false;
+        var onGenerateClientSecretEventRaised = false;
+        var onValidateIdTokenEventRaised = false;
 
         void ConfigureServices(IServiceCollection services)
         {
@@ -429,13 +429,13 @@ public class AppleTests : OAuthTests<AppleAuthenticationOptions>
             UsePkce = usePkce,
         };
 
-        string redirectUrl = "https://my-site.local/signin-zalo";
+        var redirectUrl = "https://my-site.local/signin-zalo";
 
         // Act
         Uri actual = await BuildChallengeUriAsync(
             options,
             redirectUrl,
-            (options, loggerFactory, encoder, clock) => new AppleAuthenticationHandler(options, loggerFactory, encoder, clock));
+            (options, loggerFactory, encoder) => new AppleAuthenticationHandler(options, loggerFactory, encoder));
 
         // Assert
         actual.ShouldNotBeNull();

--- a/test/AspNet.Security.OAuth.Providers.Tests/AspNet.Security.OAuth.Providers.Tests.csproj
+++ b/test/AspNet.Security.OAuth.Providers.Tests/AspNet.Security.OAuth.Providers.Tests.csproj
@@ -5,7 +5,7 @@
     <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-    <NoWarn>$(NoWarn);CA1054;CA1055;CA1707;CA2227;CA5404</NoWarn>
+    <NoWarn>$(NoWarn);CA1054;CA1055;CA1707;CA1861;CA2227;CA5404</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/AspNet.Security.OAuth.Providers.Tests/Deezer/DeezerTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Deezer/DeezerTests.cs
@@ -70,13 +70,13 @@ public class DeezerTests : OAuthTests<DeezerAuthenticationOptions>
 
         options.Scope.Add("scope-1");
 
-        string redirectUrl = "https://my-site.local/signin-deezer";
+        var redirectUrl = "https://my-site.local/signin-deezer";
 
         // Act
         Uri actual = await BuildChallengeUriAsync(
             options,
             redirectUrl,
-            (options, loggerFactory, encoder, clock) => new DeezerAuthenticationHandler(options, loggerFactory, encoder, clock));
+            (options, loggerFactory, encoder) => new DeezerAuthenticationHandler(options, loggerFactory, encoder));
 
         // Assert
         actual.ShouldNotBeNull();

--- a/test/AspNet.Security.OAuth.Providers.Tests/Discord/DiscordTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Discord/DiscordTests.cs
@@ -44,7 +44,7 @@ public class DiscordTests : OAuthTests<DiscordAuthenticationOptions>
     [Fact]
     public async Task Authorization_Endpoint_Uri_by_Default_Does_Not_Contain_Prompt()
     {
-        bool doesNotContainPrompt = false;
+        var doesNotContainPrompt = false;
 
         void ConfigureServices(IServiceCollection services)
         {
@@ -75,7 +75,7 @@ public class DiscordTests : OAuthTests<DiscordAuthenticationOptions>
     [Fact]
     public async Task Authorization_Endpoint_Uri_Contains_Prompt_None()
     {
-        bool promptIsSetToNone = false;
+        var promptIsSetToNone = false;
 
         void ConfigureServices(IServiceCollection services)
         {
@@ -107,7 +107,7 @@ public class DiscordTests : OAuthTests<DiscordAuthenticationOptions>
     [Fact]
     public async Task Authorization_Endpoint_Uri_Contains_Prompt_Consent()
     {
-        bool promptIsSetToConsent = false;
+        var promptIsSetToConsent = false;
 
         void ConfigureServices(IServiceCollection services)
         {
@@ -150,13 +150,13 @@ public class DiscordTests : OAuthTests<DiscordAuthenticationOptions>
 
         options.Scope.Add("scope-1");
 
-        string redirectUrl = "https://my-site.local/signin-discord";
+        var redirectUrl = "https://my-site.local/signin-discord";
 
         // Act
         Uri actual = await BuildChallengeUriAsync(
             options,
             redirectUrl,
-            (options, loggerFactory, encoder, clock) => new DiscordAuthenticationHandler(options, loggerFactory, encoder, clock));
+            (options, loggerFactory, encoder) => new DiscordAuthenticationHandler(options, loggerFactory, encoder));
 
         // Assert
         actual.ShouldNotBeNull();

--- a/test/AspNet.Security.OAuth.Providers.Tests/Dropbox/DropboxTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Dropbox/DropboxTests.cs
@@ -44,7 +44,7 @@ public class DropboxTests : OAuthTests<DropboxAuthenticationOptions>
     [InlineData("legacy")]
     public async Task RedirectUri_Contains_Access_Type(string value)
     {
-        bool accessTypeIsSet = false;
+        var accessTypeIsSet = false;
 
         void ConfigureServices(IServiceCollection services)
         {
@@ -76,7 +76,7 @@ public class DropboxTests : OAuthTests<DropboxAuthenticationOptions>
     [Fact]
     public async Task Response_Contains_Refresh_Token()
     {
-        bool refreshTokenIsPresent = false;
+        var refreshTokenIsPresent = false;
 
         void ConfigureServices(IServiceCollection services)
         {
@@ -116,13 +116,13 @@ public class DropboxTests : OAuthTests<DropboxAuthenticationOptions>
             UsePkce = usePkce,
         };
 
-        string redirectUrl = "https://my-site.local/signin-dropbox";
+        var redirectUrl = "https://my-site.local/signin-dropbox";
 
         // Act
         Uri actual = await BuildChallengeUriAsync(
             options,
             redirectUrl,
-            (options, loggerFactory, encoder, clock) => new DropboxAuthenticationHandler(options, loggerFactory, encoder, clock));
+            (options, loggerFactory, encoder) => new DropboxAuthenticationHandler(options, loggerFactory, encoder));
 
         // Assert
         actual.ShouldNotBeNull();

--- a/test/AspNet.Security.OAuth.Providers.Tests/Ebay/EbayTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Ebay/EbayTests.cs
@@ -56,13 +56,13 @@ public class EbayTests : OAuthTests<EbayAuthenticationOptions>
         options.Scope.Add("scope-1");
         options.Scope.Add("scope-2");
 
-        string redirectUrl = "https://my-site.local/signin-ebay";
+        var redirectUrl = "https://my-site.local/signin-ebay";
 
         // Act
         Uri actual = await BuildChallengeUriAsync(
             options,
             redirectUrl,
-            (options, loggerFactory, encoder, clock) => new EbayAuthenticationHandler(options, loggerFactory, encoder, clock));
+            (options, loggerFactory, encoder) => new EbayAuthenticationHandler(options, loggerFactory, encoder));
 
         // Assert
         actual.ShouldNotBeNull();

--- a/test/AspNet.Security.OAuth.Providers.Tests/Line/LineTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Line/LineTests.cs
@@ -55,13 +55,13 @@ public class LineTests : OAuthTests<LineAuthenticationOptions>
             UsePkce = usePkce,
         };
 
-        string redirectUrl = "https://my-site.local/signin-line";
+        var redirectUrl = "https://my-site.local/signin-line";
 
         // Act
         Uri actual = await BuildChallengeUriAsync(
             options,
             redirectUrl,
-            (options, loggerFactory, encoder, clock) => new LineAuthenticationHandler(options, loggerFactory, encoder, clock));
+            (options, loggerFactory, encoder) => new LineAuthenticationHandler(options, loggerFactory, encoder));
 
         // Assert
         actual.ShouldNotBeNull();

--- a/test/AspNet.Security.OAuth.Providers.Tests/Mixcloud/MixcloudTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Mixcloud/MixcloudTests.cs
@@ -55,13 +55,13 @@ public class MixcloudTests : OAuthTests<MixcloudAuthenticationOptions>
             UsePkce = usePkce,
         };
 
-        string redirectUrl = "https://my-site.local/signin-mixcloud";
+        var redirectUrl = "https://my-site.local/signin-mixcloud";
 
         // Act
         Uri actual = await BuildChallengeUriAsync(
             options,
             redirectUrl,
-            (options, loggerFactory, encoder, clock) => new MixcloudAuthenticationHandler(options, loggerFactory, encoder, clock));
+            (options, loggerFactory, encoder) => new MixcloudAuthenticationHandler(options, loggerFactory, encoder));
 
         // Assert
         actual.ShouldNotBeNull();

--- a/test/AspNet.Security.OAuth.Providers.Tests/OAuthTests`1.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/OAuthTests`1.cs
@@ -134,7 +134,7 @@ public abstract class OAuthTests<TOptions> : ITestOutputHelperAccessor
     public async Task OnCreatingTicket_Is_Raised_By_Handler()
     {
         // Arrange
-        bool onCreatingTicketEventRaised = false;
+        var onCreatingTicketEventRaised = false;
 
         void ConfigureServices(IServiceCollection services)
         {
@@ -166,7 +166,7 @@ public abstract class OAuthTests<TOptions> : ITestOutputHelperAccessor
     public async Task OnCreatingTicket_Is_Raised_By_Handler_Using_Custom_Events_Type()
     {
         // Arrange
-        bool onCreatingTicketEventRaised = false;
+        var onCreatingTicketEventRaised = false;
 
         void ConfigureServices(IServiceCollection services)
         {
@@ -261,7 +261,7 @@ public abstract class OAuthTests<TOptions> : ITestOutputHelperAccessor
             result.Content.Headers.ContentType.ShouldNotBeNull();
             result.Content.Headers.ContentType!.MediaType.ShouldBe("text/xml");
 
-            string xml = await result.Content.ReadAsStringAsync();
+            var xml = await result.Content.ReadAsStringAsync();
 
             element = XElement.Parse(xml);
         }
@@ -288,7 +288,7 @@ public abstract class OAuthTests<TOptions> : ITestOutputHelperAccessor
     {
         actual.ShouldContainKey(claimType);
 
-        string actualValue = actual[claimType].Value;
+        var actualValue = actual[claimType].Value;
 
         // Parse date strings as DateTimeOffsets so that local time zone differences
         // do not cause claims which are ISO date values to fail to assert correctly.
@@ -306,7 +306,7 @@ public abstract class OAuthTests<TOptions> : ITestOutputHelperAccessor
     protected async Task<Uri> BuildChallengeUriAsync<THandler>(
         TOptions options,
         string redirectUrl,
-        Func<IOptionsMonitor<TOptions>, ILoggerFactory, UrlEncoder, ISystemClock, THandler> factory,
+        Func<IOptionsMonitor<TOptions>, ILoggerFactory, UrlEncoder, THandler> factory,
         AuthenticationProperties? properties = null)
         where THandler : OAuthHandler<TOptions>
     {
@@ -342,18 +342,17 @@ public abstract class OAuthTests<TOptions> : ITestOutputHelperAccessor
         var optionsMonitor = mock.Object;
         var loggerFactory = NullLoggerFactory.Instance;
         var encoder = UrlEncoder.Default;
-        var clock = new SystemClock();
 
-        var handler = factory(optionsMonitor, loggerFactory, encoder, clock);
+        var handler = factory(optionsMonitor, loggerFactory, encoder);
 
         await handler.InitializeAsync(scheme, context);
 
         var type = handler.GetType();
         var method = type.GetMethod("BuildChallengeUrl", BindingFlags.NonPublic | BindingFlags.Instance);
 
-        object[] parameters = new object[] { properties, redirectUrl };
+        var parameters = new object[] { properties, redirectUrl };
 
-        string url = (string)method!.Invoke(handler, parameters)!;
+        var url = (string)method!.Invoke(handler, parameters)!;
 
         url.ShouldNotBeNullOrWhiteSpace();
         if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))

--- a/test/AspNet.Security.OAuth.Providers.Tests/Odnoklassniki/OdnoklassnikiTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Odnoklassniki/OdnoklassnikiTests.cs
@@ -63,13 +63,13 @@ public class OdnoklassnikiTests : OAuthTests<OdnoklassnikiAuthenticationOptions>
 
         options.Scope.Add("scope-1");
 
-        string redirectUrl = "https://my-site.local/signin-odnoklassniki";
+        var redirectUrl = "https://my-site.local/signin-odnoklassniki";
 
         // Act
         Uri actual = await BuildChallengeUriAsync(
             options,
             redirectUrl,
-            (options, loggerFactory, encoder, clock) => new OdnoklassnikiAuthenticationHandler(options, loggerFactory, encoder, clock));
+            (options, loggerFactory, encoder) => new OdnoklassnikiAuthenticationHandler(options, loggerFactory, encoder));
 
         // Assert
         actual.ShouldNotBeNull();

--- a/test/AspNet.Security.OAuth.Providers.Tests/QQ/QQTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/QQ/QQTests.cs
@@ -60,13 +60,13 @@ public class QQTests : OAuthTests<QQAuthenticationOptions>
 
         options.Scope.Add("scope-1");
 
-        string redirectUrl = "https://my-site.local/signin-qq";
+        var redirectUrl = "https://my-site.local/signin-qq";
 
         // Act
         Uri actual = await BuildChallengeUriAsync(
             options,
             redirectUrl,
-            (options, loggerFactory, encoder, clock) => new QQAuthenticationHandler(options, loggerFactory, encoder, clock));
+            (options, loggerFactory, encoder) => new QQAuthenticationHandler(options, loggerFactory, encoder));
 
         // Assert
         actual.ShouldNotBeNull();

--- a/test/AspNet.Security.OAuth.Providers.Tests/Reddit/RedditTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Reddit/RedditTests.cs
@@ -51,13 +51,13 @@ public class RedditTests : OAuthTests<RedditAuthenticationOptions>
 
         options.Scope.Add("scope-1");
 
-        string redirectUrl = "https://my-site.local/signin-reddit";
+        var redirectUrl = "https://my-site.local/signin-reddit";
 
         // Act
         Uri actual = await BuildChallengeUriAsync(
             options,
             redirectUrl,
-            (options, loggerFactory, encoder, clock) => new RedditAuthenticationHandler(options, loggerFactory, encoder, clock));
+            (options, loggerFactory, encoder) => new RedditAuthenticationHandler(options, loggerFactory, encoder));
 
         // Assert
         actual.ShouldNotBeNull();

--- a/test/AspNet.Security.OAuth.Providers.Tests/Shopify/ShopifyTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Shopify/ShopifyTests.cs
@@ -72,13 +72,13 @@ public class ShopifyTests : OAuthTests<ShopifyAuthenticationOptions>
         properties.Items["GrantOptions"] = "per-user";
         properties.Items["ShopName"] = "Apple";
 
-        string redirectUrl = "https://my-site.local/signin-shopify";
+        var redirectUrl = "https://my-site.local/signin-shopify";
 
         // Act
         Uri actual = await BuildChallengeUriAsync(
             options,
             redirectUrl,
-            (options, loggerFactory, encoder, clock) => new ShopifyAuthenticationHandler(options, loggerFactory, encoder, clock),
+            (options, loggerFactory, encoder) => new ShopifyAuthenticationHandler(options, loggerFactory, encoder),
             properties);
 
         // Assert

--- a/test/AspNet.Security.OAuth.Providers.Tests/Strava/StravaTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Strava/StravaTests.cs
@@ -62,13 +62,13 @@ public class StravaTests : OAuthTests<StravaAuthenticationOptions>
 
         options.Scope.Add("scope-1");
 
-        string redirectUrl = "https://my-site.local/signin-strava";
+        var redirectUrl = "https://my-site.local/signin-strava";
 
         // Act
         Uri actual = await BuildChallengeUriAsync(
             options,
             redirectUrl,
-            (options, loggerFactory, encoder, clock) => new StravaAuthenticationHandler(options, loggerFactory, encoder, clock));
+            (options, loggerFactory, encoder) => new StravaAuthenticationHandler(options, loggerFactory, encoder));
 
         // Assert
         actual.ShouldNotBeNull();

--- a/test/AspNet.Security.OAuth.Providers.Tests/Streamlabs/StreamlabsTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Streamlabs/StreamlabsTests.cs
@@ -59,13 +59,13 @@ public class StreamlabsTests : OAuthTests<StreamlabsAuthenticationOptions>
             UsePkce = usePkce,
         };
 
-        string redirectUrl = "https://my-site.local/signin-streamlabs";
+        var redirectUrl = "https://my-site.local/signin-streamlabs";
 
         // Act
         Uri actual = await BuildChallengeUriAsync(
             options,
             redirectUrl,
-            (options, loggerFactory, encoder, clock) => new StreamlabsAuthenticationHandler(options, loggerFactory, encoder, clock));
+            (options, loggerFactory, encoder) => new StreamlabsAuthenticationHandler(options, loggerFactory, encoder));
 
         // Assert
         actual.ShouldNotBeNull();

--- a/test/AspNet.Security.OAuth.Providers.Tests/SuperOffice/SuperOfficeTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/SuperOffice/SuperOfficeTests.cs
@@ -97,7 +97,7 @@ public class SuperOfficeTests : OAuthTests<SuperOfficeAuthenticationOptions>
         using var server = CreateTestServer(ConfigureServices);
 
         // Act
-        var exception = await Assert.ThrowsAsync<Exception>(() => AuthenticateUserAsync(server));
+        var exception = await Assert.ThrowsAsync<AuthenticationFailureException>(() => AuthenticateUserAsync(server));
 
         // Assert
         exception.InnerException.ShouldBeOfType<SecurityTokenValidationException>();

--- a/test/AspNet.Security.OAuth.Providers.Tests/Trovo/TrovoTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Trovo/TrovoTests.cs
@@ -59,7 +59,7 @@ public class TrovoTests : OAuthTests<TrovoAuthenticationOptions>
         Uri actual = await BuildChallengeUriAsync(
             options,
             redirectUrl,
-            (options, loggerFactory, encoder, clock) => new TrovoAuthenticationHandler(options, loggerFactory, encoder, clock));
+            (options, loggerFactory, encoder) => new TrovoAuthenticationHandler(options, loggerFactory, encoder));
 
         // Assert
         actual.ShouldNotBeNull();

--- a/test/AspNet.Security.OAuth.Providers.Tests/Twitch/TwitchTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Twitch/TwitchTests.cs
@@ -58,13 +58,13 @@ public class TwitchTests : OAuthTests<TwitchAuthenticationOptions>
 
         options.Scope.Add("scope-1");
 
-        string redirectUrl = "https://my-site.local/signin-twitch";
+        var redirectUrl = "https://my-site.local/signin-twitch";
 
         // Act
         Uri actual = await BuildChallengeUriAsync(
             options,
             redirectUrl,
-            (options, loggerFactory, encoder, clock) => new TwitchAuthenticationHandler(options, loggerFactory, encoder, clock));
+            (options, loggerFactory, encoder) => new TwitchAuthenticationHandler(options, loggerFactory, encoder));
 
         // Assert
         actual.ShouldNotBeNull();

--- a/test/AspNet.Security.OAuth.Providers.Tests/VisualStudio/VisualStudioTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/VisualStudio/VisualStudioTests.cs
@@ -50,13 +50,13 @@ public class VisualStudioTests : OAuthTests<VisualStudioAuthenticationOptions>
             UsePkce = usePkce,
         };
 
-        string redirectUrl = "https://my-site.local/signin-visualstudio";
+        var redirectUrl = "https://my-site.local/signin-visualstudio";
 
         // Act
         Uri actual = await BuildChallengeUriAsync(
             options,
             redirectUrl,
-            (options, loggerFactory, encoder, clock) => new VisualStudioAuthenticationHandler(options, loggerFactory, encoder, clock));
+            (options, loggerFactory, encoder) => new VisualStudioAuthenticationHandler(options, loggerFactory, encoder));
 
         // Assert
         actual.ShouldNotBeNull();

--- a/test/AspNet.Security.OAuth.Providers.Tests/Weibo/WeiboTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Weibo/WeiboTests.cs
@@ -63,13 +63,13 @@ public class WeiboTests : OAuthTests<WeiboAuthenticationOptions>
         options.Scope.Add("scope-1");
         options.Scope.Add("scope-2");
 
-        string redirectUrl = "https://my-site.local/signin-weibo";
+        var redirectUrl = "https://my-site.local/signin-weibo";
 
         // Act
         Uri actual = await BuildChallengeUriAsync(
             options,
             redirectUrl,
-            (options, loggerFactory, encoder, clock) => new WeiboAuthenticationHandler(options, loggerFactory, encoder, clock));
+            (options, loggerFactory, encoder) => new WeiboAuthenticationHandler(options, loggerFactory, encoder));
 
         // Assert
         actual.ShouldNotBeNull();

--- a/test/AspNet.Security.OAuth.Providers.Tests/Weixin/WeixinTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Weixin/WeixinTests.cs
@@ -122,7 +122,7 @@ public class WeixinTests : OAuthTests<WeixinAuthenticationOptions>
         Uri actual = await BuildChallengeUriAsync(
             options,
             redirectUrl,
-            (options, loggerFactory, encoder, clock) => new WeixinAuthenticationHandler(options, loggerFactory, encoder, clock));
+            (options, loggerFactory, encoder) => new WeixinAuthenticationHandler(options, loggerFactory, encoder));
 
         // Assert
         actual.ShouldNotBeNull();

--- a/test/AspNet.Security.OAuth.Providers.Tests/WorkWeixin/WorkWeixinTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/WorkWeixin/WorkWeixinTests.cs
@@ -54,13 +54,13 @@ public class WorkWeixinTests : OAuthTests<WorkWeixinAuthenticationOptions>
             UsePkce = usePkce,
         };
 
-        string redirectUrl = "https://my-site.local/signin-workweixin";
+        var redirectUrl = "https://my-site.local/signin-workweixin";
 
         // Act
         Uri actual = await BuildChallengeUriAsync(
             options,
             redirectUrl,
-            (options, loggerFactory, encoder, clock) => new WorkWeixinAuthenticationHandler(options, loggerFactory, encoder, clock));
+            (options, loggerFactory, encoder) => new WorkWeixinAuthenticationHandler(options, loggerFactory, encoder));
 
         // Assert
         actual.ShouldNotBeNull();

--- a/test/AspNet.Security.OAuth.Providers.Tests/Xero/XeroTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Xero/XeroTests.cs
@@ -71,7 +71,7 @@ public class XeroTests : OAuthTests<XeroAuthenticationOptions>
         Uri actual = await BuildChallengeUriAsync(
             options,
             redirectUrl,
-            (options, loggerFactory, encoder, clock) => new XeroAuthenticationHandler(options, loggerFactory, encoder, clock));
+            (options, loggerFactory, encoder) => new XeroAuthenticationHandler(options, loggerFactory, encoder));
 
         // Assert
         actual.ShouldNotBeNull();
@@ -112,7 +112,7 @@ public class XeroTests : OAuthTests<XeroAuthenticationOptions>
         using var server = CreateTestServer(ConfigureServices);
 
         // Act
-        var exception = await Assert.ThrowsAsync<Exception>(() => AuthenticateUserAsync(server));
+        var exception = await Assert.ThrowsAsync<AuthenticationFailureException>(() => AuthenticateUserAsync(server));
 
         // Assert
         exception.InnerException.ShouldBeOfType<SecurityTokenValidationException>();

--- a/test/AspNet.Security.OAuth.Providers.Tests/Zalo/ZaloTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Zalo/ZaloTests.cs
@@ -50,13 +50,13 @@ public class ZaloTests : OAuthTests<ZaloAuthenticationOptions>
             UsePkce = usePkce,
         };
 
-        string redirectUrl = "https://my-site.local/signin-zalo";
+        var redirectUrl = "https://my-site.local/signin-zalo";
 
         // Act
         Uri actual = await BuildChallengeUriAsync(
             options,
             redirectUrl,
-            (options, loggerFactory, encoder, clock) => new ZaloAuthenticationHandler(options, loggerFactory, encoder, clock));
+            (options, loggerFactory, encoder) => new ZaloAuthenticationHandler(options, loggerFactory, encoder));
 
         // Assert
         actual.ShouldNotBeNull();


### PR DESCRIPTION
- Update to preview 5 of ASP.NET Core 8.
- Remove usage of `ISystemClock` and use `TimeProvider` instead.
- Suppress `CA1861` in tests.
- Apply some style suggestions from Visual Studio.
