### PR TITLE
AoT support

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -66,6 +66,14 @@
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(IsPackable)' == 'true' ">
+    <EnableAotAnalyzer>true</EnableAotAnalyzer>
+    <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <IsAotCompatible>true</IsAotCompatible>
+    <IsTrimmable>true</IsTrimmable>
+  </PropertyGroup>
+
   <PropertyGroup>
     <EnablePackageValidation>$(IsPackable)</EnablePackageValidation>
   </PropertyGroup>

--- a/samples/Mvc.Client/Mvc.Client.csproj
+++ b/samples/Mvc.Client/Mvc.Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <IsShipping>false</IsShipping>
-    <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
+    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <UserSecretsId>AspNet.Security.OAuth.Providers.Mvc.Client</UserSecretsId>
   </PropertyGroup>
 

--- a/src/AspNet.Security.OAuth.Trovo/TrovoAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Trovo/TrovoAuthenticationHandler.cs
@@ -11,6 +11,7 @@ using System.Security.Claims;
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -72,11 +73,13 @@ public partial class TrovoAuthenticationHandler : OAuthHandler<TrovoAuthenticati
             context.Properties.Items.Remove(OAuthConstants.CodeVerifierKey);
         }
 
+        var content = JsonSerializer.Serialize(tokenRequestParameters, AppJsonSerializerContext.Default.DictionaryStringString);
+
         using var request = new HttpRequestMessage(HttpMethod.Post, Options.TokenEndpoint);
 
         request.Headers.Add(ClientIdHeaderName, Options.ClientId);
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(MediaTypeNames.Application.Json));
-        request.Content = new StringContent(JsonSerializer.Serialize(tokenRequestParameters), Encoding.UTF8, MediaTypeNames.Application.Json);
+        request.Content = new StringContent(content, Encoding.UTF8, MediaTypeNames.Application.Json);
 
         using var response = await Backchannel.SendAsync(request, Context.RequestAborted);
 
@@ -89,6 +92,11 @@ public partial class TrovoAuthenticationHandler : OAuthHandler<TrovoAuthenticati
         var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
 
         return OAuthTokenResponse.Success(payload);
+    }
+
+    [JsonSerializable(typeof(Dictionary<string, string>))]
+    internal sealed partial class AppJsonSerializerContext : JsonSerializerContext
+    {
     }
 
     private static partial class Log


### PR DESCRIPTION
Add support for native AoT for the libraries.

After my adventures getting this working for Polly, I thought I'd give it a try here, and it seemed to be relatively simple.

The only changes required were for the Trovo and Yammer providers to use AoT-friendly JSON serialization. Everything else appears to Just Work™️.

Tested by:

1. Adding the following to the Mvc.Sample project file:
    ```xml
    <PropertyGroup>
      <PublishAot>true</PublishAot>
      <SelfContained>true</SelfContained>
      <TrimmerSingleWarn>false</TrimmerSingleWarn>
    </PropertyGroup>
    <ItemGroup>
      <TrimmerRootAssembly Include="@(ProjectReference->'%(Filename)')" />
    </ItemGroup>
    ```
1. Commenting out `services.AddMvc()` (because it's not supported)
1. Running `dotnet publish` for the Mvc.Sample project.

Only one warning is output, and that's from MVC's own lack of support.

```
ILC : Trim analysis warning IL2026: Microsoft.AspNetCore.Mvc.Routing.ConventionalRouteEntry.ConventionalRouteEntry(String,String,RouteValueDictionary,IDictionary`2<String,Object>,RouteValueDictionary,Int32,List`1<Acion`1<EndpointBuilder>>,List`1<Action`1<EndpointBuilder>>): Using member 'Microsoft.AspNetCore.Routing.Patterns.RoutePatternFactory.Parse(String,Object,Object)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. This API may perform reflection on supplied parameters which may be trimmed if not referenced directly. Initialize a RouteValueDictionary with route values to avoid this issue. [C:\Coding\aspnet-contrib\AspNet.Security.OAuth.Providers\samples\Mvc.Client\Mvc.Client.csproj]
```

Thoughts?
