### PR TITLE
Use unified BattleNet server

### DIFF
--- a/src/AspNet.Security.OAuth.BattleNet/BattleNetAuthenticationDefaults.cs
+++ b/src/AspNet.Security.OAuth.BattleNet/BattleNetAuthenticationDefaults.cs
@@ -31,6 +31,22 @@ public static class BattleNetAuthenticationDefaults
     /// </summary>
     public static readonly string CallbackPath = "/signin-battlenet";
 
+    /// <summary>
+    /// Default value for <see cref="OAuthOptions.AuthorizationEndpoint"/>.
+    /// </summary>
+    public static readonly string AuthorizationEndpoint = "https://oauth.battle.net/oauth/authorize";
+
+    /// <summary>
+    /// Default value for <see cref="OAuthOptions.TokenEndpoint"/>.
+    /// </summary>
+    public static readonly string TokenEndpoint = "https://oauth.battle.net/oauth/token";
+
+    /// <summary>
+    /// Default value for <see cref="OAuthOptions.UserInformationEndpoint"/>.
+    /// </summary>
+    public static readonly string UserInformationEndpoint = "https://oauth.battle.net/oauth/userinfo";
+
+    [Obsolete("This class is obsolete and will be removed in a future release.")]
     public static class America
     {
         /// <summary>
@@ -49,6 +65,7 @@ public static class BattleNetAuthenticationDefaults
         public static readonly string UserInformationEndpoint = "https://us.battle.net/oauth/userinfo";
     }
 
+    [Obsolete("This class is obsolete and will be removed in a future release.")]
     public static class Europe
     {
         /// <summary>
@@ -67,6 +84,7 @@ public static class BattleNetAuthenticationDefaults
         public static readonly string UserInformationEndpoint = "https://eu.battle.net/oauth/userinfo";
     }
 
+    [Obsolete("This class is obsolete and will be removed in a future release.")]
     public static class Korea
     {
         /// <summary>
@@ -85,6 +103,7 @@ public static class BattleNetAuthenticationDefaults
         public static readonly string UserInformationEndpoint = "https://kr.battle.net/oauth/userinfo";
     }
 
