### PR TITLE
Update Autodesk Auth to new v2 API endpoints

### DIFF
--- a/src/AspNet.Security.OAuth.Autodesk/AutodeskAuthenticationDefaults.cs
+++ b/src/AspNet.Security.OAuth.Autodesk/AutodeskAuthenticationDefaults.cs
@@ -34,15 +34,15 @@ public static class AutodeskAuthenticationDefaults
     /// <summary>
     /// Default value for <see cref="OAuthOptions.AuthorizationEndpoint"/>.
     /// </summary>
-    public static readonly string AuthorizationEndpoint = "https://developer.api.autodesk.com/authentication/v1/authorize";
+    public static readonly string AuthorizationEndpoint = "https://developer.api.autodesk.com/authentication/v2/authorize";
 
     /// <summary>
     /// Default value for <see cref="OAuthOptions.TokenEndpoint"/>.
     /// </summary>
-    public static readonly string TokenEndpoint = "https://developer.api.autodesk.com/authentication/v1/gettoken";
+    public static readonly string TokenEndpoint = "https://developer.api.autodesk.com/authentication/v2/gettoken";
 
     /// <summary>
     /// Default value for <see cref="OAuthOptions.UserInformationEndpoint"/>.
     /// </summary>
-    public static readonly string UserInformationEndpoint = "https://developer.api.autodesk.com/userprofile/v1/users/@me";
+    public static readonly string UserInformationEndpoint = "https://api.userprofile.autodesk.com/userinfo";
 }

--- a/src/AspNet.Security.OAuth.Autodesk/AutodeskAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Autodesk/AutodeskAuthenticationOptions.cs
@@ -25,12 +25,11 @@ public class AutodeskAuthenticationOptions : OAuthOptions
 
         Scope.Add("user-profile:read");
 
-        ClaimActions.MapJsonKey(ClaimTypes.NameIdentifier, "userId");
-        ClaimActions.MapJsonKey(ClaimTypes.Name, "userName");
-        ClaimActions.MapJsonKey(ClaimTypes.GivenName, "firstName");
-        ClaimActions.MapJsonKey(ClaimTypes.Surname, "lastName");
-        ClaimActions.MapJsonKey(ClaimTypes.Email, "emailId");
-        ClaimActions.MapJsonKey(Claims.EmailVerified, "emailVerified");
-        ClaimActions.MapJsonKey(Claims.TwoFactorEnabled, "2FaEnabled");
+        ClaimActions.MapJsonKey(ClaimTypes.NameIdentifier, "sub");
+        ClaimActions.MapJsonKey(ClaimTypes.Name, "preferred_username");
+        ClaimActions.MapJsonKey(ClaimTypes.GivenName, "given_name");
+        ClaimActions.MapJsonKey(ClaimTypes.Surname, "family_name");
+        ClaimActions.MapJsonKey(ClaimTypes.Email, "email");
+        ClaimActions.MapJsonKey(Claims.EmailVerified, "email_verified");
     }
 }


### PR DESCRIPTION
Autodesk is deprecating their v1 Auth API endpoints, per the following blog post: https://aps.autodesk.com/blog/authentication-v2-and-deprecation-v1

This PR updates the URLs, and adjusts the claims to match the new userInfo API response, per the following documentation links: 
* https://aps.autodesk.com/en/docs/oauth/v2/reference/http/authorize-GET/
* https://aps.autodesk.com/en/docs/oauth/v2/reference/http/gettoken-POST/
* https://aps.autodesk.com/en/docs/oauth/v2/reference/http/userinfo-GET/