### PR TITLE
Add dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,8 @@ version: 2
 updates:
 - package-ecosystem: "github-actions"
   directory: "/"
+  cooldown:
+    default-days: 3
   groups:
     actions:
       patterns:
@@ -11,6 +13,8 @@ updates:
     time: "06:30"
     timezone: Europe/London
 - package-ecosystem: nuget
+  cooldown:
+    default-days: 3
   directory: "/"
   schedule:
     interval: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,9 +13,9 @@ updates:
     time: "06:30"
     timezone: Europe/London
 - package-ecosystem: nuget
+  directory: "/"
   cooldown:
     default-days: 3
-  directory: "/"
   schedule:
     interval: daily
     time: "06:30"

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,6 +1,9 @@
 rules:
   anonymous-definition:
     disable: true
+  dependabot-cooldown:
+    config:
+      days: 3
   secrets-outside-env:
     disable: true
   undocumented-permissions:


### PR DESCRIPTION
Add a 3 day cooldown for dependabot updates.

Resolves https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/security/code-scanning/2 and https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/security/code-scanning/3.