### PR TITLE
Set size for cached client secrets in DefaultAppleClientSecretGenerator

### DIFF
--- a/src/AspNet.Security.OAuth.Apple/Internal/DefaultAppleClientSecretGenerator.cs
+++ b/src/AspNet.Security.OAuth.Apple/Internal/DefaultAppleClientSecretGenerator.cs
@@ -27,6 +27,7 @@ internal sealed partial class DefaultAppleClientSecretGenerator(
         {
             try
             {
+                entry.Size = 1;
                 (var clientSecret, entry.AbsoluteExpiration) = await GenerateNewSecretAsync(context);
                 return clientSecret;
             }
@@ -35,7 +36,7 @@ internal sealed partial class DefaultAppleClientSecretGenerator(
                 Log.ClientSecretGenerationFailed(logger, ex, context.Scheme.Name);
                 throw;
             }
-        }, new MemoryCacheEntryOptions { Size = 1 });
+        });
 
         return clientSecret!;
     }

--- a/src/AspNet.Security.OAuth.Apple/Internal/DefaultAppleClientSecretGenerator.cs
+++ b/src/AspNet.Security.OAuth.Apple/Internal/DefaultAppleClientSecretGenerator.cs
@@ -35,7 +35,7 @@ internal sealed partial class DefaultAppleClientSecretGenerator(
                 Log.ClientSecretGenerationFailed(logger, ex, context.Scheme.Name);
                 throw;
             }
-        });
+        }, new MemoryCacheEntryOptions { Size = 1 });
 
         return clientSecret!;
     }


### PR DESCRIPTION
This PR ensures that the `MemoryCache` entry created for the Apple client secret has a defined `Size`. 

#### Motivation
When a developer configures `IMemoryCache` with a `SizeLimit` (e.g., `services.AddMemoryCache(options => options.SizeLimit = 1024)`), **all** cache entries must have a `Size` specified. Currently, `DefaultAppleClientSecretGenerator` does not set this value, which causes the cache to throw an exception.

By setting `entry.Size = 1`, we ensure compatibility with memory-constrained configurations and prevent potential GC pressure or performance degradation.

#### Related Issue
Fixes #1190