### PR TITLE
Update to ASP.NET Core 8 RC 1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,9 +4,9 @@
     <PackageVersion Include="JetBrains.Annotations" Version="2022.1.0" />
     <PackageVersion Include="JustEat.HttpClientInterception" Version="3.1.2" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.0-preview.7.23375.9" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0-preview.7.23375.9" />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.0-preview.7.23375.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.0-rc.1.23421.29" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0-rc.1.23421.29" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.0-rc.1.23421.29" />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.16.0" />
     <PackageVersion Include="NSubstitute" Version="5.0.0" />
     <PackageVersion Include="Shouldly" Version="4.1.0" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -9,9 +9,9 @@
       TODO Change to 8.0.0 post-release
     -->
     <PackageValidationBaselineVersion Condition="'$(PackageValidationBaselineVersion)' == ''">7.0.0</PackageValidationBaselineVersion>
-    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
-    <PreReleaseVersionIteration>7</PreReleaseVersionIteration>
-    <PreReleaseBrandingLabel>Preview $(PreReleaseVersionIteration)</PreReleaseBrandingLabel>
+    <PreReleaseVersionLabel>rc</PreReleaseVersionLabel>
+    <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
+    <PreReleaseBrandingLabel>RC $(PreReleaseVersionIteration)</PreReleaseBrandingLabel>
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
     <IncludePreReleaseLabelInPackageVersion>true</IncludePreReleaseLabelInPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -11,7 +11,7 @@
     <PackageValidationBaselineVersion Condition="'$(PackageValidationBaselineVersion)' == ''">7.0.0</PackageValidationBaselineVersion>
     <PreReleaseVersionLabel>rc</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
-    <PreReleaseBrandingLabel>RC $(PreReleaseVersionIteration)</PreReleaseBrandingLabel>
+    <PreReleaseBrandingLabel>Release Candidate $(PreReleaseVersionIteration)</PreReleaseBrandingLabel>
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
     <IncludePreReleaseLabelInPackageVersion>true</IncludePreReleaseLabelInPackageVersion>

--- a/global.json
+++ b/global.json
@@ -1,12 +1,12 @@
 {
   "sdk": {
-    "version": "8.0.100-preview.7.23376.3",
+    "version": "8.0.100-rc.1.23455.8",
     "allowPrerelease": true,
     "rollForward": "major"
   },
 
   "tools": {
-    "dotnet": "8.0.100-preview.7.23376.3"
+    "dotnet": "8.0.100-rc.1.23455.8"
   },
 
   "msbuild-sdks": {

--- a/src/AspNet.Security.OAuth.Apple/Internal/DefaultAppleClientSecretGenerator.cs
+++ b/src/AspNet.Security.OAuth.Apple/Internal/DefaultAppleClientSecretGenerator.cs
@@ -109,7 +109,7 @@ internal sealed partial class DefaultAppleClientSecretGenerator : AppleClientSec
         }
         catch (Exception)
         {
-            algorithm?.Dispose();
+            algorithm.Dispose();
             throw;
         }
     }

--- a/test/AspNet.Security.OAuth.Providers.Tests/Apple/AppleTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Apple/AppleTests.cs
@@ -16,6 +16,8 @@ namespace AspNet.Security.OAuth.Apple;
 
 public class AppleTests : OAuthTests<AppleAuthenticationOptions>
 {
+    private static readonly JsonSerializerOptions SerializerOptions = new() { WriteIndented = true };
+
     public AppleTests(ITestOutputHelper outputHelper)
     {
         OutputHelper = outputHelper;
@@ -533,7 +535,7 @@ public class AppleTests : OAuthTests<AppleAuthenticationOptions>
 
         var publicEmailIdToken = new JwtSecurityTokenHandler().WriteToken(publicEmailToken);
         var privateEmailIdToken = new JwtSecurityTokenHandler().WriteToken(privateEmailToken);
-        var serializedRsaPublicKey = JsonSerializer.Serialize(webKey, new JsonSerializerOptions() { WriteIndented = true });
+        var serializedRsaPublicKey = JsonSerializer.Serialize(webKey, SerializerOptions);
 
         // Copy the values from the test output to bundles.json if you need to regenerate the JWTs to edit the claims
 


### PR DESCRIPTION
Update to release candidate 1 of ASP.NET Core 8.

Unless there's any new analyzer warnings, this should be good to rebuild, move out of draft and merge when it's available tomorrow.