+    [Obsolete("This class is obsolete and will be removed in a future release.")]
     public static class Taiwan
     {
         /// <summary>

--- a/src/AspNet.Security.OAuth.BattleNet/BattleNetAuthenticationDefaults.cs
+++ b/src/AspNet.Security.OAuth.BattleNet/BattleNetAuthenticationDefaults.cs
@@ -32,21 +32,29 @@ public static class BattleNetAuthenticationDefaults
     public static readonly string CallbackPath = "/signin-battlenet";
 
     /// <summary>
-    /// Default value for <see cref="OAuthOptions.AuthorizationEndpoint"/>.
+    /// A class containing the URLs for the unified global BattleNet OAuth servers.
     /// </summary>
-    public static readonly string AuthorizationEndpoint = "https://oauth.battle.net/oauth/authorize";
+    public static class Unified
+    {
+        /// <summary>
+        /// Default value for <see cref="OAuthOptions.AuthorizationEndpoint"/>.
+        /// </summary>
+        public static readonly string AuthorizationEndpoint = "https://oauth.battle.net/oauth/authorize";
+
+        /// <summary>
+        /// Default value for <see cref="OAuthOptions.TokenEndpoint"/>.
+        /// </summary>
+        public static readonly string TokenEndpoint = "https://oauth.battle.net/oauth/token";
+
+        /// <summary>
+        /// Default value for <see cref="OAuthOptions.UserInformationEndpoint"/>.
+        /// </summary>
+        public static readonly string UserInformationEndpoint = "https://oauth.battle.net/oauth/userinfo";
+    }
 
     /// <summary>
-    /// Default value for <see cref="OAuthOptions.TokenEndpoint"/>.
+    /// A class containing the URLs for the BattleNet OAuth servers for America.
     /// </summary>
-    public static readonly string TokenEndpoint = "https://oauth.battle.net/oauth/token";
-
-    /// <summary>
-    /// Default value for <see cref="OAuthOptions.UserInformationEndpoint"/>.
-    /// </summary>
-    public static readonly string UserInformationEndpoint = "https://oauth.battle.net/oauth/userinfo";
-
-    [Obsolete("This class is obsolete and will be removed in a future release.")]
     public static class America
     {
         /// <summary>
@@ -65,77 +73,86 @@ public static class BattleNetAuthenticationDefaults
         public static readonly string UserInformationEndpoint = "https://us.battle.net/oauth/userinfo";
     }
 
-    [Obsolete("This class is obsolete and will be removed in a future release.")]
+    /// <summary>
+    /// A class containing the URLs for the BattleNet OAuth servers for Europe.
+    /// </summary>
     public static class Europe
     {
         /// <summary>
-        /// Default value for <see cref="OAuthOptions.AuthorizationEndpoint"/> for EU servers.
+        /// Default value for <see cref="OAuthOptions.AuthorizationEndpoint"/> for European servers.
         /// </summary>
         public static readonly string AuthorizationEndpoint = "https://eu.battle.net/oauth/authorize";
 
         /// <summary>
-        /// Default value for <see cref="OAuthOptions.TokenEndpoint"/> for EU servers.
+        /// Default value for <see cref="OAuthOptions.TokenEndpoint"/> for European servers.
         /// </summary>
         public static readonly string TokenEndpoint = "https://eu.battle.net/oauth/token";
 
         /// <summary>
-        /// Default value for <see cref="OAuthOptions.UserInformationEndpoint"/> for EU servers.
+        /// Default value for <see cref="OAuthOptions.UserInformationEndpoint"/> for European servers.
         /// </summary>
         public static readonly string UserInformationEndpoint = "https://eu.battle.net/oauth/userinfo";
     }
 
-    [Obsolete("This class is obsolete and will be removed in a future release.")]
+    /// <summary>
+    /// A class containing the URLs for the BattleNet OAuth servers for Korea.
+    /// </summary>
     public static class Korea
     {
         /// <summary>
-        /// Default value for <see cref="OAuthOptions.AuthorizationEndpoint"/> for KR servers.
+        /// Default value for <see cref="OAuthOptions.AuthorizationEndpoint"/> for Korean servers.
         /// </summary>
         public static readonly string AuthorizationEndpoint = "https://kr.battle.net/oauth/authorize";
 
         /// <summary>
-        /// Default value for <see cref="OAuthOptions.TokenEndpoint"/> for KR servers.
+        /// Default value for <see cref="OAuthOptions.TokenEndpoint"/> for Korean servers.
         /// </summary>
         public static readonly string TokenEndpoint = "https://kr.battle.net/oauth/token";
 
         /// <summary>
-        /// Default value for <see cref="OAuthOptions.UserInformationEndpoint"/> for KR servers.
+        /// Default value for <see cref="OAuthOptions.UserInformationEndpoint"/> for Korean servers.
         /// </summary>
         public static readonly string UserInformationEndpoint = "https://kr.battle.net/oauth/userinfo";
     }
 
-    [Obsolete("This class is obsolete and will be removed in a future release.")]
+    /// <summary>
+    /// A class containing the URLs for the BattleNet OAuth servers for Taiwan.
+    /// </summary>
     public static class Taiwan
     {
         /// <summary>
-        /// Default value for <see cref="OAuthOptions.AuthorizationEndpoint"/> for TW servers.
+        /// Default value for <see cref="OAuthOptions.AuthorizationEndpoint"/> for Taiwanese servers.
         /// </summary>
         public static readonly string AuthorizationEndpoint = "https://tw.battle.net/oauth/authorize";
 
         /// <summary>
-        /// Default value for <see cref="OAuthOptions.TokenEndpoint"/> for TW servers.
+        /// Default value for <see cref="OAuthOptions.TokenEndpoint"/> for Taiwanese servers.
         /// </summary>
         public static readonly string TokenEndpoint = "https://tw.battle.net/oauth/token";
 
         /// <summary>
-        /// Default value for <see cref="OAuthOptions.UserInformationEndpoint"/> for TW servers.
+        /// Default value for <see cref="OAuthOptions.UserInformationEndpoint"/> for Taiwanese servers.
         /// </summary>
         public static readonly string UserInformationEndpoint = "https://tw.battle.net/oauth/userinfo";
     }
 
+    /// <summary>
+    /// A class containing the URLs for the BattleNet OAuth servers for China.
+    /// </summary>
     public static class China
     {
         /// <summary>
-        /// Default value for <see cref="OAuthOptions.AuthorizationEndpoint"/> for CN servers.
+        /// Default value for <see cref="OAuthOptions.AuthorizationEndpoint"/> for China servers.
         /// </summary>
         public static readonly string AuthorizationEndpoint = "https://www.battlenet.com.cn/oauth/authorize";
 
         /// <summary>
-        /// Default value for <see cref="OAuthOptions.TokenEndpoint"/> for CN servers.
+        /// Default value for <see cref="OAuthOptions.TokenEndpoint"/> for China servers.
         /// </summary>
         public static readonly string TokenEndpoint = "https://www.battlenet.com.cn/oauth/token";
 
         /// <summary>
-        /// Default value for <see cref="OAuthOptions.UserInformationEndpoint"/> for CN servers.
+        /// Default value for <see cref="OAuthOptions.UserInformationEndpoint"/> for China servers.
         /// </summary>
         public static readonly string UserInformationEndpoint = "https://www.battlenet.com.cn/oauth/userinfo";
     }

--- a/src/AspNet.Security.OAuth.BattleNet/BattleNetAuthenticationExtensions.cs
+++ b/src/AspNet.Security.OAuth.BattleNet/BattleNetAuthenticationExtensions.cs
@@ -5,6 +5,8 @@
  */
 
 using AspNet.Security.OAuth.BattleNet;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -69,6 +71,7 @@ public static class BattleNetAuthenticationExtensions
         [CanBeNull] string caption,
         [NotNull] Action<BattleNetAuthenticationOptions> configuration)
     {
+        builder.Services.TryAddSingleton<IPostConfigureOptions<BattleNetAuthenticationOptions>, BattleNetPostConfigureOptions>();
         return builder.AddOAuth<BattleNetAuthenticationOptions, BattleNetAuthenticationHandler>(scheme, caption, configuration);
     }
 }

