### PR TITLE
Fix duplicated query string parameters for VSO/AzDo provider

### DIFF
--- a/src/AspNet.Security.OAuth.VisualStudio/VisualStudioAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.VisualStudio/VisualStudioAuthenticationHandler.cs
@@ -9,6 +9,7 @@ using System.Net.Http.Headers;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
 using System.Text.Json;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -96,12 +97,11 @@ public partial class VisualStudioAuthenticationHandler : OAuthHandler<VisualStud
 
         query["response_type"] = "Assertion";
 
-        // Remove the query and re-add with the edit so that the parameters are not duplicated.
+        // Replace the query with the edit so that the parameters are not duplicated.
         // See https://github.com/dotnet/aspnetcore/issues/47054 for more context.
-        challengeUri.Query = string.Empty;
-        challengeUrl = challengeUri.Uri.ToString();
+        challengeUri.Query = QueryString.Create(query).Value;
 
-        return QueryHelpers.AddQueryString(challengeUrl, query);
+        return challengeUri.Uri.AbsoluteUri;
     }
 
     private static partial class Log

--- a/src/AspNet.Security.OAuth.VisualStudio/VisualStudioAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.VisualStudio/VisualStudioAuthenticationHandler.cs
@@ -91,12 +91,17 @@ public partial class VisualStudioAuthenticationHandler : OAuthHandler<VisualStud
         var challengeUrl = base.BuildChallengeUrl(properties, redirectUri);
 
         // Visual Studio Online/Azure DevOps uses "Assertion" instead of "code"
-        var challengeUri = new Uri(challengeUrl, UriKind.Absolute);
+        var challengeUri = new UriBuilder(challengeUrl);
         var query = QueryHelpers.ParseQuery(challengeUri.Query);
 
         query["response_type"] = "Assertion";
 
-        return QueryHelpers.AddQueryString(Options.AuthorizationEndpoint, query);
+        // Remove the query and re-add with the edit so that the parameters are not duplicated.
+        // See https://github.com/dotnet/aspnetcore/issues/47054 for more context.
+        challengeUri.Query = string.Empty;
+        challengeUrl = challengeUri.Uri.ToString();
+
+        return QueryHelpers.AddQueryString(challengeUrl, query);
     }
 
     private static partial class Log

--- a/test/AspNet.Security.OAuth.Providers.Tests/VisualStudio/VisualStudioTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/VisualStudio/VisualStudioTests.cs
@@ -26,15 +26,21 @@ public class VisualStudioTests(ITestOutputHelper outputHelper) : OAuthTests<Visu
         => await AuthenticateUserAndAssertClaimValue(claimType, claimValue);
 
     [Theory]
-    [InlineData(false)]
-    [InlineData(true)]
-    public async Task BuildChallengeUrl_Generates_Correct_Url(bool usePkce)
+    [InlineData(false, "")]
+    [InlineData(true, "")]
+    [InlineData(false, "?foo=bar")]
+    [InlineData(true, "?foo=bar")]
+    public async Task BuildChallengeUrl_Generates_Correct_Url(
+        bool usePkce,
+        string authorizationEndpointSuffix)
     {
         // Arrange
         var options = new VisualStudioAuthenticationOptions()
         {
             UsePkce = usePkce,
         };
+
+        options.AuthorizationEndpoint += authorizationEndpointSuffix;
 
         var redirectUrl = "https://my-site.local/signin-visualstudio";
 
@@ -65,6 +71,11 @@ public class VisualStudioTests(ITestOutputHelper outputHelper) : OAuthTests<Visu
         {
             query.ShouldNotContainKey(OAuthConstants.CodeChallengeKey);
             query.ShouldNotContainKey(OAuthConstants.CodeChallengeMethodKey);
+        }
+
+        foreach (var parameter in query)
+        {
+            parameter.Value.Count.ShouldBe(1, $"Query string parameter {parameter.Key} appears more than once: {parameter.Value}.");
         }
     }
 }


### PR DESCRIPTION
Fix query string parameters being duplicated if `AuthorizationEndpoint` contains any user-added query string parameters.

If this change looks good, I can look at making a similar change to the Google provider for dotnet/aspnetcore#47054.

/cc @Tratcher
