### PR TITLE
Add support for Alipay certificate signing and openid.

### DIFF
--- a/src/AspNet.Security.OAuth.Alipay/AlipayAuthenticationConstants.cs
+++ b/src/AspNet.Security.OAuth.Alipay/AlipayAuthenticationConstants.cs
@@ -25,5 +25,16 @@ public static class AlipayAuthenticationConstants
         /// The user's gender. F: Female; M: Male.
         /// </summary>
         public const string Gender = "urn:alipay:gender";
+
+        /// <summary>
+        /// OpenID is the unique identifier of Alipay users in the application dimension.
+        /// See https://opendocs.alipay.com/mini/0ai2i6
+        /// </summary>
+        public const string OpenId = "urn:alipay:open_id";
+
+        /// <summary>
+        /// Alipay user system internal identifier, will no longer be independently open in the future, and will be replaced by OpenID.
+        /// </summary>
+        public const string UserId = "urn:alipay:user_id";
     }
 }

--- a/src/AspNet.Security.OAuth.Alipay/AlipayAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Alipay/AlipayAuthenticationHandler.cs
@@ -134,8 +134,6 @@ public partial class AlipayAuthenticationHandler : OAuthHandler<AlipayAuthentica
             throw new AuthenticationFailureException($"An error (Code:{code}) occurred while retrieving user information.");
         }
 
-        identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, mainElement.GetString("user_id")!, ClaimValueTypes.String, Options.ClaimsIssuer));
-
         var principal = new ClaimsPrincipal(identity);
         var context = new OAuthCreatingTicketContext(principal, properties, Context, Scheme, Options, Backchannel, tokens, mainElement);
 

--- a/src/AspNet.Security.OAuth.Alipay/AlipayAuthenticationHandler.cs
+++ b/src/AspNet.Security.OAuth.Alipay/AlipayAuthenticationHandler.cs
@@ -59,6 +59,12 @@ public partial class AlipayAuthenticationHandler : OAuthHandler<AlipayAuthentica
             ["timestamp"] = TimeProvider.GetUtcNow().ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture),
             ["version"] = "1.0",
         };
+        if (Options.EnableCertSignature)
+        {
+            tokenRequestParameters["app_cert_sn"] = Options.AppCertSN;
+            tokenRequestParameters["alipay_root_cert_sn"] = Options.RootCertSN;
+        }
+
         tokenRequestParameters.Add("sign", GetRSA2Signature(tokenRequestParameters));
 
         // PKCE https://tools.ietf.org/html/rfc7636#section-4.5, see BuildChallengeUrl
@@ -107,6 +113,12 @@ public partial class AlipayAuthenticationHandler : OAuthHandler<AlipayAuthentica
             ["timestamp"] = TimeProvider.GetUtcNow().ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture),
             ["version"] = "1.0",
         };
+        if (Options.EnableCertSignature)
+        {
+            parameters["app_cert_sn"] = Options.AppCertSN;
+            parameters["alipay_root_cert_sn"] = Options.RootCertSN;
+        }
+
         parameters.Add("sign", GetRSA2Signature(parameters));
 
         var address = QueryHelpers.AddQueryString(Options.UserInformationEndpoint, parameters);

--- a/src/AspNet.Security.OAuth.Alipay/AlipayAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Alipay/AlipayAuthenticationOptions.cs
@@ -29,5 +29,14 @@ public class AlipayAuthenticationOptions : OAuthOptions
         ClaimActions.MapJsonKey(Claims.Gender, "gender");
         ClaimActions.MapJsonKey(Claims.Nickname, "nick_name");
         ClaimActions.MapJsonKey(Claims.Province, "province");
+        ClaimActions.MapJsonKey(Claims.OpenId, "open_id");
+        ClaimActions.MapJsonKey(Claims.UserId, "user_id");
+        ClaimActions.MapCustomJson(System.Security.Claims.ClaimTypes.NameIdentifier, user => user.GetString(NameIdentifierKey));
     }
+
+    /// <summary>
+    /// Alipay user system internal identifier, which will no longer be open independently in the future and will be replaced by open_id. Currently the default is user_id
+    /// See https://opendocs.alipay.com/mini/0ai2i6?pathHash=13dd5946
+    /// </summary>
+    public string NameIdentifierKey { get; set; } = "user_id";
 }

--- a/src/AspNet.Security.OAuth.Alipay/AlipayAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Alipay/AlipayAuthenticationOptions.cs
@@ -34,9 +34,41 @@ public class AlipayAuthenticationOptions : OAuthOptions
         ClaimActions.MapCustomJson(System.Security.Claims.ClaimTypes.NameIdentifier, user => user.GetString(NameIdentifierKey));
     }
 
+    public override void Validate()
+    {
+        base.Validate();
+
+        if (!string.IsNullOrEmpty(AppCertSN) && !string.IsNullOrEmpty(RootCertSN))
+        {
+            EnableCertSignature = true;
+        }
+        else if (!string.IsNullOrEmpty(AppCertPath) && !string.IsNullOrEmpty(RootCertPath))
+        {
+            try
+            {
+                AppCertSN = AlipayCertificationUtils.GetCertSN(AppCertPath);
+                RootCertSN = AlipayCertificationUtils.GetRootCertSN(RootCertPath);
+                EnableCertSignature = true;
+            }
+            catch (Exception ex)
+            {
+                throw new ArgumentException($"The '{nameof(AppCertPath)}' and '{nameof(RootCertPath)}' options must be set to the correct certificate files.", ex);
+            }
+        }
+    }
+
     /// <summary>