--- a/src/AspNet.Security.OAuth.BattleNet/BattleNetAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.BattleNet/BattleNetAuthenticationOptions.cs
@@ -18,9 +18,7 @@ public class BattleNetAuthenticationOptions : OAuthOptions
         ClaimsIssuer = BattleNetAuthenticationDefaults.Issuer;
         CallbackPath = BattleNetAuthenticationDefaults.CallbackPath;
 
-        AuthorizationEndpoint = BattleNetAuthenticationDefaults.AuthorizationEndpoint;
-        TokenEndpoint = BattleNetAuthenticationDefaults.TokenEndpoint;
-        UserInformationEndpoint = BattleNetAuthenticationDefaults.UserInformationEndpoint;
+        Region = BattleNetAuthenticationRegion.Unified;
 
         ClaimActions.MapJsonKey(ClaimTypes.NameIdentifier, "id");
         ClaimActions.MapJsonKey(ClaimTypes.Name, "battletag");
@@ -28,50 +26,7 @@ public class BattleNetAuthenticationOptions : OAuthOptions
 
     /// <summary>
     /// Sets the region used to determine the appropriate API endpoints when communicating
-    /// with BattleNet. By default the unified <c>oauth.battle.net</c> domain is used.
+    /// with BattleNet. The default value is <see cref="BattleNetAuthenticationRegion.Unified"/>.
     /// </summary>
