### PR TITLE
Group updates to actions from actions org

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,10 @@ version: 2
 updates:
 - package-ecosystem: "github-actions"
   directory: "/"
+  groups:
+    actions:
+      patterns:
+        - actions/*
   schedule:
     interval: daily
     time: "06:30"


### PR DESCRIPTION
Group `actions/*` updates.

If you look through [the history](https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/commits/dev/), multiple actions updates in one day isn't that common.

This just groups any updates to actions from `actions` as I still believe it's best practice to not group unrelated dependencies together, as when something inevitably breaks in one of them you then have to manually unpick it all to take everything but the broken one.
