### PR TITLE
Revert "Bump actions/attest-build-provenance from 1.4.4 to 2.0.0 in the actions group"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
       run: ./eng/common/cibuild.sh -configuration Release -prepareMachine
 
     - name: Attest artifacts
-      uses: actions/attest-build-provenance@619dbb2e03e0189af0c55118e7d3c5e129e99726 # v2.0.0
+      uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v1.4.4
       if: |
         runner.os == 'Windows' &&
         github.event.repository.fork == false &&


### PR DESCRIPTION
Reverts aspnet-contrib/AspNet.Security.OAuth.Providers#981 as the build is failing.