### PR TITLE
improves efficiency parsing Response

### DIFF
--- a/src/AspNet.Security.OAuth.AdobeIO/AdobeIOAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.AdobeIO/AdobeIOAuthenticationHandler.cs
@@ -42,7 +42,8 @@ public partial class AdobeIOAuthenticationHandler : OAuthHandler<AdobeIOAuthenti
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.Amazon/AmazonAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Amazon/AmazonAuthenticationHandler.cs
@@ -57,7 +57,8 @@ public partial class AmazonAuthenticationHandler : OAuthHandler<AmazonAuthentica
             throw new HttpRequestException("An error occurred while retrieving the user profile from Amazon.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.AmoCrm/AmoCrmAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.AmoCrm/AmoCrmAuthenticationHandler.cs
@@ -51,7 +51,8 @@ public partial class AmoCrmAuthenticationHandler : OAuthHandler<AmoCrmAuthentica
             throw new HttpRequestException("An error occurred while retrieving the user profile from amoCRM.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.ArcGIS/ArcGISAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.ArcGIS/ArcGISAuthenticationHandler.cs
@@ -43,7 +43,8 @@ public partial class ArcGISAuthenticationHandler : OAuthHandler<ArcGISAuthentica
 
         // Request the token
         using var response = await Backchannel.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, Context.RequestAborted);
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         // Note: error responses always return 200 status codes.
         if (payload.RootElement.TryGetProperty("error", out var error))

--- a/src/AspNet.Security.OAuth.Asana/AsanaAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Asana/AsanaAuthenticationHandler.cs
@@ -39,7 +39,8 @@ public partial class AsanaAuthenticationHandler : OAuthHandler<AsanaAuthenticati
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.Autodesk/AutodeskAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Autodesk/AutodeskAuthenticationHandler.cs
@@ -40,7 +40,8 @@ public partial class AutodeskAuthenticationHandler : OAuthHandler<AutodeskAuthen
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.Baidu/BaiduAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Baidu/BaiduAuthenticationHandler.cs
@@ -41,7 +41,8 @@ public partial class BaiduAuthenticationHandler : OAuthHandler<BaiduAuthenticati
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.Basecamp/BasecampAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Basecamp/BasecampAuthenticationHandler.cs
@@ -39,7 +39,8 @@ public partial class BasecampAuthenticationHandler : OAuthHandler<BasecampAuthen
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.BattleNet/BattleNetAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.BattleNet/BattleNetAuthenticationHandler.cs
@@ -41,7 +41,8 @@ public partial class BattleNetAuthenticationHandler : OAuthHandler<BattleNetAuth
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.Bitbucket/BitbucketAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Bitbucket/BitbucketAuthenticationHandler.cs
@@ -39,7 +39,8 @@ public partial class BitbucketAuthenticationHandler : OAuthHandler<BitbucketAuth
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
@@ -76,7 +77,8 @@ public partial class BitbucketAuthenticationHandler : OAuthHandler<BitbucketAuth
             throw new HttpRequestException("An error occurred while retrieving the email address associated to the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         return (from address in payload.RootElement.GetProperty("values").EnumerateArray()
                 where address.GetProperty("is_primary").GetBoolean()

--- a/src/AspNet.Security.OAuth.Buffer/BufferAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Buffer/BufferAuthenticationHandler.cs
@@ -39,7 +39,8 @@ public partial class BufferAuthenticationHandler : OAuthHandler<BufferAuthentica
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.CiscoSpark/CiscoSparkAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.CiscoSpark/CiscoSparkAuthenticationHandler.cs
@@ -39,7 +39,8 @@ public partial class CiscoSparkAuthenticationHandler : OAuthHandler<CiscoSparkAu
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.Coinbase/CoinbaseAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Coinbase/CoinbaseAuthenticationHandler.cs
@@ -39,7 +39,8 @@ public partial class CoinbaseAuthenticationHandler : OAuthHandler<CoinbaseAuthen
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement.GetProperty("data"));

--- a/src/AspNet.Security.OAuth.Deezer/DeezerAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Deezer/DeezerAuthenticationHandler.cs
@@ -55,7 +55,8 @@ public partial class DeezerAuthenticationHandler : OAuthHandler<DeezerAuthentica
             return OAuthTokenResponse.Failed(new Exception("An error occurred while retrieving an OAuth token."));
         }
 
