### PR TITLE
Only attest tag builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,10 +153,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event.repository.fork == false &&
-      (github.ref_name == github.event.repository.default_branch ||
-       startsWith(github.ref, 'refs/heads/dev') ||
-       startsWith(github.ref, 'refs/heads/rel/') ||
-       startsWith(github.ref, 'refs/tags/'))
+      startsWith(github.ref, 'refs/tags/')
     steps:
 
     - name: Download packages


### PR DESCRIPTION
Only attest the artifacts for a release from a tag for publishing to NuGet.org, otherwise due to the number of artifacts we produce the build takes ~10 minutes extra to complete.
