### PR TITLE
Update to ASP.NET Core 8 preview 7

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,9 +4,9 @@
     <PackageVersion Include="JetBrains.Annotations" Version="2022.1.0" />
     <PackageVersion Include="JustEat.HttpClientInterception" Version="3.1.2" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.0-preview.6.23329.11" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0-preview.6.23329.11" />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.0-preview.6.23329.11" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.0-preview.7.23375.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0-preview.7.23375.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.0-preview.7.23375.9" />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.16.0" />
     <PackageVersion Include="Moq" Version="4.18.2" />
     <PackageVersion Include="Shouldly" Version="4.1.0" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -10,7 +10,7 @@
     -->
     <PackageValidationBaselineVersion Condition="'$(PackageValidationBaselineVersion)' == ''">7.0.0</PackageValidationBaselineVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
-    <PreReleaseVersionIteration>6</PreReleaseVersionIteration>
+    <PreReleaseVersionIteration>7</PreReleaseVersionIteration>
     <PreReleaseBrandingLabel>Preview $(PreReleaseVersionIteration)</PreReleaseBrandingLabel>
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>

--- a/global.json
+++ b/global.json
@@ -1,12 +1,12 @@
 {
   "sdk": {
-    "version": "8.0.100-preview.6.23330.14",
+    "version": "8.0.100-preview.7.23376.3",
     "allowPrerelease": true,
     "rollForward": "major"
   },
 
   "tools": {
-    "dotnet": "8.0.100-preview.6.23330.14"
+    "dotnet": "8.0.100-preview.7.23376.3"
   },
 
   "msbuild-sdks": {

--- a/src/AspNet.Security.OAuth.Alipay/AlipayAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Alipay/AlipayAuthenticationHandler.cs
@@ -78,7 +78,7 @@ public partial class AlipayAuthenticationHandler : OAuthHandler<AlipayAuthentica
         }
 
         using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
-        using var document = JsonDocument.Parse(stream);
+        using var document = await JsonDocument.ParseAsync(stream);
 
         var mainElement = document.RootElement.GetProperty("alipay_system_oauth_token_response");
         if (!ValidateReturnCode(mainElement, out var code))
@@ -120,7 +120,7 @@ public partial class AlipayAuthenticationHandler : OAuthHandler<AlipayAuthentica
         }
 
         using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
-        using var document = JsonDocument.Parse(stream);
+        using var document = await JsonDocument.ParseAsync(stream);
         var rootElement = document.RootElement;
 
         if (!rootElement.TryGetProperty("alipay_user_info_share_response", out JsonElement mainElement))

--- a/src/AspNet.Security.OAuth.AmoCrm/AmoCrmAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.AmoCrm/AmoCrmAuthenticationOptions.cs
@@ -32,6 +32,7 @@ public class AmoCrmAuthenticationOptions : OAuthOptions
         ClaimActions.MapJsonKey(ClaimTypes.NameIdentifier, "id");
     }
 
+#pragma warning disable CA1863
     /// <summary>
     /// Gets or sets the amoCRM account name.
     /// </summary>
@@ -48,4 +49,5 @@ public class AmoCrmAuthenticationOptions : OAuthOptions
             UserInformationEndpoint = string.Format(CultureInfo.InvariantCulture, AmoCrmAuthenticationDefaults.UserInformationEndpointFormat, value);
         }
     }
+#pragma warning restore CA1863
 }

--- a/src/AspNet.Security.OAuth.DigitalOcean/DigitalOceanAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.DigitalOcean/DigitalOceanAuthenticationHandler.cs
@@ -56,7 +56,7 @@ public partial class DigitalOceanAuthenticationHandler : OAuthHandler<DigitalOce
         }
 
         using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
-        var payload = JsonDocument.Parse(stream);
+        var payload = await JsonDocument.ParseAsync(stream);
         return OAuthTokenResponse.Success(payload);
     }
 

--- a/src/AspNet.Security.OAuth.Okta/OktaAuthenticationDefaults.cs
+++ b/src/AspNet.Security.OAuth.Okta/OktaAuthenticationDefaults.cs
@@ -53,6 +53,7 @@ public static class OktaAuthenticationDefaults
     /// </summary>
     public static readonly string UserInformationEndpointPathFormat = "/oauth2/{0}/v1/userinfo";
 
+#pragma warning disable CA1863
     /// <summary>
     /// Default path to use for <see cref="OAuthOptions.AuthorizationEndpoint"/>.
     /// </summary>
@@ -67,4 +68,5 @@ public static class OktaAuthenticationDefaults
     /// Default path to use for <see cref="OAuthOptions.UserInformationEndpoint"/>.
     /// </summary>
     public static readonly string UserInformationEndpointPath = string.Format(CultureInfo.InvariantCulture, UserInformationEndpointPathFormat, DefaultAuthorizationServer);
+#pragma warning disable CA1863
 }

--- a/src/AspNet.Security.OAuth.QQ/QQAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.QQ/QQAuthenticationHandler.cs
@@ -59,7 +59,7 @@ public partial class QQAuthenticationHandler : OAuthHandler<QQAuthenticationOpti
         }
 
         using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
-        using var payload = JsonDocument.Parse(stream);
+        using var payload = await JsonDocument.ParseAsync(stream);
 
         var status = payload.RootElement.GetProperty("ret").GetInt32();
 