-        var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
         return OAuthTokenResponse.Success(payload);
     }
 
@@ -76,7 +77,8 @@ public partial class DeezerAuthenticationHandler : OAuthHandler<DeezerAuthentica
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.DeviantArt/DeviantArtAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.DeviantArt/DeviantArtAuthenticationHandler.cs
@@ -39,7 +39,8 @@ public partial class DeviantArtAuthenticationHandler : OAuthHandler<DeviantArtAu
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.DigitalOcean/DigitalOceanAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.DigitalOcean/DigitalOceanAuthenticationHandler.cs
@@ -75,7 +75,8 @@ public partial class DigitalOceanAuthenticationHandler : OAuthHandler<DigitalOce
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var account = payload.RootElement.GetProperty("account");
 

--- a/src/AspNet.Security.OAuth.Discord/DiscordAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Discord/DiscordAuthenticationHandler.cs
@@ -55,7 +55,8 @@ public partial class DiscordAuthenticationHandler : OAuthHandler<DiscordAuthenti
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.Dropbox/DropboxAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Dropbox/DropboxAuthenticationHandler.cs
@@ -55,7 +55,8 @@ public partial class DropboxAuthenticationHandler : OAuthHandler<DropboxAuthenti
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.Ebay/EbayAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Ebay/EbayAuthenticationHandler.cs
@@ -37,7 +37,8 @@ public partial class EbayAuthenticationHandler : OAuthHandler<EbayAuthentication
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
@@ -82,7 +83,8 @@ public partial class EbayAuthenticationHandler : OAuthHandler<EbayAuthentication
             return OAuthTokenResponse.Failed(new Exception("An error occurred while retrieving an access token."));
         }
 
-        var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         return OAuthTokenResponse.Success(payload);
     }

--- a/src/AspNet.Security.OAuth.ExactOnline/ExactOnlineAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.ExactOnline/ExactOnlineAuthenticationHandler.cs
@@ -40,7 +40,8 @@ public partial class ExactOnlineAuthenticationHandler : OAuthHandler<ExactOnline
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
         var user = payload.RootElement
             .GetProperty("d")
             .GetProperty("results")

--- a/src/AspNet.Security.OAuth.Feishu/FeishuAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Feishu/FeishuAuthenticationHandler.cs
@@ -39,7 +39,8 @@ public partial class FeishuAuthenticationHandler : OAuthHandler<FeishuAuthentica
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.Fitbit/FitbitAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Fitbit/FitbitAuthenticationHandler.cs
@@ -40,7 +40,8 @@ public partial class FitbitAuthenticationHandler : OAuthHandler<FitbitAuthentica
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
@@ -79,7 +80,8 @@ public partial class FitbitAuthenticationHandler : OAuthHandler<FitbitAuthentica
             return OAuthTokenResponse.Failed(new Exception("An error occurred while retrieving an access token."));
         }
 
-        var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         return OAuthTokenResponse.Success(payload);
     }

