### PR TITLE
Bump version

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,6 @@
+changelog:
+  exclude:
+    authors:
+      - aspnet-contrib-service-account[bot]
+      - dependabot[bot]
+      - github-actions[bot]

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,9 +3,9 @@
   <PropertyGroup>
     <MajorVersion>9</MajorVersion>
     <MinorVersion>4</MinorVersion>
-    <PatchVersion>1</PatchVersion>
+    <PatchVersion>2</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
-    <PackageValidationBaselineVersion Condition=" '$(EnablePackageValidation)' == 'true' AND '$(PackageValidationBaselineVersion)' == '' ">9.0.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion Condition=" '$(EnablePackageValidation)' == 'true' AND '$(PackageValidationBaselineVersion)' == '' ">9.4.1</PackageValidationBaselineVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <PreReleaseVersionIteration></PreReleaseVersionIteration>
     <PreReleaseBrandingLabel>Preview $(PreReleaseVersionIteration)</PreReleaseBrandingLabel>

--- a/src/AspNet.Security.OAuth.Atlassian/AspNet.Security.OAuth.Atlassian.csproj
+++ b/src/AspNet.Security.OAuth.Atlassian/AspNet.Security.OAuth.Atlassian.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <PackageValidationBaselineVersion>9.1.0</PackageValidationBaselineVersion>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
   </PropertyGroup>
 

--- a/src/AspNet.Security.OAuth.Bilibili/AspNet.Security.OAuth.Bilibili.csproj
+++ b/src/AspNet.Security.OAuth.Bilibili/AspNet.Security.OAuth.Bilibili.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <PackageValidationBaselineVersion>9.4.0</PackageValidationBaselineVersion>
     <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 

--- a/src/AspNet.Security.OAuth.Contentful/AspNet.Security.OAuth.Contentful.csproj
+++ b/src/AspNet.Security.OAuth.Contentful/AspNet.Security.OAuth.Contentful.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <PackageValidationBaselineVersion>9.3.0</PackageValidationBaselineVersion>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
   </PropertyGroup>
 

--- a/src/AspNet.Security.OAuth.GitCode/AspNet.Security.OAuth.GitCode.csproj
+++ b/src/AspNet.Security.OAuth.GitCode/AspNet.Security.OAuth.GitCode.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <PackageValidationBaselineVersion>9.1.0</PackageValidationBaselineVersion>
     <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 

--- a/src/AspNet.Security.OAuth.Linear/AspNet.Security.OAuth.Linear.csproj
+++ b/src/AspNet.Security.OAuth.Linear/AspNet.Security.OAuth.Linear.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <PackageValidationBaselineVersion>9.2.0</PackageValidationBaselineVersion>
     <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 

--- a/src/AspNet.Security.OAuth.Miro/AspNet.Security.OAuth.Miro.csproj
+++ b/src/AspNet.Security.OAuth.Miro/AspNet.Security.OAuth.Miro.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <PackageValidationBaselineVersion>9.2.0</PackageValidationBaselineVersion>
     <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 

--- a/src/AspNet.Security.OAuth.Webflow/AspNet.Security.OAuth.Webflow.csproj
+++ b/src/AspNet.Security.OAuth.Webflow/AspNet.Security.OAuth.Webflow.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <PackageValidationBaselineVersion>9.2.0</PackageValidationBaselineVersion>
     <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 


### PR DESCRIPTION
- Bump version to 9.4.2 for next release.
- Update package baseline versions to 9.4.1.
- Add configuration file to skip PRs from bot accounts when generating release notes.
