### PR TITLE
Update Zalo OAuth provider to v4

### DIFF
--- a/src/AspNet.Security.OAuth.Zalo/ZaloAuthenticationDefaults.cs
+++ b/src/AspNet.Security.OAuth.Zalo/ZaloAuthenticationDefaults.cs
@@ -34,12 +34,12 @@ public class ZaloAuthenticationDefaults
     /// <summary>
     /// Default value for <see cref="OAuthOptions.AuthorizationEndpoint"/>.
     /// </summary>
-    public static readonly string AuthorizationEndpoint = "https://oauth.zaloapp.com/v3/auth";
+    public static readonly string AuthorizationEndpoint = "https://oauth.zaloapp.com/v4/permission";
 
     /// <summary>
     /// Default value for <see cref="OAuthOptions.TokenEndpoint"/>.
     /// </summary>
-    public static readonly string TokenEndpoint = "https://oauth.zaloapp.com/v3/access_token";
+    public static readonly string TokenEndpoint = "https://oauth.zaloapp.com/v4/access_token";
 
     /// <summary>
     /// Default value for <see cref="OAuthOptions.UserInformationEndpoint"/>.

--- a/src/AspNet.Security.OAuth.Zalo/ZaloAuthenticationOptions.cs
+++ b/src/AspNet.Security.OAuth.Zalo/ZaloAuthenticationOptions.cs
@@ -20,6 +20,7 @@ public class ZaloAuthenticationOptions : OAuthOptions
         AuthorizationEndpoint = ZaloAuthenticationDefaults.AuthorizationEndpoint;
         TokenEndpoint = ZaloAuthenticationDefaults.TokenEndpoint;
         UserInformationEndpoint = ZaloAuthenticationDefaults.UserInformationEndpoint;
+        UsePkce = true;
 
         ClaimActions.MapJsonKey(ClaimTypes.NameIdentifier, "id");
         ClaimActions.MapJsonKey(ClaimTypes.Name, "name");


### PR DESCRIPTION
## Changes:
- Update AuthorizationEndpoint to **https://oauth.zaloapp.com/v4/permission**
- Update TokenEndpoint to **https://oauth.zaloapp.com/v4/access_token**
- Enable **UsePkce = true** by default