--- a/src/AspNet.Security.OAuth.Foursquare/FoursquareAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Foursquare/FoursquareAuthenticationHandler.cs
@@ -48,7 +48,8 @@ public partial class FoursquareAuthenticationHandler : OAuthHandler<FoursquareAu
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.GitHub/GitHubAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.GitHub/GitHubAuthenticationHandler.cs
@@ -39,7 +39,8 @@ public partial class GitHubAuthenticationHandler : OAuthHandler<GitHubAuthentica
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
@@ -77,7 +78,8 @@ public partial class GitHubAuthenticationHandler : OAuthHandler<GitHubAuthentica
             throw new HttpRequestException("An error occurred while retrieving the email address associated to the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         return (from address in payload.RootElement.EnumerateArray()
                 where address.GetProperty("primary").GetBoolean()

--- a/src/AspNet.Security.OAuth.GitLab/GitLabAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.GitLab/GitLabAuthenticationHandler.cs
@@ -40,7 +40,8 @@ public partial class GitLabAuthenticationHandler : OAuthHandler<GitLabAuthentica
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.Gitee/GiteeAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Gitee/GiteeAuthenticationHandler.cs
@@ -40,7 +40,8 @@ public partial class GiteeAuthenticationHandler : OAuthHandler<GiteeAuthenticati
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
@@ -77,7 +78,8 @@ public partial class GiteeAuthenticationHandler : OAuthHandler<GiteeAuthenticati
             throw new HttpRequestException("An error occurred while retrieving the email address associated to the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         return (from address in payload.RootElement.EnumerateArray()
                 select address.GetString("email")).FirstOrDefault();

--- a/src/AspNet.Security.OAuth.Harvest/HarvestAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Harvest/HarvestAuthenticationHandler.cs
@@ -39,7 +39,8 @@ public partial class HarvestAuthenticationHandler : OAuthHandler<HarvestAuthenti
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.HealthGraph/HealthGraphAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.HealthGraph/HealthGraphAuthenticationHandler.cs
@@ -39,7 +39,8 @@ public partial class HealthGraphAuthenticationHandler : OAuthHandler<HealthGraph
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.Huawei/HuaweiAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Huawei/HuaweiAuthenticationHandler.cs
@@ -46,7 +46,8 @@ public partial class HuaweiAuthenticationHandler : OAuthHandler<HuaweiAuthentica
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.HubSpot/HubSpotAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.HubSpot/HubSpotAuthenticationHandler.cs
@@ -57,7 +57,7 @@ public partial class HubSpotAuthenticationHandler : OAuthHandler<HubSpotAuthenti
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        return JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        return await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync(Context.RequestAborted), cancellationToken: Context.RequestAborted);
     }
 
     private static partial class Log

--- a/src/AspNet.Security.OAuth.Imgur/ImgurAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Imgur/ImgurAuthenticationHandler.cs
@@ -39,7 +39,8 @@ public partial class ImgurAuthenticationHandler : OAuthHandler<ImgurAuthenticati
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.Instagram/InstagramAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Instagram/InstagramAuthenticationHandler.cs
@@ -46,7 +46,8 @@ public partial class InstagramAuthenticationHandler : OAuthHandler<InstagramAuth
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.JumpCloud/JumpCloudAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.JumpCloud/JumpCloudAuthenticationHandler.cs
@@ -51,7 +51,8 @@ public partial class JumpCloudAuthenticationHandler : OAuthHandler<JumpCloudAuth
             throw new HttpRequestException("An error occurred while retrieving the user profile from JumpCloud.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.KakaoTalk/KakaoTalkAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.KakaoTalk/KakaoTalkAuthenticationHandler.cs
@@ -51,7 +51,7 @@ public partial class KakaoTalkAuthenticationHandler : OAuthHandler<KakaoTalkAuth
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        return JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        return await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync(Context.RequestAborted), cancellationToken: Context.RequestAborted);
     }
 
     private static partial class Log

--- a/src/AspNet.Security.OAuth.Keycloak/KeycloakAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Keycloak/KeycloakAuthenticationHandler.cs
@@ -52,7 +52,8 @@ public partial class KeycloakAuthenticationHandler : OAuthHandler<KeycloakAuthen
             throw new HttpRequestException("An error occurred while retrieving the user profile from Keycloak.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
         context.RunClaimActions();

--- a/src/AspNet.Security.OAuth.Kook/KookAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Kook/KookAuthenticationHandler.cs
@@ -39,7 +39,8 @@ public partial class KookAuthenticationHandler : OAuthHandler<KookAuthentication
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var code = payload.RootElement.GetProperty("code").GetInt32();
 

--- a/src/AspNet.Security.OAuth.Kroger/KrogerAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Kroger/KrogerAuthenticationHandler.cs
@@ -49,7 +49,8 @@ public partial class KrogerAuthenticationHandler : OAuthHandler<KrogerAuthentica
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.Lichess/LichessAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Lichess/LichessAuthenticationHandler.cs
@@ -79,7 +79,8 @@ public partial class LichessAuthenticationHandler : OAuthHandler<LichessAuthenti
             throw new HttpRequestException($"An error occurred while retrieving the {requestInformationType}.");
         }
 
