### PR TITLE
JumpCloud provider improvements

### DIFF
--- a/AspNet.Security.OAuth.Providers.sln
+++ b/AspNet.Security.OAuth.Providers.sln
@@ -191,6 +191,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{C2CA4B38-A
 		docs\gitee.md = docs\gitee.md
 		docs\github.md = docs\github.md
 		docs\instagram.md = docs\instagram.md
+		docs\jumpcloud.md = docs\jumpcloud.md
 		docs\keycloak.md = docs\keycloak.md
 		docs\kloudless.md = docs\kloudless.md
 		docs\kook.md = docs\kook.md
@@ -296,7 +297,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNet.Security.OAuth.Kook"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNet.Security.OAuth.PingOne", "src\AspNet.Security.OAuth.PingOne\AspNet.Security.OAuth.PingOne.csproj", "{CF8C4235-6AE6-404E-B572-4FF4E85AB5FF}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AspNet.Security.OAuth.JumpCloud", "src\AspNet.Security.OAuth.JumpCloud\AspNet.Security.OAuth.JumpCloud.csproj", "{8AF5DDBE-2631-4E71-9045-73A6356CE86B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNet.Security.OAuth.JumpCloud", "src\AspNet.Security.OAuth.JumpCloud\AspNet.Security.OAuth.JumpCloud.csproj", "{8AF5DDBE-2631-4E71-9045-73A6356CE86B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/docs/jumpcloud.md
+++ b/docs/jumpcloud.md
@@ -8,16 +8,16 @@ services.AddAuthentication(options => /* Auth configuration */)
         {
             options.ClientId = "my-client-id";
             options.ClientSecret = "my-client-secret";
-            options.Domain = "https://oauth.id.jumpcloud.com";
+            options.Domain = "oauth.id.jumpcloud.com";
         });
 ```
 
 ## Required Additional Settings
 
-| Property Name | Property Type | Description | Default Value |
-|:--|:--|:--|:--|
-| `Domain` | `string?` | The JumpCloud domain to use for authentication. | `null` |
+_None._
 
 ## Optional Settings
 
-_None._
+| Property Name | Property Type | Description | Default Value |
+|:--|:--|:--|:--|
+| `Domain` | `string?` | The JumpCloud domain to use for authentication. | `"oauth.id.jumpcloud.com"` |

--- a/src/AspNet.Security.OAuth.JumpCloud/JumpCloudAuthenticationDefaults.cs
+++ b/src/AspNet.Security.OAuth.JumpCloud/JumpCloudAuthenticationDefaults.cs
@@ -4,8 +4,6 @@
  * for more information concerning the license and the contributors participating to this project.
  */
 
-using System.Globalization;
-
 namespace AspNet.Security.OAuth.JumpCloud;
 
 /// <summary>
@@ -36,30 +34,33 @@ public static class JumpCloudAuthenticationDefaults
     /// <summary>
     /// Default path format to use for <see cref="OAuthOptions.AuthorizationEndpoint"/>.
     /// </summary>
+    [Obsolete("This field is obsolete and will be removed in a future version.")]
     public static readonly string AuthorizationEndpointPathFormat = "/oauth2/auth";
 
     /// <summary>
     /// Default path format to use for <see cref="OAuthOptions.TokenEndpoint"/>.
     /// </summary>
+    [Obsolete("This field is obsolete and will be removed in a future version.")]
     public static readonly string TokenEndpointPathFormat = "/oauth2/token";
 
     /// <summary>
     /// Default path format to use for <see cref="OAuthOptions.UserInformationEndpoint"/>.
     /// </summary>
+    [Obsolete("This field is obsolete and will be removed in a future version.")]
     public static readonly string UserInformationEndpointPathFormat = "/userinfo";
 
     /// <summary>
     /// Default path to use for <see cref="OAuthOptions.AuthorizationEndpoint"/>.
     /// </summary>
-    public static readonly string AuthorizationEndpointPath = string.Format(CultureInfo.InvariantCulture, AuthorizationEndpointPathFormat);
+    public static readonly string AuthorizationEndpointPath = "/oauth2/auth";
 
     /// <summary>
     /// Default path to use for <see cref="OAuthOptions.TokenEndpoint"/>.
     /// </summary>
-    public static readonly string TokenEndpointPath = string.Format(CultureInfo.InvariantCulture, TokenEndpointPathFormat);
+    public static readonly string TokenEndpointPath = "/oauth2/token";
 
     /// <summary>
     /// Default path to use for <see cref="OAuthOptions.UserInformationEndpoint"/>.
     /// </summary>
-    public static readonly string UserInformationEndpointPath = string.Format(CultureInfo.InvariantCulture, UserInformationEndpointPathFormat);
+    public static readonly string UserInformationEndpointPath = "/userinfo";
 }

--- a/src/AspNet.Security.OAuth.JumpCloud/JumpCloudAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.JumpCloud/JumpCloudAuthenticationOptions.cs
@@ -18,6 +18,8 @@ public class JumpCloudAuthenticationOptions : OAuthOptions
     /// </summary>
     public JumpCloudAuthenticationOptions()
     {
+        UsePkce = true;
+
         ClaimsIssuer = JumpCloudAuthenticationDefaults.Issuer;
         CallbackPath = JumpCloudAuthenticationDefaults.CallbackPath;
 

--- a/src/AspNet.Security.OAuth.JumpCloud/JumpCloudAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.JumpCloud/JumpCloudAuthenticationOptions.cs
@@ -24,8 +24,6 @@ public class JumpCloudAuthenticationOptions : OAuthOptions
         CallbackPath = JumpCloudAuthenticationDefaults.CallbackPath;
 
         Scope.Add("openid");
-        Scope.Add("profile");
-        Scope.Add("email");
 
         ClaimActions.MapJsonKey(ClaimTypes.Email, "email");
         ClaimActions.MapJsonKey(ClaimTypes.GivenName, "given_name");

--- a/src/AspNet.Security.OAuth.JumpCloud/JumpCloudAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.JumpCloud/JumpCloudAuthenticationOptions.cs
@@ -33,9 +33,9 @@ public class JumpCloudAuthenticationOptions : OAuthOptions
     }
 
     /// <summary>
-    /// Gets or sets the JumpCloud domain (Org URL) to use for authentication.
+    /// Gets or sets the optional JumpCloud domain (Org URL) to use for authentication.
     /// </summary>
-    public string? Domain { get; set; }
+    public string? Domain { get; set; } = "oauth.id.jumpcloud.com";
 
     /// <inheritdoc/>
     public override void Validate()

--- a/src/AspNet.Security.OAuth.JumpCloud/JumpCloudPostConfigureOptions.cs
+++ b/src/AspNet.Security.OAuth.JumpCloud/JumpCloudPostConfigureOptions.cs
@@ -4,7 +4,6 @@
  * for more information concerning the license and the contributors participating to this project.
  */
 
-using System.Globalization;
 using Microsoft.Extensions.Options;
 
 namespace AspNet.Security.OAuth.JumpCloud;
@@ -24,15 +23,13 @@ public class JumpCloudPostConfigureOptions : IPostConfigureOptions<JumpCloudAuth
             throw new ArgumentException("No JumpCloud domain configured.", nameof(options));
         }
 
-        options.AuthorizationEndpoint = CreateUrl(options.Domain, JumpCloudAuthenticationDefaults.AuthorizationEndpointPathFormat);
-        options.TokenEndpoint = CreateUrl(options.Domain, JumpCloudAuthenticationDefaults.TokenEndpointPathFormat);
-        options.UserInformationEndpoint = CreateUrl(options.Domain, JumpCloudAuthenticationDefaults.UserInformationEndpointPathFormat);
+        options.AuthorizationEndpoint = CreateUrl(options.Domain, JumpCloudAuthenticationDefaults.AuthorizationEndpointPath);
+        options.TokenEndpoint = CreateUrl(options.Domain, JumpCloudAuthenticationDefaults.TokenEndpointPath);
+        options.UserInformationEndpoint = CreateUrl(options.Domain, JumpCloudAuthenticationDefaults.UserInformationEndpointPath);
     }
 
-    private static string CreateUrl(string domain, string pathFormat, params object[] args)
+    private static string CreateUrl(string domain, string path)
     {
-        var path = string.Format(CultureInfo.InvariantCulture, pathFormat, args);
-
         // Enforce use of HTTPS
         var builder = new UriBuilder(domain)
         {

--- a/test/AspNet.Security.OAuth.Providers.Tests/JumpCloud/JumpCloudEnterpriseTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/JumpCloud/JumpCloudEnterpriseTests.cs
@@ -6,20 +6,23 @@
 
 namespace AspNet.Security.OAuth.JumpCloud;
 
-public class JumpCloudTests : OAuthTests<JumpCloudAuthenticationOptions>
+public class JumpCloudEnterpriseTests : OAuthTests<JumpCloudAuthenticationOptions>
 {
-    public JumpCloudTests(ITestOutputHelper outputHelper)
+    public JumpCloudEnterpriseTests(ITestOutputHelper outputHelper)
     {
         OutputHelper = outputHelper;
     }
 
     public override string DefaultScheme => JumpCloudAuthenticationDefaults.AuthenticationScheme;
 
+    protected override string BundleName => "JumpCloud";
+
     protected internal override void RegisterAuthentication(AuthenticationBuilder builder)
     {
         builder.AddJumpCloud(options =>
         {
             ConfigureDefaults(builder, options);
+            options.Domain = "jumpcloud.local";
         });
     }
 

--- a/test/AspNet.Security.OAuth.Providers.Tests/JumpCloud/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/JumpCloud/bundle.json
@@ -1,6 +1,47 @@
 {
-  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/master/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
+  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/main/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
   "items": [
+    {
+      "comment": "https://jumpcloud.com/support/sso-with-oidc",
+      "uri": "https://oauth.id.jumpcloud.com/oauth2/token",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "secret-access-token",
+        "token_type": "Bearer",
+        "expires_in": 3600,
+        "scope": "openid email",
+        "refresh_token": "secret-refresh-token",
+        "id_token": "secret-id-token"
+      }
+    },
+    {
+      "comment": "https://jumpcloud.com/support/sso-with-oidc",
+      "uri": "https://oauth.id.jumpcloud.com/userinfo",
+      "contentFormat": "json",
+      "contentJson": {
+        "sub": "00uid4BxXw6I6TV4m0g3",
+        "name": "John Doe",
+        "nickname": "Jimmy",
+        "given_name": "John",
+        "middle_name": "James",
+        "family_name": "Doe",
+        "profile": "https://example.com/john.doe",
+        "zoneinfo": "America/Los_Angeles",
+        "locale": "en-US",
+        "updated_at": 1311280970,
+        "email": "john.doe@example.com",
+        "email_verified": true,
+        "address": {
+          "street_address": "123 Hollywood Blvd.",
+          "locality": "Los Angeles",
+          "region": "CA",
+          "postal_code": "90210",
+          "country": "US"
+        },
+        "phone_number": "+1 (425) 555-1212"
+      }
+    },
     {
       "comment": "https://jumpcloud.com/support/sso-with-oidc",
       "uri": "https://jumpcloud.local/oauth2/token",


### PR DESCRIPTION
- Set the default domain for JumpCloud if a custom domain isn't used so that no extra configuration is required.
- Enable PKCE for the JumpCloud provider by default.
- Remove `email` and `profile` by default from JumpCloud.

I went with the second option on https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/pull/797#discussion_r1294659063 - if it's not needed, then I can just mark the associated code as obsolete instead and delete it in the v8 branch.

/cc @AaronSadlerUK 