-    [Obsolete(
-        "This property is obsolete and will be removed in a future release. " +
-        "Use the properties of the BattleNetAuthenticationDefaults.China class to configure the Endpoint properties for access to the BattleNet servers in China.")]
-    public BattleNetAuthenticationRegion Region
-    {
-        set
-        {
-            switch (value)
-            {
-                case BattleNetAuthenticationRegion.America:
-                    AuthorizationEndpoint = BattleNetAuthenticationDefaults.America.AuthorizationEndpoint;
-                    TokenEndpoint = BattleNetAuthenticationDefaults.America.TokenEndpoint;
-                    UserInformationEndpoint = BattleNetAuthenticationDefaults.America.UserInformationEndpoint;
-                    break;
-
-                case BattleNetAuthenticationRegion.China:
-                    AuthorizationEndpoint = BattleNetAuthenticationDefaults.China.AuthorizationEndpoint;
-                    TokenEndpoint = BattleNetAuthenticationDefaults.China.TokenEndpoint;
-                    UserInformationEndpoint = BattleNetAuthenticationDefaults.China.UserInformationEndpoint;
-                    break;
-
-                case BattleNetAuthenticationRegion.Europe:
-                    AuthorizationEndpoint = BattleNetAuthenticationDefaults.Europe.AuthorizationEndpoint;
-                    TokenEndpoint = BattleNetAuthenticationDefaults.Europe.TokenEndpoint;
-                    UserInformationEndpoint = BattleNetAuthenticationDefaults.Europe.UserInformationEndpoint;
-                    break;
-
-                case BattleNetAuthenticationRegion.Korea:
-                    AuthorizationEndpoint = BattleNetAuthenticationDefaults.Korea.AuthorizationEndpoint;
-                    TokenEndpoint = BattleNetAuthenticationDefaults.Korea.TokenEndpoint;
-                    UserInformationEndpoint = BattleNetAuthenticationDefaults.Korea.UserInformationEndpoint;
-                    break;
-
-                case BattleNetAuthenticationRegion.Taiwan:
-                    AuthorizationEndpoint = BattleNetAuthenticationDefaults.Taiwan.AuthorizationEndpoint;
-                    TokenEndpoint = BattleNetAuthenticationDefaults.Taiwan.TokenEndpoint;
-                    UserInformationEndpoint = BattleNetAuthenticationDefaults.Taiwan.UserInformationEndpoint;
-                    break;
-
-                default:
-                    throw new ArgumentOutOfRangeException($"Region '{value}' is unsupported.", value, nameof(value));
-            }
-        }
-    }
+    public BattleNetAuthenticationRegion Region { get; set; }
 }