-        return JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        return await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
     }
 
     private static partial class Log

--- a/src/AspNet.Security.OAuth.LinkedIn/LinkedInAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.LinkedIn/LinkedInAuthenticationHandler.cs
@@ -52,7 +52,8 @@ public partial class LinkedInAuthenticationHandler : OAuthHandler<LinkedInAuthen
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
@@ -85,7 +86,8 @@ public partial class LinkedInAuthenticationHandler : OAuthHandler<LinkedInAuthen
             throw new HttpRequestException("An error occurred while retrieving the email address.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         if (!payload.RootElement.TryGetProperty("elements", out var emails))
         {

--- a/src/AspNet.Security.OAuth.MailChimp/MailChimpAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.MailChimp/MailChimpAuthenticationHandler.cs
@@ -39,7 +39,8 @@ public partial class MailChimpAuthenticationHandler : OAuthHandler<MailChimpAuth
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.MailRu/MailRuAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.MailRu/MailRuAuthenticationHandler.cs
@@ -41,7 +41,8 @@ public partial class MailRuAuthenticationHandler : OAuthHandler<MailRuAuthentica
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.Mixcloud/MixcloudAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Mixcloud/MixcloudAuthenticationHandler.cs
@@ -91,7 +91,8 @@ public partial class MixcloudAuthenticationHandler : OAuthHandler<MixcloudAuthen
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.Moodle/MoodleAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Moodle/MoodleAuthenticationHandler.cs
@@ -39,7 +39,8 @@ public partial class MoodleAuthenticationHandler : OAuthHandler<MoodleAuthentica
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.Naver/NaverAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Naver/NaverAuthenticationHandler.cs
@@ -51,7 +51,7 @@ public partial class NaverAuthenticationHandler : OAuthHandler<NaverAuthenticati
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        return JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        return await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync(Context.RequestAborted), cancellationToken: Context.RequestAborted);
     }
 
     private static partial class Log

--- a/src/AspNet.Security.OAuth.NetEase/NetEaseAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.NetEase/NetEaseAuthenticationHandler.cs
@@ -39,7 +39,8 @@ public partial class NetEaseAuthenticationHandler : OAuthHandler<NetEaseAuthenti
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.Nextcloud/NextcloudAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Nextcloud/NextcloudAuthenticationHandler.cs
@@ -43,7 +43,8 @@ public partial class NextcloudAuthenticationHandler : OAuthHandler<NextcloudAuth
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.Notion/NotionAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Notion/NotionAuthenticationHandler.cs
@@ -52,7 +52,7 @@ public class NotionAuthenticationHandler(
         using var response = await Backchannel.SendAsync(requestMessage, Context.RequestAborted);
         if (response.IsSuccessStatusCode)
         {
-            var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+            var payload = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync(Context.RequestAborted), cancellationToken: Context.RequestAborted);
             return OAuthTokenResponse.Success(payload);
         }
 

