### PR TITLE
Update bundle data in KOOK provider test

### DIFF
--- a/test/AspNet.Security.OAuth.Providers.Tests/Kook/KookTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Kook/KookTests.cs
@@ -23,8 +23,8 @@ public class KookTests(ITestOutputHelper outputHelper) : OAuthTests<KookAuthenti
     [InlineData(ClaimTypes.MobilePhone, "110****2333")]
     [InlineData(Claims.IdentifyNumber, "1670")]
     [InlineData(Claims.OperatingSystem, "iOS")]
-    [InlineData(Claims.AvatarUrl, "https://xxx.com/assets/avatar.png/icon")]
-    [InlineData(Claims.BannerUrl, "https://xxx.com/assets/banner.png/icon")]
+    [InlineData(Claims.AvatarUrl, "https://example.com/assets/avatar.png/icon")]
+    [InlineData(Claims.BannerUrl, "https://example.com/assets/banner.png/icon")]
     [InlineData(Claims.IsMobileVerified, "True")]
     public async Task Can_Sign_In_Using_Kook(string claimType, string claimValue)
         => await AuthenticateUserAndAssertClaimValue(claimType, claimValue);

--- a/test/AspNet.Security.OAuth.Providers.Tests/Kook/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Kook/bundle.json
@@ -25,8 +25,8 @@
           "online": false,
           "os": "iOS",
           "status": 0,
-          "avatar": "https://xxx.com/assets/avatar.png/icon",
-          "banner": "https://xxx.com/assets/banner.png/icon",
+          "avatar": "https://example.com/assets/avatar.png/icon",
+          "banner": "https://example.com/assets/banner.png/icon",
           "bot": true,
           "mobile": "110****2333",
           "mobile_verified": true


### PR DESCRIPTION
This pull request modifies the mock data in KOOK tests. The data previously contained references to an unsuitable external URL, and has now been updated to use <https://example.com>.