### PR TITLE
Avoid KeyNotFoundException

### DIFF
--- a/src/AspNet.Security.OAuth.Slack/SlackAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Slack/SlackAuthenticationOptions.cs
@@ -25,13 +25,28 @@ public class SlackAuthenticationOptions : OAuthOptions
         TokenEndpoint = SlackAuthenticationDefaults.TokenEndpoint;
         UserInformationEndpoint = SlackAuthenticationDefaults.UserInformationEndpoint;
 
-        ClaimActions.MapCustomJson(ClaimTypes.NameIdentifier, user =>
-            string.Concat(user.GetProperty("team").GetString("id"), "|", user.GetProperty("user").GetString("id")));
         ClaimActions.MapJsonSubKey(ClaimTypes.Name, "user", "name");
         ClaimActions.MapJsonSubKey(ClaimTypes.Email, "user", "email");
         ClaimActions.MapJsonSubKey(Claims.UserId, "user", "id");
         ClaimActions.MapJsonSubKey(Claims.TeamId, "team", "id");
         ClaimActions.MapJsonSubKey(Claims.TeamName, "team", "name");
+        ClaimActions.MapCustomJson(ClaimTypes.NameIdentifier, (element) =>
+        {
+            string? teamId = null;
+            string? userId = null;
+
+            if (element.TryGetProperty("team", out var team))
+            {
+                teamId = team.GetString("id");
+            }
+
+            if (element.TryGetProperty("user", out var user))
+            {
+                userId = user.GetString("id");
+            }
+
+            return $"{teamId}|{userId}";
+        });
 
         Scope.Add("identity.basic");
     }

--- a/src/AspNet.Security.OAuth.Vkontakte/VkontakteAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Vkontakte/VkontakteAuthenticationHandler.cs
@@ -49,7 +49,19 @@ public partial class VkontakteAuthenticationHandler : OAuthHandler<VkontakteAuth
         }
 
         using var container = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
-        using var enumerator = container.RootElement.GetProperty("response").EnumerateArray();
+
+        if (!container.RootElement.TryGetProperty("response", out var profileResponse))
+        {
+            if (container.RootElement.TryGetProperty("error", out var error) &&
+                error.ValueKind is JsonValueKind.String)
+            {
+                throw new InvalidOperationException($"An error occurred while retrieving the user profile: {error.GetString()}");
+            }
+
+            throw new InvalidOperationException("An error occurred while retrieving the user profile.");
+        }
+
+        using var enumerator = profileResponse.EnumerateArray();
         var payload = enumerator.First();
 
         var principal = new ClaimsPrincipal(identity);

--- a/src/AspNet.Security.OAuth.Zoho/ZohoAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Zoho/ZohoAuthenticationHandler.cs
@@ -53,7 +53,7 @@ public partial class ZohoAuthenticationHandler : OAuthHandler<ZohoAuthentication
         return new AuthenticationTicket(context.Principal!, context.Properties, Scheme.Name);
     }
 
-    protected override async Task<OAuthTokenResponse> ExchangeCodeAsync(OAuthCodeExchangeContext context)
+    protected override async Task<OAuthTokenResponse> ExchangeCodeAsync([NotNull] OAuthCodeExchangeContext context)
     {
         var nameValueCollection = new Dictionary<string, string?>
         {


### PR DESCRIPTION
- Avoid `KeyNotFoundException` for Slack and VKontakte providers.
- Add missing attribute from #910.

Resolves #768 and #769.