--- a/src/AspNet.Security.OAuth.Odnoklassniki/OdnoklassnikiAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Odnoklassniki/OdnoklassnikiAuthenticationHandler.cs
@@ -55,7 +55,8 @@ public partial class OdnoklassnikiAuthenticationHandler : OAuthHandler<Odnoklass
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.Okta/OktaAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Okta/OktaAuthenticationHandler.cs
@@ -51,7 +51,8 @@ public partial class OktaAuthenticationHandler : OAuthHandler<OktaAuthentication
             throw new HttpRequestException("An error occurred while retrieving the user profile from Okta.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.Onshape/OnshapeAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Onshape/OnshapeAuthenticationHandler.cs
@@ -39,7 +39,8 @@ public partial class OnshapeAuthenticationHandler : OAuthHandler<OnshapeAuthenti
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.Patreon/PatreonAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Patreon/PatreonAuthenticationHandler.cs
@@ -52,7 +52,8 @@ public partial class PatreonAuthenticationHandler : OAuthHandler<PatreonAuthenti
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.Paypal/PaypalAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Paypal/PaypalAuthenticationHandler.cs
@@ -39,7 +39,8 @@ public partial class PaypalAuthenticationHandler : OAuthHandler<PaypalAuthentica
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.PingOne/PingOneAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.PingOne/PingOneAuthenticationHandler.cs
@@ -51,7 +51,8 @@ public partial class PingOneAuthenticationHandler : OAuthHandler<PingOneAuthenti
             throw new HttpRequestException("An error occurred while retrieving the user profile from PingOne.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.QuickBooks/QuickBooksAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.QuickBooks/QuickBooksAuthenticationHandler.cs
@@ -42,7 +42,8 @@ public partial class QuickBooksAuthenticationHandler : OAuthHandler<QuickBooksAu
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.Reddit/RedditAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Reddit/RedditAuthenticationHandler.cs
@@ -48,7 +48,8 @@ public partial class RedditAuthenticationHandler : OAuthHandler<RedditAuthentica
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
@@ -112,7 +113,7 @@ public partial class RedditAuthenticationHandler : OAuthHandler<RedditAuthentica
             return OAuthTokenResponse.Failed(new Exception("An error occurred while retrieving an access token."));
         }
 
-        var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        var payload = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync(Context.RequestAborted), cancellationToken: Context.RequestAborted);
 
         return OAuthTokenResponse.Success(payload);
     }

--- a/src/AspNet.Security.OAuth.Salesforce/SalesforceAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Salesforce/SalesforceAuthenticationHandler.cs
@@ -42,7 +42,8 @@ public partial class SalesforceAuthenticationHandler : OAuthHandler<SalesforceAu
             throw new HttpRequestException("An error occurred while retrieving the user from the Salesforce identity service.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.ServiceChannel/ServiceChannelAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.ServiceChannel/ServiceChannelAuthenticationHandler.cs
@@ -39,7 +39,8 @@ public partial class ServiceChannelAuthenticationHandler : OAuthHandler<ServiceC
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.Shopify/ShopifyAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Shopify/ShopifyAuthenticationHandler.cs
@@ -52,7 +52,8 @@ public partial class ShopifyAuthenticationHandler : OAuthHandler<ShopifyAuthenti
             throw new HttpRequestException("An error occurred while retrieving the shop profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         // In Shopify, the customer can modify the scope given to the app. Apps should verify
         // that the customer is allowing the required scope.
@@ -209,7 +210,7 @@ public partial class ShopifyAuthenticationHandler : OAuthHandler<ShopifyAuthenti
             return OAuthTokenResponse.Failed(new Exception("An error occurred while retrieving an access token."));
         }
 
-        var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        var payload = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync(Context.RequestAborted), cancellationToken: Context.RequestAborted);
         return OAuthTokenResponse.Success(payload);
     }
 

--- a/src/AspNet.Security.OAuth.Slack/SlackAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Slack/SlackAuthenticationHandler.cs
@@ -41,7 +41,8 @@ public partial class SlackAuthenticationHandler : OAuthHandler<SlackAuthenticati
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.Smartsheet/SmartsheetAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Smartsheet/SmartsheetAuthenticationHandler.cs
@@ -42,7 +42,8 @@ public partial class SmartsheetAuthenticationHandler : OAuthHandler<SmartsheetAu
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
@@ -85,7 +86,7 @@ public partial class SmartsheetAuthenticationHandler : OAuthHandler<SmartsheetAu
             return OAuthTokenResponse.Failed(new Exception("An error occurred while retrieving an access token."));
         }
 
-        var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        var payload = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync(Context.RequestAborted), cancellationToken: Context.RequestAborted);
 
         return OAuthTokenResponse.Success(payload);
     }

