### PR TITLE
feat(Keycloak): add "family_name" mapping to ClaimTypes.Surname

### DIFF
--- a/src/AspNet.Security.OAuth.Keycloak/KeycloakAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Keycloak/KeycloakAuthenticationOptions.cs
@@ -31,6 +31,7 @@ public class KeycloakAuthenticationOptions : OAuthOptions
         ClaimActions.MapJsonKey(ClaimTypes.NameIdentifier, "sub");
         ClaimActions.MapJsonKey(ClaimTypes.Name, "name");
         ClaimActions.MapJsonKey(ClaimTypes.GivenName, "given_name");
+        ClaimActions.MapJsonKey(ClaimTypes.Surname, "family_name");
         ClaimActions.MapJsonKey(ClaimTypes.Role, "roles");
     }
 

--- a/test/AspNet.Security.OAuth.Providers.Tests/Keycloak/KeycloakTests.cs
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Keycloak/KeycloakTests.cs
@@ -24,6 +24,7 @@ public class KeycloakTests(ITestOutputHelper outputHelper) : OAuthTests<Keycloak
     [InlineData(ClaimTypes.NameIdentifier, "995c1500-0dca-495e-ba72-2499d370d181")]
     [InlineData(ClaimTypes.Email, "john@smith.com")]
     [InlineData(ClaimTypes.GivenName, "John")]
+    [InlineData(ClaimTypes.Surname, "Smith")]
     [InlineData(ClaimTypes.Role, "admin")]
     [InlineData(ClaimTypes.Name, "John Smith")]
     public async Task Can_Sign_In_Using_Keycloak_BaseAddress(string claimType, string claimValue)
@@ -44,6 +45,7 @@ public class KeycloakTests(ITestOutputHelper outputHelper) : OAuthTests<Keycloak
     [InlineData(null, ClaimTypes.NameIdentifier, "995c1500-0dca-495e-ba72-2499d370d181")]
     [InlineData(null, ClaimTypes.Email, "john@smith.com")]
     [InlineData(null, ClaimTypes.GivenName, "John")]
+    [InlineData(null, ClaimTypes.Surname, "Smith")]
     [InlineData(null, ClaimTypes.Role, "admin")]
     [InlineData(null, ClaimTypes.Name, "John Smith")]
     [InlineData("17.0", ClaimTypes.NameIdentifier, "995c1500-0dca-495e-ba72-2499d370d181")]
@@ -84,6 +86,7 @@ public class KeycloakTests(ITestOutputHelper outputHelper) : OAuthTests<Keycloak
     [InlineData(ClaimTypes.NameIdentifier, "995c1500-0dca-495e-ba72-2499d370d181")]
     [InlineData(ClaimTypes.Email, "john@smith.com")]
     [InlineData(ClaimTypes.GivenName, "John")]
+    [InlineData(ClaimTypes.Surname, "Smith")]
     [InlineData(ClaimTypes.Role, "admin")]
     [InlineData(ClaimTypes.Name, "John Smith")]
     public async Task Can_Sign_In_Using_Keycloak_Public_AccessType(string claimType, string claimValue)

--- a/test/AspNet.Security.OAuth.Providers.Tests/Keycloak/bundle.json
+++ b/test/AspNet.Security.OAuth.Providers.Tests/Keycloak/bundle.json
@@ -21,6 +21,7 @@
         "roles": "admin",
         "name": "John Smith",
         "given_name": "John",
+        "family_name": "Smith",
         "email": "john@smith.com"
       }
     },
@@ -44,6 +45,7 @@
         "roles": "admin",
         "name": "John Smith",
         "given_name": "John",
+        "family_name": "Smith",
         "email": "john@smith.com"
       }
     },
@@ -67,6 +69,7 @@
         "roles": "admin",
         "name": "John Smith",
         "given_name": "John",
+        "family_name": "Smith",
         "email": "john@smith.com"
       }
     }


### PR DESCRIPTION
This commit will add support for the default ASP NET Core ClaimTypes.Surname. Default key for the surname is "family_name" in Keycloak.