--- a/src/AspNet.Security.OAuth.BattleNet/BattleNetAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.BattleNet/BattleNetAuthenticationOptions.cs
@@ -16,10 +16,11 @@ public class BattleNetAuthenticationOptions : OAuthOptions
     public BattleNetAuthenticationOptions()
     {
         ClaimsIssuer = BattleNetAuthenticationDefaults.Issuer;
-
         CallbackPath = BattleNetAuthenticationDefaults.CallbackPath;
 
-        Region = BattleNetAuthenticationRegion.America;
+        AuthorizationEndpoint = BattleNetAuthenticationDefaults.AuthorizationEndpoint;
+        TokenEndpoint = BattleNetAuthenticationDefaults.TokenEndpoint;
+        UserInformationEndpoint = BattleNetAuthenticationDefaults.UserInformationEndpoint;
 
         ClaimActions.MapJsonKey(ClaimTypes.NameIdentifier, "id");
         ClaimActions.MapJsonKey(ClaimTypes.Name, "battletag");
@@ -27,8 +28,11 @@ public class BattleNetAuthenticationOptions : OAuthOptions
 
     /// <summary>
     /// Sets the region used to determine the appropriate API endpoints when communicating
-    /// with BattleNet (by default, <see cref="BattleNetAuthenticationRegion.America"/>).
+    /// with BattleNet. By default the unified <c>oauth.battle.net</c> domain is used.
     /// </summary>
+    [Obsolete(
+        "This property is obsolete and will be removed in a future release. " +
+        "Use the properties of the BattleNetAuthenticationDefaults.China class to configure the Endpoint properties for access to the BattleNet servers in China.")]
     public BattleNetAuthenticationRegion Region
     {
         set

--- a/src/AspNet.Security.OAuth.BattleNet/BattleNetAuthenticationRegion.cs
+++ b/src/AspNet.Security.OAuth.BattleNet/BattleNetAuthenticationRegion.cs
@@ -10,12 +10,40 @@ namespace AspNet.Security.OAuth.BattleNet;
 /// Defines a list of regions used to determine the appropriate
 /// API endpoints when communicating with BattleNet.
 /// </summary>
-[Obsolete("This enumeration is obsolete and will be removed in a future release.")]
 public enum BattleNetAuthenticationRegion
 {
+    /// <summary>
+    /// The region for the Americas.
+    /// </summary>
     America = 0,
+
+    /// <summary>
+    /// The region for China.
+    /// </summary>
     China = 1,
+
+    /// <summary>
+    /// The region for Europe.
+    /// </summary>
     Europe = 2,
+
+    /// <summary>
+    /// The region for Korea.
+    /// </summary>
     Korea = 3,
-    Taiwan = 4
+
+    /// <summary>
+    /// The region for Taiwan.
+    /// </summary>
+    Taiwan = 4,
+
+    /// <summary>
+    /// The unified global region.
+    /// </summary>
+    Unified = 5,
+
+    /// <summary>
+    /// A custom region. Use this value to use custom endpoints.
+    /// </summary>
+    Custom = 6,
 }

--- a/src/AspNet.Security.OAuth.BattleNet/BattleNetAuthenticationRegion.cs
+++ b/src/AspNet.Security.OAuth.BattleNet/BattleNetAuthenticationRegion.cs
@@ -10,6 +10,7 @@ namespace AspNet.Security.OAuth.BattleNet;
 /// Defines a list of regions used to determine the appropriate
 /// API endpoints when communicating with BattleNet.
 /// </summary>
+[Obsolete("This enumeration is obsolete and will be removed in a future release.")]
 public enum BattleNetAuthenticationRegion
 {
     America = 0,

--- a/src/AspNet.Security.OAuth.BattleNet/BattleNetPostConfigureOptions.cs
+++ b/src/AspNet.Security.OAuth.BattleNet/BattleNetPostConfigureOptions.cs
@@ -1,0 +1,66 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using Microsoft.Extensions.Options;
+
+namespace AspNet.Security.OAuth.BattleNet;
+
+/// <summary>
+/// A class used to setup defaults for all <see cref="BattleNetAuthenticationOptions"/>.
+/// </summary>
+public class BattleNetPostConfigureOptions : IPostConfigureOptions<BattleNetAuthenticationOptions>
+{
+    /// <inheritdoc/>
+    public void PostConfigure(
+        string? name,
+        [NotNull] BattleNetAuthenticationOptions options)
+    {
+        switch (options.Region)
+        {
+            case BattleNetAuthenticationRegion.Unified:
+                options.AuthorizationEndpoint = BattleNetAuthenticationDefaults.Unified.AuthorizationEndpoint;
+                options.TokenEndpoint = BattleNetAuthenticationDefaults.Unified.TokenEndpoint;
+                options.UserInformationEndpoint = BattleNetAuthenticationDefaults.Unified.UserInformationEndpoint;
+                break;
+
+            case BattleNetAuthenticationRegion.America:
+                options.AuthorizationEndpoint = BattleNetAuthenticationDefaults.America.AuthorizationEndpoint;
+                options.TokenEndpoint = BattleNetAuthenticationDefaults.America.TokenEndpoint;
+                options.UserInformationEndpoint = BattleNetAuthenticationDefaults.America.UserInformationEndpoint;
+                break;
+
+            case BattleNetAuthenticationRegion.China:
+                options.AuthorizationEndpoint = BattleNetAuthenticationDefaults.China.AuthorizationEndpoint;
+                options.TokenEndpoint = BattleNetAuthenticationDefaults.China.TokenEndpoint;
+                options.UserInformationEndpoint = BattleNetAuthenticationDefaults.China.UserInformationEndpoint;
+                break;
+
+            case BattleNetAuthenticationRegion.Europe:
+                options.AuthorizationEndpoint = BattleNetAuthenticationDefaults.Europe.AuthorizationEndpoint;
+                options.TokenEndpoint = BattleNetAuthenticationDefaults.Europe.TokenEndpoint;
+                options.UserInformationEndpoint = BattleNetAuthenticationDefaults.Europe.UserInformationEndpoint;
+                break;
+
+            case BattleNetAuthenticationRegion.Korea:
+                options.AuthorizationEndpoint = BattleNetAuthenticationDefaults.Korea.AuthorizationEndpoint;
+                options.TokenEndpoint = BattleNetAuthenticationDefaults.Korea.TokenEndpoint;
+                options.UserInformationEndpoint = BattleNetAuthenticationDefaults.Korea.UserInformationEndpoint;
+                break;
+
+            case BattleNetAuthenticationRegion.Taiwan:
+                options.AuthorizationEndpoint = BattleNetAuthenticationDefaults.Taiwan.AuthorizationEndpoint;
+                options.TokenEndpoint = BattleNetAuthenticationDefaults.Taiwan.TokenEndpoint;
+                options.UserInformationEndpoint = BattleNetAuthenticationDefaults.Taiwan.UserInformationEndpoint;
+                break;
+
+            case BattleNetAuthenticationRegion.Custom:
+                break; // Do nothing
+
+            default:
+                throw new NotSupportedException($"The BattleNet region '{options.Region}' is not supported.");
+        }
+    }
+}

--- a/test/AspNet.Security.OAuth.Providers.Tests/BattleNet/BattleNetTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/BattleNet/BattleNetTests.cs
@@ -17,7 +17,45 @@ public class BattleNetTests(ITestOutputHelper outputHelper) : OAuthTests<BattleN
 
     [Theory]
     [InlineData(ClaimTypes.NameIdentifier, "my-id")]
-    [InlineData(ClaimTypes.Name, "John Smith")]
+    [InlineData(ClaimTypes.Name, "Unified")]
     public async Task Can_Sign_In_Using_BattleNet(string claimType, string claimValue)
         => await AuthenticateUserAndAssertClaimValue(claimType, claimValue);
+
+    [Theory]
+    [InlineData(BattleNetAuthenticationRegion.America)]
+    [InlineData(BattleNetAuthenticationRegion.China)]
+    [InlineData(BattleNetAuthenticationRegion.Europe)]
+    [InlineData(BattleNetAuthenticationRegion.Korea)]
+    [InlineData(BattleNetAuthenticationRegion.Taiwan)]
+    [InlineData(BattleNetAuthenticationRegion.Unified)]
+    public async Task Can_Sign_In_Using_BattleNet_Region(BattleNetAuthenticationRegion region)
+    {
+        // Arrange
+        void ConfigureServices(IServiceCollection services)
+        {
+            services.AddOptions<BattleNetAuthenticationOptions>(BattleNetAuthenticationDefaults.AuthenticationScheme)
+                    .Configure((options) => options.Region = region);
+        }
+
+        await AuthenticateUserAndAssertClaimValue(ClaimTypes.Name, region.ToString(), ConfigureServices);
+    }
+
+    [Fact]
+    public async Task Can_Sign_In_Using_Custom_BattleNet_Region()
+    {
+        // Arrange
+        static void ConfigureServices(IServiceCollection services)
+        {
+            services.AddOptions<BattleNetAuthenticationOptions>(BattleNetAuthenticationDefaults.AuthenticationScheme)
+                    .Configure((options) =>
+                    {
+                        options.Region = BattleNetAuthenticationRegion.Custom;
+                        options.AuthorizationEndpoint = "https://oauth.battle.local/oauth/authorize";
+                        options.TokenEndpoint = "https://oauth.battle.local/oauth/token";
+                        options.UserInformationEndpoint = "https://oauth.battle.local/oauth/userinfo";
+                    });
+        }
+
+        await AuthenticateUserAndAssertClaimValue(ClaimTypes.Name, "Custom", ConfigureServices);
+    }
 }

--- a/test/AspNet.Security.OAuth.Providers.Tests/BattleNet/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/BattleNet/bundle.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/master/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
   "items": [
     {
-      "uri": "https://us.battle.net/oauth/token",
+      "uri": "https://oauth.battle.net/oauth/token",
       "method": "POST",
       "contentFormat": "json",
       "contentJson": {
@@ -13,7 +13,7 @@
       }
     },
     {
-      "uri": "https://us.battle.net/oauth/userinfo?access_token=secret-access-token",
+      "uri": "https://oauth.battle.net/oauth/userinfo?access_token=secret-access-token",
       "contentFormat": "json",
       "contentJson": {
         "id": "my-id",

--- a/test/AspNet.Security.OAuth.Providers.Tests/BattleNet/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/BattleNet/bundle.json
@@ -17,7 +17,121 @@
       "contentFormat": "json",
       "contentJson": {
         "id": "my-id",
-        "battletag": "John Smith"
+        "battletag": "Unified"
+      }
+    },
+    {
+      "uri": "https://eu.battle.net/oauth/token",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "secret-access-token",
+        "token_type": "access",
+        "refresh_token": "secret-refresh-token",
+        "expires_in": "300"
+      }
+    },
+    {
+      "uri": "https://eu.battle.net/oauth/userinfo?access_token=secret-access-token",
+      "contentFormat": "json",
+      "contentJson": {
+        "id": "my-id",
+        "battletag": "Europe"
+      }
+    },
+    {
+      "uri": "https://kr.battle.net/oauth/token",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "secret-access-token",
+        "token_type": "access",
+        "refresh_token": "secret-refresh-token",
+        "expires_in": "300"
+      }
+    },
+    {
+      "uri": "https://kr.battle.net/oauth/userinfo?access_token=secret-access-token",
+      "contentFormat": "json",
+      "contentJson": {
+        "id": "my-id",
+        "battletag": "Korea"
+      }
+    },
+    {
+      "uri": "https://tw.battle.net/oauth/token",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "secret-access-token",
+        "token_type": "access",
+        "refresh_token": "secret-refresh-token",
+        "expires_in": "300"
+      }
+    },
+    {
+      "uri": "https://tw.battle.net/oauth/userinfo?access_token=secret-access-token",
+      "contentFormat": "json",
+      "contentJson": {
+        "id": "my-id",
+        "battletag": "Taiwan"
+      }
+    },
+    {
+      "uri": "https://us.battle.net/oauth/token",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "secret-access-token",
+        "token_type": "access",
+        "refresh_token": "secret-refresh-token",
+        "expires_in": "300"
+      }
+    },
+    {
+      "uri": "https://us.battle.net/oauth/userinfo?access_token=secret-access-token",
+      "contentFormat": "json",
+      "contentJson": {
+        "id": "my-id",
+        "battletag": "America"
+      }
+    },
+    {
+      "uri": "https://www.battlenet.com.cn/oauth/token",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "secret-access-token",
+        "token_type": "access",
+        "refresh_token": "secret-refresh-token",
+        "expires_in": "300"
+      }
+    },
+    {
+      "uri": "https://www.battlenet.com.cn/oauth/userinfo?access_token=secret-access-token",
+      "contentFormat": "json",
+      "contentJson": {
+        "id": "my-id",
+        "battletag": "China"
+      }
+    },
+    {
+      "uri": "https://oauth.battle.local/oauth/token",
+      "method": "POST",
+      "contentFormat": "json",
+      "contentJson": {
+        "access_token": "secret-access-token",
+        "token_type": "access",
+        "refresh_token": "secret-refresh-token",
+        "expires_in": "300"
+      }
+    },
+    {
+      "uri": "https://oauth.battle.local/oauth/userinfo?access_token=secret-access-token",
+      "contentFormat": "json",
+      "contentJson": {
+        "id": "my-id",
+        "battletag": "Custom"
       }
     }
   ]


### PR DESCRIPTION
Implemented based on https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/issues/812#issuecomment-1789607922.

Unless it's because of my office's DNS, I couldn't get `oauth.battlenet.com.cn` to resolve, so I left the URLs for China as they were.

I don't actually have a BattleNet account so I haven't tested this against the actual server.

Resolves #812.