--- a/src/AspNet.Security.OAuth.Snapchat/SnapchatAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Snapchat/SnapchatAuthenticationHandler.cs
@@ -41,7 +41,8 @@ public partial class SnapchatAuthenticationHandler : OAuthHandler<SnapchatAuthen
             throw new HttpRequestException("An error occurred while retrieving the user profile from Snapchat.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.SoundCloud/SoundCloudAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.SoundCloud/SoundCloudAuthenticationHandler.cs
@@ -41,7 +41,8 @@ public partial class SoundCloudAuthenticationHandler : OAuthHandler<SoundCloudAu
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.Spotify/SpotifyAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Spotify/SpotifyAuthenticationHandler.cs
@@ -39,7 +39,8 @@ public partial class SpotifyAuthenticationHandler : OAuthHandler<SpotifyAuthenti
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.StackExchange/StackExchangeAuthenticationHandler.cs
@@ -48,7 +48,8 @@ public partial class StackExchangeAuthenticationHandler : OAuthHandler<StackExch
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.Strava/StravaAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Strava/StravaAuthenticationHandler.cs
@@ -42,7 +42,8 @@ public partial class StravaAuthenticationHandler : OAuthHandler<StravaAuthentica
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.Streamlabs/StreamlabsAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Streamlabs/StreamlabsAuthenticationHandler.cs
@@ -39,7 +39,8 @@ public partial class StreamlabsAuthenticationHandler : OAuthHandler<StreamlabsAu
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.SuperOffice/SuperOfficeAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.SuperOffice/SuperOfficeAuthenticationHandler.cs
@@ -66,7 +66,8 @@ public partial class SuperOfficeAuthenticationHandler : OAuthHandler<SuperOffice
             throw new HttpRequestException($"An error occurred when retrieving SuperOffice user information ({response.StatusCode}).");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
 

--- a/src/AspNet.Security.OAuth.Trakt/TraktAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Trakt/TraktAuthenticationHandler.cs
@@ -42,7 +42,8 @@ public partial class TraktAuthenticationHandler : OAuthHandler<TraktAuthenticati
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.Trovo/TrovoAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Trovo/TrovoAuthenticationHandler.cs
@@ -46,7 +46,7 @@ public partial class TrovoAuthenticationHandler : OAuthHandler<TrovoAuthenticati
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        var payload = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync(Context.RequestAborted), cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
@@ -89,7 +89,7 @@ public partial class TrovoAuthenticationHandler : OAuthHandler<TrovoAuthenticati
             return OAuthTokenResponse.Failed(new Exception("An error occurred while retrieving an access token."));
         }
 
-        var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        var payload = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync(Context.RequestAborted), cancellationToken: Context.RequestAborted);
 
         return OAuthTokenResponse.Success(payload);
     }

--- a/src/AspNet.Security.OAuth.Twitch/TwitchAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Twitch/TwitchAuthenticationHandler.cs
@@ -47,7 +47,8 @@ public partial class TwitchAuthenticationHandler : OAuthHandler<TwitchAuthentica
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.Twitter/TwitterAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Twitter/TwitterAuthenticationHandler.cs
@@ -58,7 +58,8 @@ public partial class TwitterAuthenticationHandler : OAuthHandler<TwitterAuthenti
             throw new HttpRequestException("An error occurred while retrieving the user profile from Twitter.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.Untappd/UntappdAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Untappd/UntappdAuthenticationHandler.cs
@@ -62,7 +62,7 @@ public partial class UntappdAuthenticationHandler : OAuthHandler<UntappdAuthenti
         using var response = await Backchannel.SendAsync(requestMessage, Context.RequestAborted);
         if (response.IsSuccessStatusCode)
         {
-            var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+            var payload = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync(Context.RequestAborted), cancellationToken: Context.RequestAborted);
             return OAuthTokenResponse.Success(payload);
         }
         else
@@ -88,7 +88,8 @@ public partial class UntappdAuthenticationHandler : OAuthHandler<UntappdAuthenti
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.Vimeo/VimeoAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Vimeo/VimeoAuthenticationHandler.cs
@@ -39,7 +39,8 @@ public partial class VimeoAuthenticationHandler : OAuthHandler<VimeoAuthenticati
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.VisualStudio/VisualStudioAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.VisualStudio/VisualStudioAuthenticationHandler.cs
@@ -42,7 +42,8 @@ public partial class VisualStudioAuthenticationHandler : OAuthHandler<VisualStud
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
@@ -82,7 +83,8 @@ public partial class VisualStudioAuthenticationHandler : OAuthHandler<VisualStud
             return OAuthTokenResponse.Failed(new Exception("An error occurred while retrieving an access token."));
         }
 
