### PR TITLE
Add .NET SDK update workflow

### DIFF
--- a/.github/workflows/update-dotnet-sdks.yml
+++ b/.github/workflows/update-dotnet-sdks.yml
@@ -29,5 +29,8 @@ jobs:
       labels: 'dependencies,.NET'
       ref: ${{ inputs.branch || 'dev' }}
       update-nuget-packages: true
+      user-email: ${{ vars.SERVICE_ACCOUNT_GIT_EMAIL }}
+      user-name: ${{ vars.SERVICE_ACCOUNT_GIT_NAME }}
     secrets:
-      repo-token: ${{ secrets.GITHUB_TOKEN }}
+      application-id: ${{ secrets.SERVICE_ACCOUNT_ID }}
+      application-private-key: ${{ secrets.SERVICE_ACCOUNT_PRIVATE_KEY }}

--- a/.github/workflows/update-dotnet-sdks.yml
+++ b/.github/workflows/update-dotnet-sdks.yml
@@ -1,0 +1,33 @@
+name: update-dotnet-sdk
+
+on:
+  schedule:
+    - cron:  '00 19 * * TUE'
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'The branch to run the SDK updates for.'
+        required: false
+        type: choice
+        options:
+          - 'dev'
+          - 'dev-v9'
+        default: 'dev'
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  update-sdk:
+    name: Update .NET SDK
+    uses: martincostello/update-dotnet-sdk/.github/workflows/update-dotnet-sdk.yml@9d42ad9bcbd97a74394c7273c9c616b4bf136b53 # v3.1.3
+    permissions:
+      contents: write
+      pull-requests: write
+    with:
+      labels: 'dependencies,.NET'
+      ref: ${{ inputs.branch || 'dev' }}
+      update-nuget-packages: true
+    secrets:
+      repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add a GitHub Actions workflow that patches the .NET SDK and ASP.NET Core NuGet packages every month.

It can also be run manually targeting the `dev-v9` branch for updating the .NET 9 SDK from month-to-month as new previews are published.

> Note that because of the use of `GITHUB_TOKEN`, GitHub Actions CI will not be triggered when PRs are opened due to a [GitHub Actions restriction](https://docs.github.com/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow); PRs need to be closed then opened by a maintainer to get it to run. A user PAT or a GitHub app is required to remove that limitation ([example](https://github.com/App-vNext/Polly/blob/61a767e9028d96b2eb0292cbb1ba3ec45e7b6167/.github/workflows/update-dotnet-sdk.yml#L11-L21)).