-    /// Alipay user system internal identifier, which will no longer be open independently in the future and will be replaced by open_id. Currently the default is user_id
     /// See https://opendocs.alipay.com/mini/0ai2i6?pathHash=13dd5946
     /// </summary>
     public string NameIdentifierKey { get; set; } = "user_id";
+
+    public string? AppCertPath { get; set; }
+
+    public string? RootCertPath { get; set; }
+
+    public bool EnableCertSignature { get; set; }
+
+    public string AppCertSN { get; set; } = string.Empty;
+
+    public string RootCertSN { get; set; } = string.Empty;
 }

--- a/src/AspNet.Security.OAuth.Alipay/AlipayCertificationUtils.cs
+++ b/src/AspNet.Security.OAuth.Alipay/AlipayCertificationUtils.cs
@@ -1,0 +1,55 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using System.Numerics;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+
+namespace AspNet.Security.OAuth.Alipay;
+
+/// <summary>
+/// This class of code refers to the Alipay official SDK code.
+/// See https://github.com/alipay/alipay-sdk-net-all/blob/1b7b73909954b107bddb6476dec68aafcc3f16e9/v2/AlipaySDKNet.Standard/Util/AntCertificationUtil.cs
+/// See https://opendocs.alipay.com/common/056zub?pathHash=91c49771
+/// </summary>
+internal static class AlipayCertificationUtils
+{
+    internal static string GetCertSN([NotNull] string certFilePath)
+    {
+        using var cert = X509Certificate.CreateFromCertFile(certFilePath);
+        return GetCertSN(cert);
+    }
+
+    internal static string GetCertSN([NotNull] X509Certificate cert)
+    {
+        var issuerDN = cert.Issuer.Replace(", ", ",", StringComparison.InvariantCulture);
+        var input = issuerDN + new BigInteger(cert.GetSerialNumber());
+#pragma warning disable CA5351 // Do Not Use Broken Cryptographic Algorithms
+        var certSN = Convert.ToHexString(MD5.HashData(Encoding.UTF8.GetBytes(input))).ToLowerInvariant();
+#pragma warning restore CA5351 // Do Not Use Broken Cryptographic Algorithms
+        return certSN;
+    }
+
+    internal static string GetRootCertSN([NotNull] string rootCertPath, [NotNull] string signType = "RSA2")
+    {
+        var certSNs = new List<string>();
+        var certCollection = new X509Certificate2Collection();
+        certCollection.ImportFromPemFile(rootCertPath);
+
+        foreach (var cert in certCollection)
+        {
+            if ((signType.StartsWith("RSA", StringComparison.Ordinal) && cert.SignatureAlgorithm.Value?.StartsWith("1.2.840.113549.1.1", StringComparison.Ordinal) == true) ||
+                (signType.Equals("SM2", StringComparison.Ordinal) && cert.SignatureAlgorithm.Value?.StartsWith("1.2.156.10197.1.501", StringComparison.Ordinal) == true))
+            {
+                certSNs.Add(GetCertSN(cert));
+            }
+        }
+
+        var rootCertSN = string.Join('_', certSNs);
+        return rootCertSN;
+    }
+}


### PR DESCRIPTION
I need to call Alipay's "fund expenditure interface", and I have to change the key signature method to the certificate signature method, which will make the current Alipay Provider unavailable, so I refer to the [Alipay official SDK code](https://github.com/alipay/alipay-sdk-net-all/blob/1b7b73909954b107bddb6476dec68aafcc3f16e9/v2/AlipaySDKNet.Standard/Util/AntCertificationUtil.cs#L71), add some code, just add two certificate-related fields in the request content:
- app_cert_sn
- alipay_root_cert_sn

When options _AppCertPath_  and _RootCertPath_  are configured with the certificate file path, the certificate signing mode will be enabled

Alipay's certificate signature document:
- https://opendocs.alipay.com/common/057k53?pathHash=7b14a0af#%E8%AF%81%E4%B9%A6%E6%96%B9%E5%BC%8F

----

Alipay now only provides open_id to new merchants, without user_id. In this case, the following code will cause an error.

https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/blob/1aaadb1fe28f3b9b3bc8e0405bf6746e900e4350/src/AspNet.Security.OAuth.Alipay/AlipayAuthenticationHandler.cs#L137

Alipay's openid document:
- https://opendocs.alipay.com/mini/0ai2i6

_Alipay documents are in Chinese, so they need to be translated._

----

Screenshot of network packet capture:
![TokenEndpoint](https://github.com/user-attachments/assets/dc856565-0b87-430e-8f68-dc00130b59dd)
Calling TokenEndpoint

![UserInformationEndpoint](https://github.com/user-attachments/assets/d2e88965-d9d8-4986-9649-9fcb908532bc)
Calling UserInformationEndpoint