-        var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         return OAuthTokenResponse.Success(payload);
     }

--- a/src/AspNet.Security.OAuth.Vkontakte/VkontakteAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Vkontakte/VkontakteAuthenticationHandler.cs
@@ -48,7 +48,7 @@ public partial class VkontakteAuthenticationHandler : OAuthHandler<VkontakteAuth
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var container = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var container = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync(Context.RequestAborted), cancellationToken: Context.RequestAborted);
         using var enumerator = container.RootElement.GetProperty("response").EnumerateArray();
         var payload = enumerator.First();
 

--- a/src/AspNet.Security.OAuth.Weibo/WeiboAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Weibo/WeiboAuthenticationHandler.cs
@@ -48,7 +48,8 @@ public partial class WeiboAuthenticationHandler : OAuthHandler<WeiboAuthenticati
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         // When the email address is not public, retrieve it from
         // the emails endpoint if the user:email scope is specified.
@@ -91,7 +92,8 @@ public partial class WeiboAuthenticationHandler : OAuthHandler<WeiboAuthenticati
             throw new HttpRequestException("An error occurred while retrieving the email address associated to the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         return (from email in payload.RootElement.EnumerateArray()
                 select email.GetString("email")).FirstOrDefault();

--- a/src/AspNet.Security.OAuth.WordPress/WordPressAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.WordPress/WordPressAuthenticationHandler.cs
@@ -39,7 +39,8 @@ public partial class WordPressAuthenticationHandler : OAuthHandler<WordPressAuth
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.WorkWeixin/WorkWeixinAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.WorkWeixin/WorkWeixinAuthenticationHandler.cs
@@ -54,7 +54,8 @@ public partial class WorkWeixinAuthenticationHandler : OAuthHandler<WorkWeixinAu
             throw new HttpRequestException("An error occurred while retrieving user information.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         errorCode = payload.RootElement.GetProperty("errcode").GetInt32();
         if (errorCode != 0)
@@ -96,7 +97,7 @@ public partial class WorkWeixinAuthenticationHandler : OAuthHandler<WorkWeixinAu
             return OAuthTokenResponse.Failed(new Exception("An error occurred while retrieving an access token."));
         }
 
-        var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        var payload = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync(Context.RequestAborted), cancellationToken: Context.RequestAborted);
 
         return OAuthTokenResponse.Success(payload);
     }
@@ -148,7 +149,8 @@ public partial class WorkWeixinAuthenticationHandler : OAuthHandler<WorkWeixinAu
             throw new HttpRequestException("An error occurred while retrieving the user identifier.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var errorCode =
             payload.RootElement.TryGetProperty("errcode", out var errCodeElement) && errCodeElement.ValueKind == JsonValueKind.Number ?

--- a/src/AspNet.Security.OAuth.Xero/XeroAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Xero/XeroAuthenticationHandler.cs
@@ -74,7 +74,7 @@ public partial class XeroAuthenticationHandler : OAuthHandler<XeroAuthentication
             return OAuthTokenResponse.Failed(new Exception("An error occurred while retrieving an access token."));
         }
 
-        var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        var payload = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync(Context.RequestAborted), cancellationToken: Context.RequestAborted);
 
         return OAuthTokenResponse.Success(payload);
     }

--- a/src/AspNet.Security.OAuth.Xumm/XummAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Xumm/XummAuthenticationHandler.cs
@@ -39,7 +39,8 @@ public partial class XummAuthenticationHandler : OAuthHandler<XummAuthentication
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);

--- a/src/AspNet.Security.OAuth.Yahoo/YahooAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Yahoo/YahooAuthenticationHandler.cs
@@ -41,7 +41,8 @@ public partial class YahooAuthenticationHandler : OAuthHandler<YahooAuthenticati
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
@@ -79,7 +80,7 @@ public partial class YahooAuthenticationHandler : OAuthHandler<YahooAuthenticati
             return OAuthTokenResponse.Failed(new Exception("An error occurred while retrieving an access token."));
         }
 