@@ -109,7 +109,7 @@ public partial class QQAuthenticationHandler : OAuthHandler<QQAuthenticationOpti
         }
 
         using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
-        var payload = JsonDocument.Parse(stream);
+        var payload = await JsonDocument.ParseAsync(stream);
 
         return OAuthTokenResponse.Success(payload);
     }
@@ -139,7 +139,7 @@ public partial class QQAuthenticationHandler : OAuthHandler<QQAuthenticationOpti
         }
 
         using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
-        using JsonDocument payload = JsonDocument.Parse(stream);
+        using var payload = await JsonDocument.ParseAsync(stream);
 
         var payloadRoot = payload.RootElement;
 

--- a/src/AspNet.Security.OAuth.Shopify/ShopifyAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Shopify/ShopifyAuthenticationHandler.cs
@@ -34,10 +34,12 @@ public partial class ShopifyAuthenticationHandler : OAuthHandler<ShopifyAuthenti
         [NotNull] AuthenticationProperties properties,
         [NotNull] OAuthTokenResponse tokens)
     {
+#pragma warning disable CA1863
         var uri = string.Format(
             CultureInfo.InvariantCulture,
             ShopifyAuthenticationDefaults.UserInformationEndpointFormat,
             properties.Items[ShopifyAuthenticationDefaults.ShopNameAuthenticationProperty]);
+#pragma warning restore CA1863
 
         using var request = new HttpRequestMessage(HttpMethod.Get, uri);
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));

--- a/src/AspNet.Security.OAuth.SuperOffice/SuperOfficeAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.SuperOffice/SuperOfficeAuthenticationHandler.cs
@@ -50,7 +50,9 @@ public partial class SuperOfficeAuthenticationHandler : OAuthHandler<SuperOffice
         // UserInfo endpoint must support multiple subdomains, i.e. sod, sod1, online, online1, online2, ...
         // - subdomain only becomes known from id token
         // Example WebApi Url https://sod.superoffice.com/Cust12345/api/
+#pragma warning disable CA1863
         var userInfoEndpoint = string.Format(CultureInfo.InvariantCulture, SuperOfficeAuthenticationConstants.FormatStrings.UserInfoEndpoint, webApiUrl);
+#pragma warning restore CA1863
 
         // Get the SuperOffice user principal.
         using var request = new HttpRequestMessage(HttpMethod.Get, userInfoEndpoint);

--- a/src/AspNet.Security.OAuth.SuperOffice/SuperOfficeAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.SuperOffice/SuperOfficeAuthenticationOptions.cs
@@ -148,6 +148,7 @@ public class SuperOfficeAuthenticationOptions : OAuthOptions
     {
         string env = GetEnvironment();
 
+#pragma warning disable CA1863
         AuthorizationEndpoint = string.Format(CultureInfo.InvariantCulture,
             FormatStrings.AuthorizeEndpoint,
             env);
@@ -167,5 +168,6 @@ public class SuperOfficeAuthenticationOptions : OAuthOptions
         Authority = string.Format(CultureInfo.InvariantCulture,
             FormatStrings.Authority,
             env);
+#pragma warning restore CA1863
     }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/AspNet.Security.OAuth.Providers.Tests.csproj
+++ b/test/AspNet.Security.OAuth.Providers.Tests/AspNet.Security.OAuth.Providers.Tests.csproj
@@ -5,7 +5,7 @@
     <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-    <NoWarn>$(NoWarn);CA1054;CA1055;CA1707;CA1861;CA2227;CA5404</NoWarn>
+    <NoWarn>$(NoWarn);CA1054;CA1055;CA1707;CA1861;CA1863;CA2227;CA5404</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/AspNet.Security.OAuth.Providers.Tests/StaticAnalysisTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/StaticAnalysisTests.cs
@@ -58,7 +58,7 @@ public static class StaticAnalysisTests
         testedMethods.ShouldBeGreaterThan(0);
     }
 
-    private static IList<AssemblyName> GetProviderAssemblyNames()
+    private static AssemblyName[] GetProviderAssemblyNames()
     {
         var thisType = typeof(StaticAnalysisTests);
 
@@ -72,7 +72,7 @@ public static class StaticAnalysisTests
         return assemblies;
     }
 
-    private static IList<Type> GetPublicTypes(IEnumerable<AssemblyName> assemblyNames)
+    private static Type[] GetPublicTypes(IEnumerable<AssemblyName> assemblyNames)
     {
         var types = assemblyNames
             .Select((p) => AssemblyLoadContext.Default.LoadFromAssemblyName(p))
@@ -85,7 +85,7 @@ public static class StaticAnalysisTests
         return types;
     }
 
-    private static IList<MethodBase> GetPublicOrProtectedConstructorsOrMethods(Type type)
+    private static MethodBase[] GetPublicOrProtectedConstructorsOrMethods(Type type)
     {
         var constructors = type
             .GetConstructors(BindingFlags.Public | BindingFlags.NonPublic)


### PR DESCRIPTION
- Update to preview 7 of ASP.NET Core 8.
- Suppress `CA1863` warnings to use `CompositeFormat`.
- Use `JsonDocument.ParseAsync()` where relevant.
