### PR TITLE
Ignore Arcade and Helix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,4 +20,6 @@ updates:
       update-types: ["version-update:semver-major"]
     - dependency-name: "Microsoft.AspNetCore.TestHost"
       update-types: ["version-update:semver-major"]
+    - dependency-name: "Microsoft.DotNet.Arcade.Sdk"
+    - dependency-name: "Microsoft.DotNet.Helix.Sdk"
     - dependency-name: "Microsoft.IdentityModel.Protocols.OpenIdConnect"


### PR DESCRIPTION
Ignore these SDKs as otherwise dependabot generates a broken global.json file.