-        var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        var payload = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync(Context.RequestAborted), cancellationToken: Context.RequestAborted);
 
         return OAuthTokenResponse.Success(payload);
     }

--- a/src/AspNet.Security.OAuth.Yammer/YammerAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Yammer/YammerAuthenticationHandler.cs
@@ -40,7 +40,8 @@ public partial class YammerAuthenticationHandler : OAuthHandler<YammerAuthentica
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
@@ -83,7 +84,8 @@ public partial class YammerAuthenticationHandler : OAuthHandler<YammerAuthentica
         // Note: Yammer doesn't return a standard OAuth2 response. To make this middleware compatible
         // with the OAuth2 generic middleware, a compliant JSON payload is generated manually.
         // See https://developer.yammer.com/docs/oauth-2 for more information about this process.
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
         var accessToken = payload.RootElement.GetProperty("access_token").GetString("token");
 
         var token = new OAuthToken()

--- a/src/AspNet.Security.OAuth.Yandex/YandexAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Yandex/YandexAuthenticationHandler.cs
@@ -41,7 +41,8 @@ public partial class YandexAuthenticationHandler : OAuthHandler<YandexAuthentica
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
@@ -80,7 +81,7 @@ public partial class YandexAuthenticationHandler : OAuthHandler<YandexAuthentica
             return OAuthTokenResponse.Failed(new Exception("An error occurred while retrieving an access token."));
         }
 
-        var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        var payload = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync(Context.RequestAborted), cancellationToken: Context.RequestAborted);
 
         return OAuthTokenResponse.Success(payload);
     }

--- a/src/AspNet.Security.OAuth.Zalo/ZaloAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Zalo/ZaloAuthenticationHandler.cs
@@ -47,7 +47,8 @@ public partial class ZaloAuthenticationHandler : OAuthHandler<ZaloAuthentication
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
@@ -90,7 +91,7 @@ public partial class ZaloAuthenticationHandler : OAuthHandler<ZaloAuthentication
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        var payload = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync(Context.RequestAborted), cancellationToken: Context.RequestAborted);
 
         return OAuthTokenResponse.Success(payload);
     }

--- a/src/AspNet.Security.OAuth.Zendesk/ZendeskAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Zendesk/ZendeskAuthenticationHandler.cs
@@ -39,7 +39,8 @@ public partial class ZendeskAuthenticationHandler : OAuthHandler<ZendeskAuthenti
             throw new HttpRequestException("An error occurred while retrieving the user profile.");
         }
 
-        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+        using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
+        using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
 
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement.GetProperty("user"));


### PR DESCRIPTION
# Suggestion: Refactor to Use JsonDocument.ParseAsync for Improved Efficiency

## Description

This Pull Request refactors instances of `JsonDocument.Parse` to `JsonDocument.ParseAsync` across the project. The new implementation uses `await response.Content.ReadAsStreamAsync(Context.RequestAborted)` and `JsonDocument.ParseAsync` to parse JSON content. This change improves performance and memory efficiency by leveraging asynchronous stream reading and parsing.

## Reason for Change

### Current Implementation

The current implementation reads the entire JSON content as a string before parsing it:

```csharp
using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
```
## Proposed Implementation

The proposed implementation reads the JSON content as a stream and parses it asynchronously:

```csharp 
using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
```
## Benefits
    Performance: Asynchronous operations allow for better use of resources and improve the responsiveness of the application.
    Memory Efficiency: Reading the content as a stream avoids the overhead of creating an intermediate string representation of the entire response content, reducing memory usage.

## Impact
Impact

This refactor is applied across the project, ensuring that all instances where JsonDocument.Parse was used are updated to JsonDocument.ParseAsync. The change should be backward compatible and only improves the performance and efficiency of the existing code.
## Example:
before
```csharp
using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
```
after:
```csharp
using var stream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
using var payload = await JsonDocument.ParseAsync(stream, cancellationToken: Context.RequestAborted);
```
